### PR TITLE
update connection instructions

### DIFF
--- a/docs/en/_snippets/_gather_your_details_http.mdx
+++ b/docs/en/_snippets/_gather_your_details_http.mdx
@@ -2,7 +2,7 @@ To connect to ClickHouse with HTTP(S) you need this information:
 
 - The HOST and PORT: typically the port is 8443 when using TLS, or 8123 when not using TLS, but these are configurable by your ClickHouse administrator. 
 
-- The DATABASE NAME: out of the box there is a database named `default`, use the name of any existing database.
+- The DATABASE NAME: out of the box there is a database named `default`, use the name the database that you want to connect to.
 
-- The USERNAME and PASSWORD: out of the box the username is `default`. Your ClickHouse administrator will provide the password to use. 
+- The USERNAME and PASSWORD: out of the box the username is `default`. Use the username appropriate for your use case.  Your ClickHouse administrator will provide the password to use. 
 

--- a/docs/en/_snippets/_gather_your_details_native.md
+++ b/docs/en/_snippets/_gather_your_details_native.md
@@ -1,7 +1,10 @@
 ## Gather your connection details
 
-Your connection details are available for each of your ClickHouse Cloud services from the Cloud Console.  From your service, click on ????
+To connect to ClickHouse with native TCP you need this information:
 
-Select the tab for Native and ???
+- The HOST and PORT: typically the port is 9440 when using TLS, or 9000 when not using TLS, but these are configurable by your ClickHouse administrator. 
 
-![Connection details dialog](@site/docs/en/_snippets/images/connection-details-native.png)
+- The DATABASE NAME: out of the box there is a database named `default`, use the name the database that you want to connect to.
+
+- The USERNAME and PASSWORD: out of the box the username is `default`. Use the username appropriate for your use case.  Your ClickHouse administrator will provide the password to use. 
+


### PR DESCRIPTION
@gingerwizard @rfraposa @tom-clickhouse @Ryado @genzgd 

 if you are updating any docs where we tell the reader to configure a connection please use these include files rather than telling them to connect to localhost with no password.  See the [import line of the Metabase docs](https://github.com/ClickHouse/clickhouse-docs/blob/7a1969114a50102afbb4efa174677c2db2142c9e/docs/en/integrations/data-visualization/metabase-and-clickhouse.md?plain=1#L8) and the [render lines](https://github.com/ClickHouse/clickhouse-docs/blob/7a1969114a50102afbb4efa174677c2db2142c9e/docs/en/integrations/data-visualization/metabase-and-clickhouse.md?plain=1#L25-L26)

This will allow us to update the connection details across the docs by just changing the include files.

What the metabse docs now look like:

![image](https://user-images.githubusercontent.com/25182304/187710980-97156f38-23e9-4d2e-83fc-93877928c9b4.png)
