### PR TITLE
ignore .ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/_clients
 run.sh
 cleanup.sh
 update.sh
+
+.ignore


### PR DESCRIPTION
I use neovim to edit the docs, and the [Markdown language server marksman](https://github.com/artempyanykh/marksman/) will verify the paths to Markdown files (and provide autocomplete) for me as I write.  The problem is that Marksman honors the `.gitignore` file, and ignores the reference docs (reporting them as non-existent).  To have the best experience I have added a `.ignore` file with negated entries for the reference dirs.  For example:
```
!docs/en/engines
!docs/en/getting-started
!docs/en/operations
```

related to https://github.com/artempyanykh/marksman/issues/113