### PR TITLE
Update cloud-compatibility.md

### DIFF
--- a/docs/en/cloud/reference/cloud-compatibility.md
+++ b/docs/en/cloud/reference/cloud-compatibility.md
@@ -49,6 +49,7 @@ ClickHouse Cloud provides a highly-available, replicated service by default. As 
   - GenerateRandom
   - Null
   - Buffer
+  - Memory
 
 ### Interfaces
 ClickHouse Cloud supports HTTPS and Native interfaces. Support for more interfaces such as MySQL and Postgres is coming soon.


### PR DESCRIPTION
Add Memory table engine as it is supported in Cloud

```
clickhouse-cloud :) create table t (a UInt32) engine=Memory

CREATE TABLE t
(
    `a` UInt32
)
ENGINE = Memory

Query id: e658feea-7a3c-48d0-8d68-4b7d6e92130c

Ok.

0 rows in set. Elapsed: 0.094 sec.
```