### PR TITLE
Fix docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ ClickHouse is blazing fast, but understanding ClickHouse and using it effectivel
 
 Some of the highlights of the ClickHouse docs include:
 
-- A **[Quick Start](https://clickhouse.com/docs/quick-start)** and **[Tutorial](https://clickhouse.com/docs/tutorial)** to get new users up and running quickly
-- A **[Connect a UI section](https://clickhouse.com/docs/connect-a-ui)** with guides on how to connect popular UI/BI tools to ClickHouse like Grafana, Metabase, Superset and Tableau
-- An **[Integrations section](https://clickhouse.com/docs/integrations)** of guides on how to connect ClickHouse to external systems like Kafka AWS S3, PostgreSQL, MySQL, Airbyte and much more
-- A **[User Guides section](https://clickhouse.com/docs/guides)** filled with articles, tutorials and how-to guides covering all sorts of fundamental and advanced ClickHouse topics, including how to choose a primary key, configure a replicated table, improve query performance, and lots of other helpful tips and tricks.
+- A **[Quick Start](https://clickhouse.com/docs/quick-start)** and **[Tutorial](https://clickhouse.com/docs/en/tutorial)** to get new users up and running quickly
+- A **[Connect a UI section](https://clickhouse.com/docs/en/connect-a-ui)** with guides on how to connect popular UI/BI tools to ClickHouse like Grafana, Metabase, Superset and Tableau
+- An **[Integrations section](https://clickhouse.com/docs/en/integrations)** of guides on how to connect ClickHouse to external systems like Kafka AWS S3, PostgreSQL, MySQL, Airbyte and much more
+- A **[User Guides section](https://clickhouse.com/docs/en/guides)** filled with articles, tutorials and how-to guides covering all sorts of fundamental and advanced ClickHouse topics, including how to choose a primary key, configure a replicated table, improve query performance, and lots of other helpful tips and tricks.
 - The historical docs can be found in the **[References section](https://clickhouse.com/docs/en)**, where you will find all the technical details like a complete ClickHouse SQL reference, a explanation of the various ClickHouse data types, instructions on how to build ClickHouse from the source code, the recent changelog, and much more.
 
 ## How to Contribute


### PR DESCRIPTION
Looks like some of the redirects from `https://clickhouse.com/docs/{section}` don't work properly, while others do. A better fix would be to redirect and use the user, like `https://clickhouse.com/docs/quick-start` 

Updated the following links:
`https://clickhouse.com/docs/tutorial` -> `https://clickhouse.com/docs/en/tutorial` `https://clickhouse.com/docs/connect-a-ui` -> `https://clickhouse.com/docs/en/connect-a-ui` `https://clickhouse.com/docs/guides` -> `https://clickhouse.com/docs/en/guides`