### PR TITLE
Fix missing CREATE TABLE statement and add sql wrapper

### DIFF
--- a/docs/en/integrations/data-ingestion/kafka/kafka-table-engine.md
+++ b/docs/en/integrations/data-ingestion/kafka/kafka-table-engine.md
@@ -306,7 +306,13 @@ You should have 200,000 rows:
 
 Now insert rows from the GitHub target table back into the Kafka table engine github_queue. Note how we utilize JSONEachRow format and LIMIT the select to 100.
 
-INSERT INTO default.github_queue (*) SELECT file_time, event_type, actor_login, repo_name, created_at, updated_at, action, comment_id, path, ref, ref_type, creator_user_login, number, title, labels, state, assignee, assignees, closed_at, merged_at, merge_commit_sha, requested_reviewers, merged_by, review_comments, member_login FROM default.github LIMIT 100 FORMAT JSONEachRow;
+```sql
+INSERT INTO default.github_queue (*)
+SELECT file_time, event_type, actor_login, repo_name, created_at, updated_at, action, comment_id, path, ref, ref_type, creator_user_login, number, title, labels, state, assignee, assignees, closed_at, merged_at, merge_commit_sha, requested_reviewers, merged_by, review_comments, member_login 
+FROM default.github
+LIMIT 100
+FORMAT JSONEachRow;
+```
 
 Recount the row in GitHub to confirm it has increased by 100. As shown in the above diagram, rows have been inserted into Kafka via the Kafka table engine before being re-read by the same engine and inserted into the GitHub target table by our materialized view!
 
@@ -331,6 +337,7 @@ We can utilize materialized views to push messages to a Kafka engine (and a topi
 Create a new Kafka topic `github_out` or equivalent. Ensure a Kafka table engine `github_out_queue` points to this topic.
 
 ```sql
+CREATE TABLE default.github_out_queue
 (
     file_time DateTime,
     event_type Enum('CommitCommentEvent' = 1, 'CreateEvent' = 2, 'DeleteEvent' = 3, 'ForkEvent' = 4, 'GollumEvent' = 5, 'IssueCommentEvent' = 6, 'IssuesEvent' = 7, 'MemberEvent' = 8, 'PublicEvent' = 9, 'PullRequestEvent' = 10, 'PullRequestReviewCommentEvent' = 11, 'PushEvent' = 12, 'ReleaseEvent' = 13, 'SponsorshipEvent' = 14, 'WatchEvent' = 15, 'GistEvent' = 16, 'FollowEvent' = 17, 'DownloadEvent' = 18, 'PullRequestReviewEvent' = 19, 'ForkApplyEvent' = 20, 'Event' = 21, 'TeamAddEvent' = 22),


### PR DESCRIPTION
I found that there isn't CREATE TABLE statement in [utilizing-materialized-views](https://clickhouse.com/docs/en/integrations/kafka/kafka-table-engine#2-utilizing-materialized-views), it would cause the Syntax error.