### PR TITLE
Tune cloud links in Quick Start

### DIFF
--- a/docs/en/quick-start.mdx
+++ b/docs/en/quick-start.mdx
@@ -14,7 +14,7 @@ import CodeBlock from '@theme/CodeBlock';
 # ClickHouse Quick Start
 
 The quickest and easiest way to get up and running with ClickHouse is to create a new
-service in [ClickHouse Cloud](https://clickhouse.cloud).
+service in [ClickHouse Cloud](https://clickhouse.com/cloud).
 
 <div class='vimeo-container'>
   <iframe src="https://player.vimeo.com/video/756877867?h=c58e171729"
@@ -35,7 +35,7 @@ service in [ClickHouse Cloud](https://clickhouse.cloud).
 <Tabs groupId="deployMethod">
 <TabItem value="serverless" label="ClickHouse Cloud" default>
 
-To create a free ClickHouse service in [ClickHouse Cloud](https://clickhouse.cloud), you just need to sign up by completing the following steps:
+To create a free ClickHouse service in [ClickHouse Cloud](https://clickhouse.com/cloud), you just need to sign up by completing the following steps:
 
   - Create an account on the [sign-up page](https://clickhouse.cloud/signUp)
   - Verify your email address (by clicking the link in the email you receive)


### PR DESCRIPTION
I think for people who landed to documentation from Google it is more valuable to explain what ClickHouse Cloud is first, instead of bringing them straight to sign-up (which is still linked below in the instruction + main CTA on that /cloud).