### PR TITLE
move operations/backup to an include file

### DIFF
--- a/docs/en/manage/backups.mdx
+++ b/docs/en/manage/backups.mdx
@@ -2,6 +2,7 @@
 sidebar_label: Backups
 sidebar_position: 1
 slug: /en/manage/backups
+hide_table_of_contents: true
 ---
 import SelfManagedBackup from '@site/docs/en/operations/_backup.md';
 

--- a/docs/en/manage/backups.mdx
+++ b/docs/en/manage/backups.mdx
@@ -3,7 +3,7 @@ sidebar_label: Backups
 sidebar_position: 1
 slug: /en/manage/backups
 ---
-import SelfManagedBackup from '@site/docs/en/operations/backup.md';
+import SelfManagedBackup from '@site/docs/en/operations/_backup.md';
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -680,6 +680,7 @@ const config = {
           { from: '/quick-start', to: '/en/quick-start' },
           { from: '/ru/whats-new/index', to: '/ru/whats-new/' },
           { from: '/en/operations', to: '/en/manage' },
+          { from: '/en/operations/backup', to: '/en/manage/backups' },
           { from: '/manage/security', to: '/en/manage/security' },
         ],
       },


### PR DESCRIPTION

This must be merged with https://github.com/ClickHouse/ClickHouse/pull/42666

Because we include the self managed and cloud backup instructions into a single file with tabs the self managed file is renamed from backup.md to _backup.md to remove it from the side nav.

This PR does:
- add redir
- change import filename to_backup.md
