### PR TITLE
Tips on file() & fixed JSON link

### DIFF
--- a/docs/en/integrations/data-ingestion/data-formats/binary.md
+++ b/docs/en/integrations/data-ingestion/data-formats/binary.md
@@ -36,6 +36,10 @@ DESCRIBE file('data.clickhouse', Native);
 └───────┴────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘
 ```
 
+:::tip
+When using the `file()` function, with ClickHouse Cloud you will need to run the commands in `clickhouse client` on the machine where the file resides. Another option is to use [`clickhouse-local`](/docs/en/operations/utilities/clickhouse-local.md) to explore files locally.
+:::
+
 In production, we use `FROM INFILE` to import data:
 
 ```sql

--- a/docs/en/integrations/data-ingestion/data-formats/csv-tsv.md
+++ b/docs/en/integrations/data-ingestion/data-formats/csv-tsv.md
@@ -100,6 +100,10 @@ SELECT count(*) FROM file('data-small.csv', CSV)
 
 The [file](assets/data_small.csv) has 1k rows, but ClickHouse loaded only 990 since we’ve asked to skip the first 10.
 
+:::tip
+When using the `file()` function, with ClickHouse Cloud you will need to run the commands in `clickhouse client` on the machine where the file resides. Another option is to use [`clickhouse-local`](/docs/en/operations/utilities/clickhouse-local.md) to explore files locally.
+:::
+
 
 ### Treating NULL values in CSV files
 

--- a/docs/en/integrations/data-ingestion/data-formats/json.md
+++ b/docs/en/integrations/data-ingestion/data-formats/json.md
@@ -14,7 +14,7 @@ JSON is a popular format for exchanging data between different layers of modern 
 To import JSON data, we first have to define which JSON type to use. This will depend on how the input data is structured.
 
 :::tip JSON tutorial
-For a step by step tutorial with a large JSON dataset, please see Loading JSON in 5 steps.
+For a step by step tutorial with a large JSON dataset, please see [Loading JSON in 5 steps](/docs/en/guides/developer/working-with-json/json-load-data.md).
 :::
 
 ### Importing from an array of JSON objects

--- a/docs/en/integrations/data-ingestion/data-formats/parquet-arrow-avro-orc.md
+++ b/docs/en/integrations/data-ingestion/data-formats/parquet-arrow-avro-orc.md
@@ -21,7 +21,7 @@ DESCRIBE TABLE file('data.parquet', Parquet)
 ```
 
 :::tip
-When using the `file()` function, with ClickHouse Cloud you will need to run the commands in `clickhouse client` on the machine where the file resides.
+When using the `file()` function, with ClickHouse Cloud you will need to run the commands in `clickhouse client` on the machine where the file resides. Another option is to use [`clickhouse-local`](/docs/en/operations/utilities/clickhouse-local.md) to explore files locally.
 :::
 
 We've used [Parquet](/docs/en/interfaces/formats.md/#data-format-parquet) as a second argument, so ClickHouse knows the file format. This will print columns with the types:

--- a/docs/en/integrations/data-ingestion/data-formats/sql.md
+++ b/docs/en/integrations/data-ingestion/data-formats/sql.md
@@ -70,6 +70,10 @@ LIMIT 5
 └────────────────────────────────┴────────────┴──────┘
 ```
 
+:::tip
+When using the `file()` function, with ClickHouse Cloud you will need to run the commands in `clickhouse client` on the machine where the file resides. Another option is to use [`clickhouse-local`](/docs/en/operations/utilities/clickhouse-local.md) to explore files locally.
+:::
+
 By default, ClickHouse will skip unknown columns (controlled by [input_format_skip_unknown_fields](/docs/en/operations/settings/settings.md/#input_format_skip_unknown_fields) option) and process data for the first found table in a dump (in case multiple tables were dumped to a single file). DDL statements will be skipped. To load data from MySQL dump into a table ([mysql.sql](assets/mysql.sql) file):
 
 ```sql


### PR DESCRIPTION
Added tips on `file()` usage as Dale suggested. Also fixed a link to JSON article in the tip box.