### PR TITLE
move changelogs by year

### DIFF
--- a/docs/en/whats-new/changelog/2017.md
+++ b/docs/en/whats-new/changelog/2017.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 79
+sidebar_position: 6
 sidebar_label: '2017'
 ---
 

--- a/docs/en/whats-new/changelog/2018.md
+++ b/docs/en/whats-new/changelog/2018.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 78
+sidebar_position: 5
 sidebar_label: '2018'
 ---
 

--- a/docs/en/whats-new/changelog/2019.md
+++ b/docs/en/whats-new/changelog/2019.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 77
+sidebar_position: 4
 sidebar_label: '2019'
 ---
 

--- a/docs/en/whats-new/changelog/2020.md
+++ b/docs/en/whats-new/changelog/2020.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 76
+sidebar_position: 3
 sidebar_label: '2020'
 ---
 

--- a/docs/en/whats-new/changelog/2021.md
+++ b/docs/en/whats-new/changelog/2021.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 75
+sidebar_position: 2
 sidebar_label: '2021'
 ---
 

--- a/docs/en/whats-new/changelog/2022.md
+++ b/docs/en/whats-new/changelog/2022.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 90
-sidebar_label:  2022 Changelog
+sidebar_position: 1
+sidebar_label:  2022
 ---
 
 # 2022 Changelog

--- a/docs/en/whats-new/changelog/_category_.yml
+++ b/docs/en/whats-new/changelog/_category_.yml
@@ -1,0 +1,6 @@
+label: 'Changelog'
+collapsible: true
+collapsed: true
+link:
+  type: generated-index
+  title: Changelog


### PR DESCRIPTION
Changelogs were all grouped under 2022, moves like so:
![image](https://user-images.githubusercontent.com/25182304/172180277-bcfb28bb-39e8-4ea5-ac7d-8cf319484d97.png)
