### PR TITLE
Fixing colour issues on anchors in details

### DIFF
--- a/src/css/colors.scss
+++ b/src/css/colors.scss
@@ -85,6 +85,7 @@
   --click-color-background-muted: var(--palette_slate_50);
   --click-color-text: var(--palette_slate_900);
   --click-color-text-muted: var(--palette_slate_600);
+  --click-color-text-inverse: var(--palette_neutral_0);
   --click-color-stroke: var(--palette_slate_100);
   --click-color-link: var(--palette_info_400);
   --click-color-accent: var(--palette_warning_400);

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -852,7 +852,7 @@ hr {
     font-weight: 600;
   }
 
-  details h3 {
+  details h1, h2, h3 {
     color: var(--click-color-text-inverse);
   }
   

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -851,6 +851,11 @@ hr {
     line-height: 24px;
     font-weight: 600;
   }
+
+  details h3 {
+    color: var(--click-color-text-inverse);
+  }
+  
 }
 
 .main-content-wrapper {

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -31,7 +31,7 @@
   --ifm-color-primary-light: #385e96;
   --ifm-color-primary-lighter: #3b629c;
   --ifm-color-primary-lightest: #f1f6f9;;
-  --ifm-code-font-size: 14px;
+  --ifm-code-font-size: 13px;
   --ifm-link-color: var(--click-color-link);
   --ifm-color-secondary: var(--click-color-text-muted);
 


### PR DESCRIPTION
### Summary

Closes: https://github.com/ClickHouse/design/issues/56. Details areas have dark background in light mode, so the default text colour for light mode was not showing up correctly. This PR checks to see if a h1-h3 header is in a details area, and if so, makes it light in colour. If it, the header remains dark. 

#### Before
![image](https://user-images.githubusercontent.com/305167/230665885-174b4bef-0442-461b-b550-a84635a82f5c.png)

#### After
<img width="677" alt="CleanShot 2023-04-07 at 15 21 13@2x" src="https://user-images.githubusercontent.com/305167/230665850-2a5cc21c-98cc-40b2-801f-d2bb3b41cb2b.png">
