### PR TITLE
Fixed typo: URL.bin instead of URL.data

### DIFF
--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md
@@ -454,7 +454,7 @@ Furthermore, this offset information is only needed for the UserID and URL colum
 
 Offset information is not needed for columns that are not used in the query e.g. the EventTime.
 
-For our sample query, ClickHouse needs only the two physical location offsets for granule 176 in the UserID data file (UserID.bin) and the two physical location offsets for granule 176 in the URL data file (URL.data).
+For our sample query, ClickHouse needs only the two physical location offsets for granule 176 in the UserID data file (UserID.bin) and the two physical location offsets for granule 176 in the URL data file (URL.bin).
 
 The indirection provided by mark files avoids storing, directly within the primary index, entries for the physical locations of all 1083 granules for all three columns: thus avoiding having unnecessary (potentially unused) data in main memory.
 :::


### PR DESCRIPTION
Fixed typo at section WHY MARK FILES.