### PR TITLE
add raw-loader for source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.3.1",
+    "raw-loader": "^4.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "remark-docusaurus-tabs": "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6240,6 +6240,14 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"


### PR DESCRIPTION
In order to load code blocks from source code files (rather than embed the code in Markdown files) we need `raw-loader` and `webpack`.  These are added in this PR.  This will allow files (for example, the file `connect_test.go`) with this markdown:
```
---
sidebar_label: GO
---
import CodeBlock from '@theme/CodeBlock';
import conn_test from '!!raw-loader!../../../_clients/go/tests/conn_test.go'    
                                                                                
                                                                                
# GO                                                                            
                                                                                
<CodeBlock language="go">{conn_test}</CodeBlock>   
```

`go/examples` and `go/tests` will get copied to `clickhouse-docs/docs/_clients/go/`, 
This is an interim step while I work on importing sections of a source file marked with "start" and "end" comments.

cc: @gingerwizard 