### PR TITLE
Update _supported_regions.md

### DIFF
--- a/docs/en/_snippets/_supported_regions.md
+++ b/docs/en/_snippets/_supported_regions.md
@@ -8,5 +8,6 @@ These are the supported AWS regions:
 - us-east-2
 - us-west-2
 
-:::note Development services are currently not supported in ap-southeast-1 and ap-south-1 regions.
+:::note
+Development services are currently not supported in ap-southeast-1 and ap-south-1 regions.
 :::

--- a/docs/en/_snippets/_supported_regions.md
+++ b/docs/en/_snippets/_supported_regions.md
@@ -8,7 +8,5 @@ These are the supported AWS regions:
 - us-east-2
 - us-west-2
 
-:::note Region ap-south-1
-In order to access the region ap-south-1, please open a case
-with [ClickHouse Cloud support](https://clickhouse.cloud/support).
+:::note Development services are currently not supported in ap-southeast-1 and ap-south-1 regions.
 :::


### PR DESCRIPTION
@DanRoscigno Updating this snippet because we now enabled ap-south-1 for self-service for Production services. On the other hand ap-southeast-1 and ap-south-1 currently do not support Development services.

cc @krithika-ch FYI