### PR TITLE
temp fix for 404 page dark theme style

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -16,11 +16,7 @@ export default function NotFound() {
           <div className="row">
             <div className="col col--6 col--offset-3 notfound">
               <h1 className="hero__title">
-                <Translate
-                  id="theme.NotFound.title"
-                  description="The title of the 404 page">
-                  Page Not Found
-                </Translate>
+                  <font color="gray">Page Not Found</font>
               </h1>
               <p>
                   We could not find what you're looking for! Our docs have recently gone through a major reorganization, so it is possilbe that


### PR DESCRIPTION
Set the H1 color to gray as that works OK in both dark and light themes.  closes #409 We need to update the 404 page with the header and footer content etc.  I will open a new issue.