### PR TITLE
Fixes title in R2DBC driver page

### DIFF
--- a/docs/en/integrations/language-clients/java/r2dbc.md
+++ b/docs/en/integrations/language-clients/java/r2dbc.md
@@ -5,7 +5,7 @@ keywords: [clickhouse, r2dbc, integrate]
 description: The ClickHouse R2DBC Driver
 slug: /en/integrations/language-clients/java/r2dbc
 ---
-# JDBC driver
+# R2DBC driver
 [R2DBC](https://r2dbc.io/) wrapper of async [Java client](./client) for ClickHouse.
 
 ## Environment requirements


### PR DESCRIPTION
### Problem:

Page https://clickhouse.com/docs/en/integrations/language-clients/java/r2dbc has the incorrect title: the article about R2DBC driver should has the title 'R2DBC' instead of 'JDBC'.