### PR TITLE
Fix yaml indentation on DBT guide

### DIFF
--- a/docs/en/integrations/dbt/dbt-view-model.md
+++ b/docs/en/integrations/dbt/dbt-view-model.md
@@ -34,13 +34,13 @@ When using the view materialization, a model is rebuilt as a view on each run, v
 
     sources:
     - name: imdb
-    tables:
-    - name: directors
-    - name: actors
-    - name: roles
-    - name: movies
-    - name: genres
-    - name: movie_directors
+      tables:
+      - name: directors
+      - name: actors
+      - name: roles
+      - name: movies
+      - name: genres
+      - name: movie_directors
     ```
 
     The `actors_summary.sql` defines our actual model. Note in the config function we also request the model be materialized as a view in ClickHouse. Our tables are referenced from the `schema.yml` file via the function `source` e.g. `source('imdb', 'movies')` refers to the `movies` table in the `imdb` database.


### PR DESCRIPTION
Error:
```
$ dbt run            
12:21:48  Running with dbt=1.1.1
12:21:48  Partial parse save file not found. Starting full parse.
12:21:50  Encountered an error:
Compilation Error in model actor_summary (models/actors/actor_summary.sql)
  Model 'model.imdb.actor_summary' (models/actors/actor_summary.sql) depends on a source named 'imdb.genres' which was not found
```

Example of `schema.yml` from DBT's docs:
https://docs.getdbt.com/reference/configs-and-properties#example