### PR TITLE
Update changelog.md

### DIFF
--- a/docs/en/cloud/reference/changelog.md
+++ b/docs/en/cloud/reference/changelog.md
@@ -140,7 +140,6 @@ This release introduces seamless logins for administrators to SQL console, impro
 
 ### Reliability and performance
 - Added retry logic for longer running insert queries to recover in the event of network failures
-- Optimized backup schedule to run backups only if data was modified
 - Improved read performance of cold reads 
 
 ### Integrations changes


### PR DESCRIPTION
Removing "backups optimization" from Dec 20, since we ended up shipping it on March 9 instead.

@DanRoscigno