### PR TITLE
Add a note about python drivers

### DIFF
--- a/docs/en/integrations/language-clients/python/index.md
+++ b/docs/en/integrations/language-clients/python/index.md
@@ -27,6 +27,13 @@ The three primary components are:
 
 This documentation is current as of the beta release 0.5.17.
 
+:::note
+The official ClickHouse Connect Python driver uses HTTP protocol for communication with the ClickHouse server.
+It has some advantages (like better flexibility, HTTP-balancers support, better compatibility with JDBC-based tools, etc)
+and disadvantages (like slightly lower compression and performance, and a lack of support for some complex features of the native TCP-based protocol).
+For some use cases, you may consider using one of the [Community Python drivers](/docs/en/interfaces/third-party/client-libraries.md) that uses native TCP-based protocol.
+:::
+
 ### Requirements and Compatibility
 
 | Python    | | Platform¹   | | ClickHouse | | SQLAlchemy² | | Apache Superset | |


### PR DESCRIPTION
See the discussion in https://github.com/ClickHouse/clickhouse-connect/issues/91

Today I tried to find the community driver in our documentation and failed to find anything but https://clickhouse.com/docs/en/integrations/python and related pages. So let's mention it on that page. 