### PR TITLE
docs for using Google Cloud Storage (GCS) for ClickHouse

### DIFF
--- a/docs/en/guides/sre/gcs-storage.md
+++ b/docs/en/guides/sre/gcs-storage.md
@@ -1,0 +1,68 @@
+---
+slug: /en/guides/sre/gcs-storage
+sidebar_label: Using Google Cloud Storage (GCS)
+---
+
+# Using Google Cloud Storage (GCS)
+
+import SelfManaged from '@site/docs/en/_snippets/_self_managed_only_no_roadmap.md';
+
+<SelfManaged />
+
+## Plan the deployment
+This tutorial is based on deploying one ClickHouse server node in Google Cloud, and one GCS bucket.  Both of these are in the same region.
+
+## Create a GCS bucket
+
+Create a user HMAC key and secret.
+
+Create a bucket.
+
+## Install software
+
+Refer to the [installation instructions](/docs/en/getting-started/install/) when performing the deployment steps.
+
+### Configure ClickHouse
+
+Add a storage configuration in `/etc/clickhouse-server/config.d`
+```xml title=/etc/clickhouse-server/config.d/gcs_storage.xml
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <gcs>
+                <support_batch_delete>false</support_batch_delete>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/YOUR BUCKET/YOUR FOLDER/</endpoint>
+                <access_key_id>YOUR HMAC KEY ID</access_key_id>
+                <secret_access_key>YOUR HMAC SECRET</secret_access_key>
+                <metadata_path>/var/lib/clickhouse/disks/gcs/</metadata_path>
+                <cache_enabled>true</cache_enabled>
+                <data_cache_enabled>true</data_cache_enabled>
+                <cache_path>/var/lib/clickhouse/disks/gcs/cache/</cache_path>
+            </gcs>
+        </disks>
+        <policies>
+            <gcs_storage>
+                <volumes>
+                    <main>
+                        <disk>gcs</disk>
+                    </main>
+                </volumes>
+            </gcs_main>
+        </policies>
+    </storage_configuration>
+</clickhouse>
+```
+
+:::note
+Some of the steps in this guide will ask you to place a configuration file in `/etc/clickhouse-server/config.d/`.  This is the default location on Linux systems for configuration override files.  When you put these files into that directory ClickHouse will merge the content with the default configuration.  By placing these files in the `config.d` directory you will avoid losing your configuration during an upgrade.
+:::
+
+## Start ClickHouse
+
+## Verification
+
+### Verify ClickHouse Server
+
+### Verify in Google Cloud Console
+


### PR DESCRIPTION
This will probably evolve into two docs, one highlighting the use of GCS for storage, and a second tutorial on deploying a replicated / sharded cluster on top of GCS (a clone of the [S3 one](https://clickhouse.com/docs/en/guides/sre/configuring-s3-for-clickhouse-use/#create-an-s3-bucket))