### PR TITLE
rename and move APIs

### DIFF
--- a/docs/en/cloud/manage/openapi.md
+++ b/docs/en/cloud/manage/openapi.md
@@ -1,19 +1,19 @@
 ---
-sidebar_label: Control Plane Open API
+sidebar_label: ClickHouse Cloud API
 slug: /en/cloud/manage/openapi
-title: Control Plane Open API
+title: ClickHouse Cloud API
 ---
 
 ClickHouse Cloud provides an API utilizing OpenAPI that allows you to programmatically manage your account and aspects of your services.
 
 :::important
-This feature is currently experimental and only available by request. Please reach out to [support](https://clickhouse.cloud/support) to enable the `FT_USER_OPENAPI_KEYS` feature.  You will not see the **API Keys** menu entry in the ClickHouse Cloud console until support enables the feature for you.
+This feature is currently experimental and only available by request. Please reach out to [support](https://clickhouse.cloud/support) to enable access to the Clickhouse Cloud API.  You will not see the **API Keys** menu entry in the ClickHouse Cloud console until support enables the feature for you.
 :::
 
 # Managing API Keys
 
 :::note
-This document covers the Control Plane API. For database API endpoints, please see [Cloud Endpoints API](/docs/en/cloud/security/cloud-endpoints-api.md)
+This document covers the ClickHouse Cloud API. For database API endpoints, please see [Cloud Endpoints API](/docs/en/cloud/security/cloud-endpoints-api.md)
 :::
 
 1. You can use the **API Keys** tab on the left menu to create and manage your API keys.
@@ -39,7 +39,6 @@ Deleting an API key is a permanent action. Any services using the key will immed
 :::
 
   ![API Key Management](@site/docs/en/_snippets/images/openapi5.png)
-
 
 # Endpoints
 

--- a/docs/en/cloud/manage/openapi.md
+++ b/docs/en/cloud/manage/openapi.md
@@ -7,7 +7,7 @@ title: ClickHouse Cloud API
 ClickHouse Cloud provides an API utilizing OpenAPI that allows you to programmatically manage your account and aspects of your services.
 
 :::important
-This feature is currently experimental and only available by request. Please reach out to [support](https://clickhouse.cloud/support) to enable access to the Clickhouse Cloud API.  You will not see the **API Keys** menu entry in the ClickHouse Cloud console until support enables the feature for you.
+This feature is currently experimental and only available by request. Please reach out to [support](https://clickhouse.cloud/support) to enable access to the ClickHouse Cloud API.  You will not see the **API Keys** menu entry in the ClickHouse Cloud console until support enables the feature for you.
 :::
 
 # Managing API Keys

--- a/docs/en/cloud/manage/postman.md
+++ b/docs/en/cloud/manage/postman.md
@@ -4,7 +4,7 @@ sidebar_label: Programmatic API access with Postman
 title: Programmatic API access with Postman
 ---
 
-This guide will help you test the ClickHouse Programmatic API using [Postman](https://www.postman.com/product/what-is-postman/). 
+This guide will help you test the ClickHouse Cloud API using [Postman](https://www.postman.com/product/what-is-postman/). 
 The Postman Application is available for use within a web browser or can be downloaded to a desktop.
 
 ### Create an account
@@ -28,11 +28,11 @@ The Postman Application is available for use within a web browser or can be down
 * Select “Postman Collection” by clicking on the “Import” button:
 ![Collection > Import](@site/docs/en/cloud/manage/images/postman/postman6.png)
 
-### Interface with the ClickHouse Cloud OpenAPI spec
-* The “OpenAPI spec for ClickHouse Cloud” will now appear within “Collections” (Left Navigation).
+### Interface with the ClickHouse Cloud API spec
+* The “API spec for ClickHouse Cloud” will now appear within “Collections” (Left Navigation).
 ![Import your API](@site/docs/en/cloud/manage/images/postman/postman7.png)
 
-* Click on “OpenAPI spec for ClickHouse Cloud.” From the middle pain select the ‘Authorization’ tab:
+* Click on “API spec for ClickHouse Cloud.” From the middle pain select the ‘Authorization’ tab:
 ![Import complete](@site/docs/en/cloud/manage/images/postman/postman8.png)
 
 ### Set Authorization

--- a/sidebars.js
+++ b/sidebars.js
@@ -425,7 +425,17 @@ const sidebars = {
         'en/cloud/manage/service-uptime',
         'en/cloud/manage/upgrades',
         'en/cloud/manage/account-close',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'API',
+      collapsed: false,
+      collapsible: false,
+      className: 'top-nav-item',
+      items: [
         'en/cloud/manage/openapi',
+        'en/cloud/security/cloud-endpoints-api',
         'en/cloud/manage/postman',
       ]
     },
@@ -467,7 +477,6 @@ const sidebars = {
         'en/cloud/manage/users-and-roles',
         'en/cloud/security/security-companion-guide',
         'en/cloud/security/ip-access-list',
-        'en/cloud/security/cloud-endpoints-api',
         'en/cloud/security/aws-privatelink',
         'en/cloud/security/activity-log',
       ]


### PR DESCRIPTION
- puts API content together:
  - ClickHouse Cloud API
  - Endpoints API      <------------------------ @GMartinez-Sisti this is your doc; please sync with @krithika-ch 
  - Postman use w/ ClickHouse Cloud
 - Renames OpenAPI for ClickHouse to ClickHouse Cloud API
 
Note: If you want a change to the title of the swagger docs, that is done by editing the `title` in control plane repo `{ "openapi": "3.0.1", "info": { "title": "OpenAPI spec for ClickHouse Cloud", "version": "1.0" }, `

New nav:

![image](https://user-images.githubusercontent.com/25182304/233787100-8a8a3a06-3536-4b2a-9ce3-b48a9b78c2ab.png)
