### PR TITLE
Rm Original article because they're unnecessary

### DIFF
--- a/docs/en/about-us/adopters.md
+++ b/docs/en/about-us/adopters.md
@@ -213,4 +213,3 @@ The following list of companies using ClickHouse and their success stories is as
 
 </div>
 
-[Original article](https://clickhouse.com/docs/en/introduction/adopters/)

--- a/docs/en/about-us/distinctive-features.md
+++ b/docs/en/about-us/distinctive-features.md
@@ -94,4 +94,3 @@ ClickHouse implements user account management using SQL queries and allows for [
 2.  Lack of ability to modify or delete already inserted data with a high rate and low latency. There are batch deletes and updates available to clean up or modify data, for example, to comply with [GDPR](https://gdpr-info.eu).
 3.  The sparse index makes ClickHouse not so efficient for point queries retrieving single rows by their keys.
 
-[Original article](https://clickhouse.com/docs/en/introduction/distinctive-features/) <!--hide-->

--- a/docs/en/about-us/history.md
+++ b/docs/en/about-us/history.md
@@ -52,4 +52,3 @@ OLAPServer worked well for non-aggregated data, but it had many restrictions tha
 
 The initial goal for ClickHouse was to remove the limitations of OLAPServer and solve the problem of working with non-aggregated data for all reports, but over the years, it has grown into a general-purpose database management system suitable for a wide range of analytical tasks.
 
-[Original article](https://clickhouse.com/docs/en/introduction/history/) <!--hide-->

--- a/docs/en/about-us/performance.md
+++ b/docs/en/about-us/performance.md
@@ -28,4 +28,3 @@ Under the same conditions, ClickHouse can handle several hundred queries per sec
 
 We recommend inserting data in packets of at least 1000 rows, or no more than a single request per second. When inserting to a MergeTree table from a tab-separated dump, the insertion speed can be from 50 to 200 MB/s. If the inserted rows are around 1 KB in size, the speed will be from 50,000 to 200,000 rows per second. If the rows are small, the performance can be higher in rows per second (on Banner System data -`>` 500,000 rows per second; on Graphite data -`>` 1,000,000 rows per second). To improve performance, you can make multiple INSERT queries in parallel, which scales linearly.
 
-[Original article](https://clickhouse.com/docs/en/introduction/performance/)

--- a/docs/en/faq/general/index.md
+++ b/docs/en/faq/general/index.md
@@ -20,4 +20,3 @@ keywords: [clickhouse, faq, questions, what is]
 Check out our [other FAQ categories](../../faq/) and also browse the many helpful articles found here in the documentation.
 :::
 
-[Original article](https://clickhouse.com/docs/en/faq/general/)

--- a/docs/en/faq/integration/index.md
+++ b/docs/en/faq/integration/index.md
@@ -18,4 +18,3 @@ keywords: [clickhouse, faq, questions, integrations]
 Check out our [other FAQ categories](../../faq/) and also browse the many helpful articles found here in the documentation.
 :::
 
-[Original article](https://clickhouse.com/docs/faq/integration/)

--- a/docs/en/faq/operations/index.md
+++ b/docs/en/faq/operations/index.md
@@ -17,4 +17,3 @@ sidebar_label:  Question about Operating ClickHouse Servers and Clusters
 Check out our [other FAQ categories](../../faq/) and also browse the many helpful articles found here in the documentation.
 :::
 
-[Original article](https://clickhouse.com/docs/faq/production/)

--- a/docs/en/faq/use-cases/index.md
+++ b/docs/en/faq/use-cases/index.md
@@ -12,4 +12,3 @@ sidebar_label:  Questions about ClickHouse use cases
 Check out our [other FAQ categories](../../faq/) and also browse the many helpful articles found here in the documentation.
 :::
 
-[Original article](https://clickhouse.com/docs/faq/use-cases/)

--- a/docs/en/guides/developer/apply-catboost-model.md
+++ b/docs/en/guides/developer/apply-catboost-model.md
@@ -247,4 +247,3 @@ FROM
 More info about [avg()](../../sql-reference/aggregate-functions/reference/avg.md#agg_function-avg) and [log()](../../sql-reference/functions/math-functions.md) functions.
 :::
 
-[Original article](https://clickhouse.com/docs/en/guides/apply_catboost_model/) <!--hide-->

--- a/docs/en/intro.md
+++ b/docs/en/intro.md
@@ -92,4 +92,3 @@ This is not done in “normal” databases, because it does not make sense when 
 
 Note that for CPU efficiency, the query language must be declarative (SQL or MDX), or at least a vector (J, K). The query should only contain implicit loops, allowing for optimization.
 
-[Original article](https://clickhouse.com/docs/en/)

--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -463,4 +463,3 @@ Well done, you made it through the tutorial, and hopefully you have a better und
 
 
 
-[Original article](https://clickhouse.com/docs/tutorial/) <!--hide-->

--- a/docs/en/whats-new/roadmap.md
+++ b/docs/en/whats-new/roadmap.md
@@ -7,4 +7,3 @@ sidebar_label: Roadmap
 
 The roadmap for the year 2022 is published for open discussion [here](https://github.com/ClickHouse/ClickHouse/issues/32513).
 
-[Original article](https://clickhouse.com/docs/en/roadmap/)

--- a/docs/en/whats-new/security-changelog.md
+++ b/docs/en/whats-new/security-changelog.md
@@ -127,4 +127,3 @@ Incorrect configuration in deb package could lead to the unauthorized use of the
 
 Credits: the UK’s National Cyber Security Centre (NCSC)
 
-{## [Original article](https://clickhouse.com/docs/en/security_changelog/) ##}


### PR DESCRIPTION
# Changed log

- Remove `Original article` link because they're unavailable, broken or redirected to the current link.