### PR TITLE
[yarn prep] arrays as config vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "clickhouse-docs-2-3-0",
   "version": "0.0.0",
   "private": true,
+  "config": {
+    "prep_array_en": "docs/en/development docs/en/engines docs/en/getting-started docs/en/interfaces docs/en/operations docs/en/sql-reference",
+    "prep_array_root": "docs/ru docs/zh"
+  },
   "scripts": {
     "build": "docusaurus build",
     "clear": "docusaurus clear",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
-    "prep-from-local": "sh -c 'array_root=(docs/ru docs/zh);array_en=(docs/en/development docs/en/engines docs/en/getting-started docs/en/interfaces docs/en/operations docs/en/sql-reference);for folder in ${array_en[@]}; do cp -r $0/$folder docs/en;echo \"Copied $folder from ClickHouse local path [$0]\";done;for folder in ${array_root[@]}; do cp -r $0/$folder docs/;echo \"Copied $folder from ClickHouse local path [$0]\";done;echo \"Prep completed\";'",
-    "prep-from-master": "array_root=(docs/ru docs/zh);array_en=(docs/en/development docs/en/engines docs/en/getting-started docs/en/interfaces docs/en/operations docs/en/sql-reference);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo \"Copied $folder from ClickHouse source\";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo \"Copied $folder from ClickHouse source\";done;rm -rf $ch_temp && echo \"Prep completed\";",
+    "prep-from-local": "sh -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);for folder in ${array_en[@]}; do cp -r $0/$folder docs/en;echo \"Copied $folder from [$0]\";done;for folder in ${array_root[@]}; do cp -r $0/$folder docs/;echo \"Copied $folder from [$0]\";done;echo \"Prep completed\";'",
+    "prep-from-master": "array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo \"Copied $folder from ClickHouse master branch\";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo \"Copied $folder from ClickHouse master branch\";done;rm -rf $ch_temp && echo \"Prep completed\";",
     "serve": "docusaurus serve",
     "start": "docusaurus start",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
This PR moves the hardcoded `en` and `root` arrays to npm package config vars for easier readability, maintanability and to allow future changes if needed.

```
➜  clickhouse-docs git:(prep_improvements) ✗ yarn prep-from-master
yarn run v1.22.19
$ array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo "Copied $folder from ClickHouse master branch";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo "Copied $folder from ClickHouse master branch";done;rm -rf $ch_temp && echo "Prep completed";
Cloning into '/tmp/ch_temp_26405'...
remote: Enumerating objects: 22922, done.
remote: Counting objects: 100% (22922/22922), done.
remote: Compressing objects: 100% (18729/18729), done.
remote: Total 22922 (delta 3106), reused 10512 (delta 2109), pack-reused 0
Receiving objects: 100% (22922/22922), 75.41 MiB | 3.07 MiB/s, done.
Resolving deltas: 100% (3106/3106), done.
Updating files: 100% (23471/23471), done.
Copied docs/en/development from ClickHouse master branch
Copied docs/en/engines from ClickHouse master branch
Copied docs/en/getting-started from ClickHouse master branch
Copied docs/en/interfaces from ClickHouse master branch
Copied docs/en/operations from ClickHouse master branch
Copied docs/en/sql-reference from ClickHouse master branch
Copied docs/ru from ClickHouse master branch
Copied docs/zh from ClickHouse master branch
Prep completed
✨  Done in 33.80s.
➜  clickhouse-docs git:(prep_improvements) ✗ yarn prep-from-local /Users/abonuccelli/Projects/ClickHouse/ClickHouse
yarn run v1.22.19
$ sh -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);for folder in ${array_en[@]}; do cp -r $0/$folder docs/en;echo "Copied $folder from [$0]";done;for folder in ${array_root[@]}; do cp -r $0/$folder docs/;echo "Copied $folder from [$0]";done;echo "Prep completed";' /Users/abonuccelli/Projects/ClickHouse/ClickHouse
Copied docs/en/development from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/en/engines from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/en/getting-started from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/en/interfaces from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/en/operations from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/en/sql-reference from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/ru from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Copied docs/zh from [/Users/abonuccelli/Projects/ClickHouse/ClickHouse]
Prep completed
✨  Done in 0.49s.
```