### PR TITLE
Make docs nav look like clickhouse.com nav

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,10 +82,57 @@ const config = {
         },
         items: [
           {
+            type: 'dropdown',
+            label: 'Product',
+            position: 'left',
+            items: [
+              {
+                label: 'ClickHouse Cloud',
+                to: 'https://clickhouse.com/cloud'
+              },
+              {
+                label: 'ClickHouse Open Source',
+                to: 'https://clickhouse.com/clickhouse'
+              },
+            ]
+          },
+          {
             type: 'doc',
             docId: 'en/intro',
             position: 'left',
             label: 'Docs',
+          },
+          {
+            position: 'left',
+            label: 'Use Cases',
+            to: 'https://clickhouse.com/customer-stories'
+          },
+          {
+            type: 'dropdown',
+            label: 'Company',
+            position: 'left',
+            items: [
+              {
+                label: 'Blog',
+                to: 'https://clickhouse.com/blog'
+              },
+              {
+                label: 'Our story',
+                to: 'https://clickhouse.com/company/our-story'
+              },
+              {
+                label: 'Careers',
+                to: 'https://clickhouse.com/company/careers'
+              },
+              {
+                label: 'Contact us',
+                to: 'https://clickhouse.com/company/contact'
+              },
+              {
+                label: 'News and events',
+                to: 'https://clickhouse.com/company/news-events'
+              },
+            ]
           },
           {
             type: 'dropdown',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -76,6 +76,8 @@ code {
   --clickhouse-beige: #FFE4B5;
   --clickhouse-light-blue: #E3F1FE;
 
+  --ifm-font-color-base: #2F2C3A;
+
   --ifm-font-family-base: Roboto, "Helvetica Neue", sans-serif;
   --ifm-h3-font-size: 1.75rem !important;
   --ifm-h2-font-size: 2rem !important;
@@ -93,6 +95,7 @@ code {
   --ifm-footer-link-color: var(--clickhouse-gray);
   --ifm-footer-link-hover-color: #212529;
   --ifm-footer-background-color: var(--ifm-color-primary-lightest);
+
 
   --ifm-heading-color: var(--ifm-color-primary);
   --ifm-hero-text-color: var(--ifm-color-primary);
@@ -331,4 +334,8 @@ code {
 }
 .searchResultItemHeading_KbCB {
   font-size: 1.3rem;
+}
+
+.navbar__brand {
+  margin-right: 5rem;
 }


### PR DESCRIPTION
Here is what it will look like:

<img width="1393" alt="Screen Shot 2022-07-14 at 9 57 26 PM" src="https://user-images.githubusercontent.com/5323324/179241509-f9e1e195-5ad4-4626-a021-9f2a7279ed5d.png">

