### PR TITLE
Strongly recommend dedicated keepers in production

### DIFF
--- a/docs/en/deployment-guides/horizontal-scaling.md
+++ b/docs/en/deployment-guides/horizontal-scaling.md
@@ -19,11 +19,11 @@ This example architecture is designed to provide scalability.  It includes three
 ### Architecture Diagram
 ![Architecture diagram for 2 shards and 1 replica](@site/docs/en/deployment-guides/images/scaling-out-1.png)
 
-| Node    | Description                       |
-| ------- | --------------------------------- |
-| chnode1 | Data + ClickHouse Keeper          |
-| chnode2 | Data + ClickHouse Keeper          |
-| chnode3 | Used for ClickHouse Keeper quorum |
+|Node|Description|
+|----|-----------|
+|chnode1|Data + ClickHouse Keeper|
+|chnode2|Data + ClickHouse Keeper|
+|chnode3|Used for ClickHouse Keeper quorum|
 
 :::note
 In production environments we strongly recommend that ClickHouse Keeper runs on dedicated hosts.  This basic configuration runs the Keeper functionality within the ClickHouse Server process. The instructions for deploying ClickHouse Keeper standalone are available in the [installation documentation](/docs/en/getting-started/install.md/#install-standalone-clickhouse-keeper).

--- a/docs/en/deployment-guides/horizontal-scaling.md
+++ b/docs/en/deployment-guides/horizontal-scaling.md
@@ -19,14 +19,14 @@ This example architecture is designed to provide scalability.  It includes three
 ### Architecture Diagram
 ![Architecture diagram for 2 shards and 1 replica](@site/docs/en/deployment-guides/images/scaling-out-1.png)
 
-|Node|Description|
-|----|-----------|
-|chnode1|Data + ClickHouse Keeper|
-|chnode2|Data + ClickHouse Keeper|
-|chnode3|Used for ClickHouse Keeper quorum|
+| Node    | Description                       |
+| ------- | --------------------------------- |
+| chnode1 | Data + ClickHouse Keeper          |
+| chnode2 | Data + ClickHouse Keeper          |
+| chnode3 | Used for ClickHouse Keeper quorum |
 
 :::note
-In more advanced configurations, ClickHouse Keeper will be running on separate servers.  This basic configuration runs the Keeper functionality within the ClickHouse Server process.  As you scale out, you may decide to separate the ClickHouse Servers from the Keeper servers.  The instructions for deploying ClickHouse Keeper standalone are available in the [installation documentation](/docs/en/getting-started/install.md/#install-standalone-clickhouse-keeper).
+In production environments we strongly recommend that ClickHouse Keeper runs on dedicated hosts.  This basic configuration runs the Keeper functionality within the ClickHouse Server process. The instructions for deploying ClickHouse Keeper standalone are available in the [installation documentation](/docs/en/getting-started/install.md/#install-standalone-clickhouse-keeper).
 :::
 
 ## Install

--- a/docs/en/deployment-guides/replicated.md
+++ b/docs/en/deployment-guides/replicated.md
@@ -29,7 +29,7 @@ In this architecture, there are five servers configured. Two are used to host co
 |clickhouse-keeper-03|Distributed coordination|
 
 :::note
-It is possible to run ClickHouse Server and Keeper combined on the same server.  The other basic example, [Scaling out](/docs/en/deployment-guides/horizontal-scaling.md), uses this method.  In this example we present the recommended method of separating Keeper from ClickHouse Server.  The Keeper servers can be smaller, 4GB RAM is generally enough for each Keeper server until your ClickHouse Servers grow very large.
+In production environments, we strongly recommend using *dedicated* hosts for ClickHouse keeper. In test environment it is acceptable to run ClickHouse Server and ClickHouse Keeper combined on the same server.  The other basic example, [Scaling out](/docs/en/deployment-guides/horizontal-scaling.md), uses this method.  In this example we present the recommended method of separating Keeper from ClickHouse Server.  The Keeper servers can be smaller, 4GB RAM is generally enough for each Keeper server until your ClickHouse Servers grow very large.
 :::
 
 ## Install


### PR DESCRIPTION
This PR rewords our statement for running keeper nodes in production to strongly recommended on dedicated hosts

depends on https://github.com/ClickHouse/ClickHouse/pull/49841
