### PR TITLE
Fix kafka table engine link in `docs/en/quick-start.mdx`

### DIFF
--- a/docs/en/quick-start.mdx
+++ b/docs/en/quick-start.mdx
@@ -273,7 +273,7 @@ View the [`odbc` table function](/docs/en/sql-reference/table-functions/odbc) an
 
 Message queues can stream data into ClickHouse using the corresponding table engine, including:
 
-- **Kafka**: integrate with Kafka using the [`Kafka` table engine](/docs/en//engines/table-engines/integrations/kafka)
+- **Kafka**: integrate with Kafka using the [`Kafka` table engine](/docs/en/engines/table-engines/integrations/kafka)
 - **Amazon MSK**: integrate with [Amazon Managed Streaming for Apache Kafka (MSK)](/docs/en/integrations/data-ingestion/msk/index.md)
 - **RabbitMQ**: integrate with RabbitMQ using the [`RabbitMQ` table engine](/docs/en/engines/table-engines/integrations/rabbitmq)
 


### PR DESCRIPTION
- Fixes the link to `Kafka` table engine (`/docs/en/engines/table-engines/integrations/kafka`)