### PR TITLE
Fix createClient example

### DIFF
--- a/docs/en/integrations/language-clients/nodejs.md
+++ b/docs/en/integrations/language-clients/nodejs.md
@@ -100,7 +100,7 @@ import { createClient } from '@clickhouse/client'
 
 const client = createClient({
   host: process.env.CLICKHOUSE_HOST ?? 'http://localhost:8123',
-  user: process.env.CLICKHOUSE_USER ?? 'default',
+  username: process.env.CLICKHOUSE_USER ?? 'default',
   password: process.env.CLICKHOUSE_PASSWORD ?? '',
 })
 ```


### PR DESCRIPTION
The parameter `user` should be `username` per instructions further up and real implementation.