### PR TITLE
Fix `macros` note for S3 multi region doc.

### DIFF
--- a/docs/en/guides/sre/s3-multi-region.md
+++ b/docs/en/guides/sre/s3-multi-region.md
@@ -177,7 +177,7 @@ When working with clusters it is handy to define macros that populate DDL querie
 </clickhouse>
 ```
 :::note
-The above macros are for `chnode1`, on `chnode2` set `shard` to `2`, and `replica` to `replica_2`.
+The above macros are for `chnode1`, on `chnode2` set `replica` to `replica_2`.
 :::
 
 ### Disable zero-copy replication


### PR DESCRIPTION
We have only one shard for the cluster described at [Replicating a single shard across two AWS regions using S3 Object Storage](https://clickhouse.com/docs/en/guides/sre/s3-multi-region) -> The value of `clickhouse.macros.shard` must be the same for all nodes.