### PR TITLE
builds API docs in Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prep-from-local": "sh -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);for folder in ${array_en[@]}; do cp -r $0/$folder docs/en;echo \"Copied $folder from [$0]\";done;for folder in ${array_root[@]}; do cp -r $0/$folder docs/;echo \"Copied $folder from [$0]\";done;echo \"Prep completed\";'",
     "prep-from-master": "array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo \"Copied $folder from ClickHouse master branch\";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo \"Copied $folder from ClickHouse master branch\";done;rm -rf $ch_temp && echo \"Prep completed\";",
     "serve": "docusaurus serve",
-    "new-build": "bash ./copyClickhouseRepoDocs.sh && yarn build",
+    "build-api-doc": "npx @redocly/cli build-docs  https://api.control-plane.clickhouse-staging.com/v1 --output build/en/cloud/manage/api.html",
+    "new-build": "bash ./copyClickhouseRepoDocs.sh && yarn build && yarn build-api-doc",
     "start": "docusaurus start",
     "swizzle": "docusaurus swizzle",
     "write-heading-ids": "docusaurus write-heading-ids"


### PR DESCRIPTION
Soon there will be a need to host API docs.  This PR adds functionality to:
- grab the API from our endpoint
- produce HTML documentation
- insert the HTML into the build directory that Vercel then serves

I would like to get this running for the UAT so that the testing can be done using the docs that our users will see.