### PR TITLE
fix broken links in integrations docs

### DIFF
--- a/docs/en/integrations/data-ingestion/kafka/cloud/confluent/index.md
+++ b/docs/en/integrations/data-ingestion/kafka/cloud/confluent/index.md
@@ -136,7 +136,7 @@ The following additional parameters are relevant to using the HTTP Sink with Cli
 
 A full list of settings, including how to configure a proxy, retries, and advanced SSL, can be found [here](https://docs.confluent.io/kafka-connect-http/current/connector_config.html).
 
-Example configuration files for the Github sample data can be found [here](https://github.com/ClickHouse/clickhouse-docs/tree/main/docs/en/integrations/kafka/code/connectors/http_sink), assuming Connect is run in standalone mode and Kafka is hosted in Confluent Cloud.
+Example configuration files for the Github sample data can be found [here](https://github.com/ClickHouse/clickhouse-docs/tree/main/docs/en/integrations/data-ingestion/kafka/code/connectors/http_sink), assuming Connect is run in standalone mode and Kafka is hosted in Confluent Cloud.
 
 #### 2. Create the ClickHouse table
 

--- a/docs/en/integrations/data-ingestion/s3/s3-table-engine.md
+++ b/docs/en/integrations/data-ingestion/s3/s3-table-engine.md
@@ -32,7 +32,7 @@ where,
 
 ## Reading Data
 
-In the following example, we create a table trips_raw using the first ten tsv files located within the [nyc-taxi](https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/) bucket. Each of these contains 1m rows each.
+In the following example, we create a table trips_raw using the first ten tsv files located within the `https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/` bucket. Each of these contains 1m rows each.
 
 
 ```sql


### PR DESCRIPTION
report
```
htmltest started at 07:44:55 on build/build/docs/en/integrations
========================================================================
Cannot access 'build/build/docs/en/integrations', no such directory.
❯ vi .htmltest.yml
❯ htmltest
htmltest started at 07:45:12 on build/docs/en/integrations
========================================================================
airbyte-and-clickhouse/index.html
  Get "http://localhost:8000/": dial tcp [::1]:8000: connect: connection refused --- airbyte-and-clickhouse/index.html --> http://localhost:8000/
kafka/cloud/confluent/index.html
  Non-OK status: 404 --- kafka/cloud/confluent/index.html --> https://github.com/ClickHouse/clickhouse-docs/tree/main/docs/en/integrations/kafka/code/connectors/http_sink
s3/s3-table-engine/index.html
  Non-OK status: 416 --- s3/s3-table-engine/index.html --> https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/
========================================================================
✘✘✘ failed in 2m44.725470494s
3 errors in 110 documents
```

Don't understand the repot about this error
```
Get "http://localhost:8000/": dial tcp [::1]:8000: connect: connection refused --- airbyte-and-clickhouse/index.html --> http://localhost:8000/kafka/cloud/confluent/index.html
```

The PR fixes
```
Non-OK status: 404 --- kafka/cloud/confluent/index.html --> https://github.com/ClickHouse/clickhouse-docs/tree/main/docs/en/integrations/kafka/code/connectors/http_sink
s3/s3-table-engine/index.html
```

It shouldn't be a link, converted into text
```
Non-OK status: 416 --- s3/s3-table-engine/index.html --> https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/
```