### PR TITLE
Add example section to Deepnote docs page

### DIFF
--- a/docs/en/integrations/deepnote.md
+++ b/docs/en/integrations/deepnote.md
@@ -14,7 +14,7 @@ This guide assumes you already have a Deepnote account and that you have a runni
 ## Interactive example
 If you would like to explore an interactive example of querying ClickHouse from Deepnote data notebooks, click the button below to  launch a template project connected to the [ClickHouse playground](../getting-started/playground).
 
-[<img src="https://deepnote.com/buttons/launch-in-deepnote.svg">](https://deepnote.com/launch?template=ClickHouse%20and%20Deepnote)
+[<img src="https://deepnote.com/buttons/launch-in-deepnote.svg"/>](https://deepnote.com/launch?template=ClickHouse%20and%20Deepnote)
 
 ## Connect to ClickHouse
 


### PR DESCRIPTION
Added an "Interactive example section" to add an actionable component to the docs (and convince people exploring ClickHouse's integrations and capabilities that they should get started with ClickHouse and Deepnote).

The button links to a Deepnote template notebook that is connected to ClickHouse's playground. I copied the internal ClickHouse docs link structure from other links in the docs for the link to the ClickHouse playground docs page.