### PR TITLE
update links to fix 404s

### DIFF
--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-cardinality.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-cardinality.md
@@ -14,14 +14,14 @@ In a compound primary key the order of the key columns can significantly influen
 - the efficiency of the filtering on secondary key columns in queries, and
 - the compression ratio for the table's data files.
 
-In order to demonstrate that, we will use a version of our [web traffic sample data set](./sparse-primary-indexes-intro#data-set)
+In order to demonstrate that, we will use a version of our [web traffic sample data set](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-intro.md/#data-set)
 where each row contains three columns that indicate whether or not the access by an internet 'user' (`UserID` column) to a URL (`URL` column) got marked as bot traffic (`IsRobot` column).
 
 We will use a compound primary key containing all three aforementioned columns that could be used to speed up typical web analytics queries that calculate 
 - how much (percentage of) traffic to a specific URL is from bots or
 - how confident we are that a specific user is (not) a bot (what percentage of traffic from that user is (not) assumed to be bot traffic)
 
-We use this query for calculating the cardinalities of the three columns that we want to use as key columns in a compound primary key (note that we are using the [URL table function](https://clickhouse.com/docs/en/sql-reference/table-functions/url/) for querying TSV data ad-hocly without having to create a local table). Run this query in `clickhouse client`:
+We use this query for calculating the cardinalities of the three columns that we want to use as key columns in a compound primary key (note that we are using the [URL table function](/docs/en/sql-reference/table-functions/url.md) for querying TSV data ad-hocly without having to create a local table). Run this query in `clickhouse client`:
 ```sql
 SELECT
     formatReadableQuantity(uniq(URL)) AS cardinality_URL,
@@ -112,9 +112,9 @@ The response is:
 
 ## Efficient filtering on secondary key columns
 
-When a query is filtering on at least one column that is part of a compound key, and is the first key column, [then ClickHouse is running the binary search algorithm over the key column's index marks](./sparse-primary-indexes-design#the-primary-index-is-used-for-selecting-granules).
+When a query is filtering on at least one column that is part of a compound key, and is the first key column, [then ClickHouse is running the binary search algorithm over the key column's index marks](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#the-primary-index-is-used-for-selecting-granules).
 
-When a query is filtering (only) on a column that is part of a compound key, but is not the first key column, [then ClickHouse is using the generic exclusion search algorithm over the key column's index marks](./sparse-primary-indexes-multiple#secondary-key-columns-can-not-be-inefficient).
+When a query is filtering (only) on a column that is part of a compound key, but is not the first key column, [then ClickHouse is using the generic exclusion search algorithm over the key column's index marks](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md/#secondary-key-columns-can-not-be-inefficient).
 
 
 For the second case the ordering of the key columns in the compound primary key is significant for the effectiveness of the [generic exclusion search algorithm](https://github.com/ClickHouse/ClickHouse/blob/22.3/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp#L1444).
@@ -157,7 +157,7 @@ Processed 20.32 thousand rows,
 
 We can see that the query execution is significantly more effective and faster on the table where we ordered the key columns by cardinality in ascending order.
 
-The reason for that is that the [generic exclusion search algorithm](https://github.com/ClickHouse/ClickHouse/blob/22.3/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp#L1444) works most effective, when [granules](./sparse-primary-indexes-design#the-primary-index-is-used-for-selecting-granules) are selected via a secondary key column where the predecessor key column has a lower cardinality. We illustrated that in detail in a [previous section](./sparse-primary-indexes-multiple#generic-exclusion-search-algorithm) of this guide.
+The reason for that is that the [generic exclusion search algorithm](https://github.com/ClickHouse/ClickHouse/blob/22.3/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp#L1444) works most effective, when [granules](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#the-primary-index-is-used-for-selecting-granules) are selected via a secondary key column where the predecessor key column has a lower cardinality. We illustrated that in detail in a [previous section](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md/#generic-exclusion-search-algorithm) of this guide.
 
 
 ## Optimal compression ratio of data files
@@ -186,7 +186,7 @@ This is the response:
 ```
 We can see that the compression ratio for the `UserID` column is significantly higher for the table where we ordered the key columns `(IsRobot, UserID, URL)` by cardinality in ascending order. 
 
-Although in both tables exactly the same data is stored (we inserted the same 8.87 million rows into both tables), the order of the key columns in the compound primary key has a significant influence on how much disk space the <a href="https://clickhouse.com/docs/en/introduction/distinctive-features/#data-compression" target="_blank">compressed</a> data in the table's [column data files](./sparse-primary-indexes-design#data-is-stored-on-disk-ordered-by-primary-key-columns) requires:
+Although in both tables exactly the same data is stored (we inserted the same 8.87 million rows into both tables), the order of the key columns in the compound primary key has a significant influence on how much disk space the <a href="https://clickhouse.com/docs/en/introduction/distinctive-features/#data-compression" target="_blank">compressed</a> data in the table's [column data files](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#data-is-stored-on-disk-ordered-by-primary-key-columns) requires:
 - in the table `hits_URL_UserID_IsRobot` with the compound primary key `(URL, UserID, IsRobot)` where we order the key columns by cardinality in descending order, the `UserID.bin` data file takes **11.24 MiB** of disk space 
 - in the table `hits_IsRobot_UserID_URL` with the compound primary key `(IsRobot, UserID, URL)` where we order the key columns by cardinality in ascending order, the `UserID.bin` data file takes only **877.47 KiB** of disk space 
 
@@ -197,7 +197,7 @@ In the following we illustrate why it's beneficial for the compression ratio of 
 The diagram below sketches the on-disk order of rows for a primary key where the key columns are ordered by cardinality in ascending order:
 <img src={require('./images/sparse-primary-indexes-14a.png').default} class="image"/>
 
-We discussed that [the table's row data is stored on disk ordered by primary key columns](./sparse-primary-indexes-design#data-is-stored-on-disk-ordered-by-primary-key-columns).
+We discussed that [the table's row data is stored on disk ordered by primary key columns](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#data-is-stored-on-disk-ordered-by-primary-key-columns).
 
 In the diagram above, the table's rows (their column values on disk) are first ordered by their `cl` value, and rows that have the same `cl` value are ordered by their `ch` value. And because the first key column `cl` has low cardinality, it is likely that there are rows with the same `cl` value. And because of that it is also likely that `ch` values are ordered (locally - for rows with the same `cl` value).
 

--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md
@@ -16,11 +16,11 @@ Such an index allows the fast location of specific rows, resulting in high effic
 
 This capability comes at a cost: additional disk and memory overheads and higher insertion costs when adding new rows to to the table and entries to the index (and also sometimes rebalancing of the B-Tree).
 
-Considering the challenges associated with B-Tree indexes, table engines in ClickHouse utilise a different approach. The ClickHouse <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/" target="_blank">MergeTree Engine Family</a> has been designed and  optimized to handle massive data volumes.
+Considering the challenges associated with B-Tree indexes, table engines in ClickHouse utilise a different approach. The ClickHouse [MergeTree Engine Family](/docs/en/engines/table-engines/mergetree-family/index.md) has been designed and  optimized to handle massive data volumes.
 
 These tables are designed to receive millions of row inserts per second and store very large (100s of Petabytes) volumes of data.
 
-Data is quickly written to a table <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#mergetree-data-storage" target="_blank">part by part</a>, with rules applied for merging the parts in the background.
+Data is quickly written to a table [part by part](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#mergetree-data-storage), with rules applied for merging the parts in the background.
 
 In ClickHouse each part has its own primary index. When parts are merged, then the merged part’s primary indexes are also merged.
 
@@ -148,7 +148,7 @@ bytes_on_disk:               207.07 MiB
 
 The output of the ClickHouse client shows:
 
-- The table’s data is stored in <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#mergetree-data-storage" target="_blank">wide format</a> in a specific directory on disk meaning that there will be one data file (and one mark file) per table column inside that directory.
+- The table’s data is stored in [wide format](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#mergetree-data-storage) in a specific directory on disk meaning that there will be one data file (and one mark file) per table column inside that directory.
 - The table has 8.87 million rows.
 - The uncompressed data size of all rows together is 733.28 MB.
 - The compressed on disk data size of all rows together is 206.94 MB.
@@ -158,8 +158,8 @@ The output of the ClickHouse client shows:
 ## Data is stored on disk ordered by primary key column(s)
 
 Our table that we created above has
-- a compound <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#primary-keys-and-indexes-in-queries" target="_blank">primary key</a> <font face = "monospace">(UserID, URL)</font> and
-- a compound <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#choosing-a-primary-key-that-differs-from-the-sorting-key" target="_blank">sorting key</a> <font face = "monospace">(UserID, URL, EventTime)</font>.
+- a compound [primary key](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#primary-keys-and-indexes-in-queries) <font face = "monospace">(UserID, URL)</font> and
+- a compound [sorting key](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#choosing-a-primary-key-that-differs-from-the-sorting-key) <font face = "monospace">(UserID, URL, EventTime)</font>.
 
 :::note
 - If we would have specified only the sorting key, then the primary key would be implicitly defined to be equal to the sorting key.

--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-intro.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-intro.md
@@ -9,17 +9,17 @@ description: TODO
 # A Practical Introduction to Primary Indexes in ClickHouse
 
 In this guide we are going to do a deep dive into ClickHouse indexing. We will illustrate and discuss in detail:
-- [how indexing in ClickHouse is different from traditional relational database management systems](./sparse-primary-indexes-design#an-index-design-for-massive-data-scales)
-- [how ClickHouse is building and using a table’s sparse primary index](./sparse-primary-indexes-design#a-table-with-a-primary-key)
-- [what some of the best practices are for indexing in ClickHouse](./sparse-primary-indexes-multiple)
+- [how indexing in ClickHouse is different from traditional relational database management systems](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#an-index-design-for-massive-data-scales)
+- [how ClickHouse is building and using a table’s sparse primary index](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#a-table-with-a-primary-key)
+- [what some of the best practices are for indexing in ClickHouse](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md)
 
 You can optionally execute all ClickHouse SQL statements and queries given in this guide by yourself on your own machine.
-For installation of ClickHouse and getting started instructions, see the [Quick Start](../../../quick-start.mdx).
+For installation of ClickHouse and getting started instructions, see the [Quick Start](/docs/en/quick-start.mdx).
 
 :::note
 This guide is focusing on ClickHouse sparse primary indexes.
 
-For ClickHouse <a href="https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#table_engine-mergetree-data_skipping-indexes" target="_blank">secondary data skipping indexes</a>, see the [Tutorial](../skipping-indexes.md).
+For ClickHouse [secondary data skipping indexes](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#table_engine-mergetree-data_skipping-indexes), see the [Tutorial](/docs/en/guides/improving-query-performance/skipping-indexes.md).
 
 
 :::
@@ -61,7 +61,7 @@ PRIMARY KEY tuple();
 
 
 
-Next insert a subset of the hits data set into the table with the following SQL insert statement. This uses the <a href="https://clickhouse.com/docs/en/sql-reference/table-functions/url/" target="_blank">URL table function</a> in combination with <a href="https://clickhouse.com/blog/whats-new-in-clickhouse-22-1/#schema-inference" target="_blank">schema inference</a> in order to load a  subset of the full dataset hosted remotely at clickhouse.com:
+Next insert a subset of the hits data set into the table with the following SQL insert statement. This uses the [URL table function](/docs/en/sql-reference/table-functions/url.md) in combination with <a href="https://clickhouse.com/blog/whats-new-in-clickhouse-22-1/#schema-inference" target="_blank">schema inference</a> in order to load a  subset of the full dataset hosted remotely at clickhouse.com:
 
 ```sql
 INSERT INTO hits_NoPrimaryKey SELECT
@@ -82,7 +82,7 @@ Ok.
 ClickHouse client’s result output shows us that the statement above inserted 8.87 million rows into the table.
 
 
-Lastly, in order to simplify the discussions later on in this guide and to make the diagrams and results reproducible, we <a href="https://clickhouse.com/docs/en/sql-reference/statements/optimize/" target="_blank">optimize</a> the table using the FINAL keyword:
+Lastly, in order to simplify the discussions later on in this guide and to make the diagrams and results reproducible, we [optimize](/docs/en/sql-reference/statements/optimize.md) the table using the FINAL keyword:
 
 ```sql
 OPTIMIZE TABLE hits_NoPrimaryKey FINAL;

--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md
@@ -392,7 +392,7 @@ We now have two tables. Optimized for speeding up queries filtering on UserIDs, 
 
 ## Option 2: Materialized Views
 
-Create a [materialized view](/docs/en/sql-reference/statements/create/view.md/#materialized-view) on our existing table.
+Create a [materialized view](/docs/en/sql-reference/statements/create/view.md) on our existing table.
 ```sql
 CREATE MATERIALIZED VIEW mv_hits_URL_UserID
 ENGINE = MergeTree()
@@ -414,7 +414,7 @@ Ok.
 - we switch the order of the key columns (compared to our [original table](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#a-table-with-a-primary-key) ) in the view's primary key
 - the materialized view is backed by a **implicitly created table** whose row order and primary index is based on the given primary key definition
 - the implicitly created table is listed by the <font face = "monospace">SHOW TABLES</font> query and has a name starting with <font face = "monospace">.inner</font>
-- it is also possible to first explicitly create the backing table for a materialized view and then the view can target that table via the <font face = "monospace">TO [db].[table]</font> [clause](/docs/en/sql-reference/statements/create/view.md/materialized)
+- it is also possible to first explicitly create the backing table for a materialized view and then the view can target that table via the <font face = "monospace">TO [db].[table]</font> [clause](/docs/en/sql-reference/statements/create/view.md)
 - we use the <font face = "monospace">POPULATE</font> keyword in order to immediately populate the implicitly created table with all 8.87 million rows from the source table [hits_UserID_URL](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#a-table-with-a-primary-key)
 - if new rows are inserted into the source table hits_UserID_URL, then that rows are automatically also inserted into the implicitly created table
 - Effectively the implicitly created table has the same row order and primary index as the [secondary table that we created explicitly](#multiple-primary-indexes-via-secondary-tables):

--- a/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-uuids.md
+++ b/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-uuids.md
@@ -7,15 +7,15 @@ description: Identifying single rows efficiently
 
 # Identifying single rows efficiently
 
-Although in general it is [not](https://clickhouse.com/docs/en/faq/use-cases/key-value) the best use case for ClickHouse, 
+Although in general it is [not](/docs/en/faq/use-cases/key-value.md) the best use case for ClickHouse, 
 sometimes applications built on top of ClickHouse require to identify single rows of a ClickHouse table. 
 
  
 An intuitive solution for that might be to use a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) column with a unique value per row and for fast retrieval of rows to use that column as a primary key column.
 
-For the fastest retrieval, the UUID column [would need to be the first key column](./sparse-primary-indexes-design#the-primary-index-is-used-for-selecting-granules).
+For the fastest retrieval, the UUID column [would need to be the first key column](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#the-primary-index-is-used-for-selecting-granules).
 
-We discussed that because [a ClickHouse table's row data is stored on disk ordered by primary key column(s)](./sparse-primary-indexes-design#data-is-stored-on-disk-ordered-by-primary-key-columns), having a very high cardinality column (like a UUID column) in a primary key or in a compound primary key before columns with lower cardinality [is detrimental for the compression ratio of other table columns](./sparse-primary-indexes-cardinality#optimal-compression-ratio-of-data-files).
+We discussed that because [a ClickHouse table's row data is stored on disk ordered by primary key column(s)](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#data-is-stored-on-disk-ordered-by-primary-key-columns), having a very high cardinality column (like a UUID column) in a primary key or in a compound primary key before columns with lower cardinality [is detrimental for the compression ratio of other table columns](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-cardinality.md/#optimal-compression-ratio-of-data-files).
 
 A compromise between fastest retrieval and optimal data compression is to use a compound primary key where the UUID is the last key column, after low(er) cardinality key columns that are used to ensure a good compression ratio for some of the table's columns. 
 
@@ -33,7 +33,7 @@ The following diagram shows
 <img src={require('./images/sparse-primary-indexes-15a.png').default} class="image"/>
 
 Because the `hash` column is used as the primary key column
-- specific rows can be retrieved [very quickly](./sparse-primary-indexes-design#the-primary-index-is-used-for-selecting-granules), but
+- specific rows can be retrieved [very quickly](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-design.md/#the-primary-index-is-used-for-selecting-granules), but
 - the table's rows (their column data) are stored on disk ordered ascending by (the unique and random) hash values. Therefore also the content column's values are stored in random order with no data locality resulting in a **suboptimal compression ratio for the content column data file**.
 
 


### PR DESCRIPTION
links should include the `.md`

@tom-clickhouse we are seeing reports of 404's on these pages.  This is probably caused by not having the `.md` in the links.  I know you are working on these docs this week, so please pull your working copy after I fix these.