### PR TITLE
Improve cascading materialized views formatting

### DIFF
--- a/docs/en/guides/developer/cascading-materialized-views.md
+++ b/docs/en/guides/developer/cascading-materialized-views.md
@@ -20,9 +20,9 @@ Our Goal
 2. We also need the data aggregated by year for each domain name.
 
 You could choose one of these options:
-write queries that will read and aggregate the data during the SELECT request
-prepare the data at the ingest time to a new format
-Prepare the data at the time of ingest to a specific aggregation.
+- Write queries that will read and aggregate the data during the SELECT request
+- Prepare the data at the ingest time to a new format
+- Prepare the data at the time of ingest to a specific aggregation.
 
 Preparing the data using Materialized views will allow you to limit the amount of data and calculation ClickHouse needs to do, making your SELECT requests faster.
 


### PR DESCRIPTION
The current formatting of the list does not result in one item per line, but rather all the lines being concatenated after one another:

```
You could choose one of these options: write queries that will read and aggregate the data during the SELECT request prepare the data at the ingest time to a new format Prepare the data at the time of ingest to a specific aggregation.
```

The desired outcome was likely

```
You could choose one of these options:
write queries that will read and aggregate the data during the SELECT request 
prepare the data at the ingest time to a new format 
Prepare the data at the time of ingest to a specific aggregation.
```

The minor difference in this PR is that the list will be formatted.

```
You could choose one of these options:
- Write queries that will read and aggregate the data during the SELECT request 
- Prepare the data at the ingest time to a new format 
- Prepare the data at the time of ingest to a specific aggregation.
```
