### PR TITLE
Fixing missing logo in firefox.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,7 +1,7 @@
 /* keep the navbar from disappearing when scrolling */
 .navbar--fixed-top {
   position: fixed;
-  width: -webkit-fill-available;
+  width: 100%;
 } 
 
 /* give some sace for the breadcrumbs */
@@ -366,7 +366,7 @@ img  {
 footer.footer img {
   filter: none;
   background-color: transparent;
-  max-height: 5rem;
+  max-height: 2rem;
 }
 
 .footer__copyright {

--- a/static/img/logo_without_text.svg
+++ b/static/img/logo_without_text.svg
@@ -1,8 +1,8 @@
-<svg fill="none" height="100%" viewBox="0 0 37 37" width="100%" xmlns="http://www.w3.org/2000/svg" fit="" preserveAspectRatio="xMidYMid meet" focusable="false">
-  <rect fill="#FFB200" height="36.9995" rx="1" width="4.11106"></rect>
-  <path d="M0 32.8887H4.11106V35.9997C4.11106 36.552 3.66335 36.9997 3.11106 36.9997H1C0.447715 36.9997 0 36.552 0 35.9997V32.8887Z" fill="#FF0000"></path>
-  <rect fill="#FFB200" height="36.9995" rx="1" width="4.11106" x="8.22266"></rect>
-  <rect fill="#FFB200" height="36.9995" rx="1" width="4.11106" x="16.4443"></rect>
-  <rect fill="#FFB200" height="36.9995" rx="1" width="4.11106" x="24.666"></rect>
-  <rect fill="#FFB200" height="8.22212" rx="1" width="4.11106" x="32.8887" y="14.3896"></rect>
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect y="2" width="4" height="32" rx="1" fill="#FFB200"/>
+  <path d="M0 30H4V33C4 33.5523 3.55228 34 3 34H1C0.447715 34 0 33.5523 0 33V30Z" fill="#FF0000"/>
+  <rect x="8" y="2" width="4" height="32" rx="1" fill="#FFB200"/>
+  <rect x="16" y="2" width="4" height="32" rx="1" fill="#FFB200"/>
+  <rect x="24" y="2" width="4" height="32" rx="1" fill="#FFB200"/>
+  <rect x="32" y="15" width="4" height="8" rx="1" fill="#FFB200"/>
 </svg>


### PR DESCRIPTION
### Summary 
The ClickHouse logo was not displaying in FireFox. Additionally the width of the header was not reaching the full width of the page. This PR fixes both of these issues. 

#### Before
<img width="1112" alt="CleanShot 2022-08-15 at 13 48 53@2x" src="https://user-images.githubusercontent.com/305167/184691072-61246d18-6094-4de5-b310-9417a91200c8.png">


#### After
<img width="1113" alt="CleanShot 2022-08-15 at 13 49 02@2x" src="https://user-images.githubusercontent.com/305167/184691107-85277218-c756-4c92-8b19-02baf6cd2cc4.png">

Sidenote: We were using `-webkit-fill-available` which isn't supported by firefox browsers, I've been investigating why we were using it but could not find a good reason. I've replaced it with `width:100%` and have tested across browsers and device sizes and don't see any visual degradation. 

### Testing
- [x] Light & Dark mode
- [x] Chrome
- [x] Safari
- [x] Firefox 
- [x] Mobile safari (via simulator) 
- [x] Major responsive breakpoint sizes