### PR TITLE
add secure flag to enable SSL on Raft ports

### DIFF
--- a/docs/en/guides/sre/configuring-ssl.md
+++ b/docs/en/guides/sre/configuring-ssl.md
@@ -144,16 +144,19 @@ For a full explanation of all options, visit https://clickhouse.com/docs/en/oper
                 <id>1</id>
                 <hostname>chnode1.marsnet.local</hostname>
                 <port>9444</port>
+                <secure>1</secure>
             </server>
             <server>
                 <id>2</id>
                 <hostname>chnode2.marsnet.local</hostname>
                 <port>9444</port>
+                <secure>1</secure>
             </server>
             <server>
                 <id>3</id>
                 <hostname>chnode3.marsnet.local</hostname>
                 <port>9444</port>
+                <secure>1</secure>
             </server>
         </raft_configuration>
     </keeper_server>


### PR DESCRIPTION
Found Raft ports can also be set to secure, added option.
from this changelog:
https://clickhouse.com/docs/en/whats-new/changelog/2021/#:~:text=keeper_server.raft_configuration.secure
