### PR TITLE
set image width to fit the image

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -336,7 +336,7 @@ code {
 
 /* Add a drop shadow to images in the user guides and docs */
 img  {
-  width: 100%;
+  width: fit-content;
   filter: drop-shadow(2px 4px 6px gray);
   /* padding looks bad in dark mode as it adds white space around images that have dark backgrounds */
   /*padding-bottom: 0.2rem;


### PR DESCRIPTION
The deepnote button was huge suddenly, not sure how.  This fixes it.