### PR TITLE
Adding exact height, width to logo SVG

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,12 @@
 .menu__caret:before {
     filter: none !important;
 }
+
+.navbar__logo {
+  height: 2rem;
+  width: 2rem;
+}
+
 /* override the normal white background color
  * and remove the drop shadow filter for img
  * when it is inside  of a .navbar__logo
@@ -366,7 +372,8 @@ img  {
 footer.footer img {
   filter: none;
   background-color: transparent;
-  max-height: 2rem;
+  height: 2.5rem;
+  width: 2.5rem;
 }
 
 .footer__copyright {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,7 +36,7 @@
     filter: none !important;
 }
 
-.navbar__logo {
+.navbar__logo img {
   height: 2rem;
   width: 2rem;
 }


### PR DESCRIPTION
Related to: https://github.com/ClickHouse/clickhouse-docs/pull/299 which didn't produce the desired result. 

After a little more research I noticed that Firefox needs the height and width to be a little more verbose than other browsers. While the sizing and viewBox provided in the logo SVG itself worked locally, something in the build process meant that in production. the sizes weren't being recognised. This is fixed by verbosely adding desired height and width via css. 