### PR TITLE
Fix broken Cloud link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,6 +262,10 @@ const config = {
 			{
 				redirects: [
 					{
+						from: '/category/cloud-reference',
+						to: '/en/cloud/overview',
+					},
+					{
 						from: '/en/about-us/performance',
 						to: '/en/concepts/why-clickhouse-is-so-fast',
 					},


### PR DESCRIPTION
This page (https://clickhouse.com/docs/category/cloud-reference) must have existed at some point because it shows up in Google searches, but it no longer exists, so redirecting.