### PR TITLE
modify path to integrations index

### DIFF
--- a/docs/en/integrations/index.mdx
+++ b/docs/en/integrations/index.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /en/integrations/
+slug: /en/integrations/intro
 title: Integrations
 keywords: [integrations, integrate, integrate with]
 description: Integrations with ClickHouse

--- a/docs/en/quick-start.mdx
+++ b/docs/en/quick-start.mdx
@@ -430,6 +430,6 @@ Suppose we have the following text in a CSV file named `data.csv`:
 - The [Tutorial](/en/tutorial.md) has you insert 2 million rows into a table and write some analytical queries
 - We have a list of [example datasets](/en/getting-started/example-datasets/) with instructions on how to insert them
 - Check out our 25-minute video on [Getting Started with ClickHouse](https://clickhouse.com/company/events/getting-started-with-clickhouse/)
-- If your data is coming from an external source, view our [collection of integration guides](/en/integrations/) for connecting to message queues, databases, pipelines and more
+- If your data is coming from an external source, view our [collection of integration guides](/docs/en/integrations/index.mdx) for connecting to message queues, databases, pipelines and more
 - If you are using a UI/BI visualization tool, view the [user guides for connecting a UI to ClickHouse](/en/integrations/data-visualization/)
 - The user guide on [primary keys](/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-intro.md) is everything you need to know about primary keys and how to define them

--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -492,7 +492,7 @@ Let's write some queries that join the `taxi_zone_dictionary` with your `trips` 
 Well done - you made it through the tutorial, and hopefully you have a better understanding of how to use ClickHouse. Here are some options for what to do next:
 
 - Read [how primary keys work in ClickHouse](./guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-intro.md) - this knowledge will move you a long ways forward along your journey to becoming a ClickHouse expert
-- [Integrate an external data source](./integrations/) like files, Kafka, PostgreSQL, data pipelines, or lots of other data sources
+- [Integrate an external data source](/docs/en/integrations/index.mdx) like files, Kafka, PostgreSQL, data pipelines, or lots of other data sources
 - [Connect your favorite UI/BI tool](./integrations/data-visualization/) to ClickHouse
 - Check out the [SQL Reference](./sql-reference/) and browse through the various functions. ClickHouse has an amazing collection of functions for transforming, processing and analyzing data
 - Learn more about [Dictionaries](/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -313,6 +313,7 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
+          { from: '/en/integrations', to: '/en/integrations/intro' },
           { from: '/en/connect-a-ui', to: '/en/integrations/data-visualization' },
           { from: '/en/development/browse_code', to: '/en/development/developer-instruction' },
           { from: '/en/development/browse-code', to: '/en/development/developer-instruction' },


### PR DESCRIPTION
Having the parent of the integrations page as "integrations" boosts the page ranking.

So, while https://clickhouse.com/docs/en/integrations/ ranks low, https://clickhouse.com/docs/en/integrations/intro should rank higher