### PR TITLE
link to markdown file

### DIFF
--- a/docs/en/cloud/reference/changelog.md
+++ b/docs/en/cloud/reference/changelog.md
@@ -14,7 +14,7 @@ This release brings an officially supported Metabase integration, a major Java c
 - [Metabase](/docs/en/integrations/data-visualization/metabase-and-clickhouse.md) plugin: Became an official solution maintained ClickHouse
 - [dbt](/docs/en/integrations/data-ingestion/etl-tools/dbt/dbt-intro.md) plugin: Added support for [multiple threads](https://github.com/ClickHouse/dbt-clickhouse/blob/main/CHANGELOG.md)
 - [Grafana](/docs/en/integrations/data-visualization/grafana-and-clickhouse.md) plugin: Better handling of connection errors
-- [Python](/docs/en/integrations/language-clients/python/intro.md) client: [Streaming support](https://clickhouse.com/docs/en/integrations/language-clients/python/advanced/#streaming-queries) for insert operation
+- [Python](/docs/en/integrations/language-clients/python/intro.md) client: [Streaming support](/docs/en/integrations/language-clients/python/queries#streaming-queries) for insert operation
 - [Go](/docs/en/integrations/language-clients/go/intro.md) client: [Bug fixes](https://github.com/ClickHouse/clickhouse-go/blob/main/CHANGELOG.md): close canceled connections, better handling of connection errors
 - [JS](/docs/en/integrations/language-clients/nodejs.md) client: [Breaking changes in exec/insert](https://github.com/ClickHouse/clickhouse-js/releases/tag/0.0.12); exposed query_id in the return types
 - [Java](https://github.com/ClickHouse/clickhouse-java#readme) client / JDBC driver major release


### PR DESCRIPTION
had a link using `https://click...` and we need to use `/docs/en/...` to link to markdown files so that URLs are checked.