### PR TITLE
Disable compression to query Live Views using `clickhouse-js` adapter

### DIFF
--- a/docs/en/integrations/language-clients/nodejs.md
+++ b/docs/en/integrations/language-clients/nodejs.md
@@ -734,7 +734,7 @@ TLS in the repository.
 - There are some [Decimal* and Date\* / DateTime\* data types caveats](#date--datetime-types-caveats).
 - [Nested](/docs/en/sql-reference/data-types/nested-data-structures/index.md) data type is currently not officially
   supported.
-- [Response compression](#compression) must be [disabled](https://github.com/ClickHouse/clickhouse-js/issues/157#issuecomment-1546005694) when using [Live Views](/docs/en/sql-reference/statements/create/view#live-view-experimental)
+- [Response compression](#compression) must be [disabled](https://github.com/ClickHouse/clickhouse-js/issues/157#issuecomment-1546005694) when using [Live Views](/docs/en/sql-reference/statements/create/view.md/#live-view-experimental)
 
 ## Tips for performance optimizations
 

--- a/docs/en/integrations/language-clients/nodejs.md
+++ b/docs/en/integrations/language-clients/nodejs.md
@@ -734,6 +734,7 @@ TLS in the repository.
 - There are some [Decimal* and Date\* / DateTime\* data types caveats](#date--datetime-types-caveats).
 - [Nested](/docs/en/sql-reference/data-types/nested-data-structures/index.md) data type is currently not officially
   supported.
+- [Response compression](#compression) must be [disabled](https://github.com/ClickHouse/clickhouse-js/issues/157#issuecomment-1546005694) when using [Live Views](/docs/en/sql-reference/statements/create/view#live-view-experimental)
 
 ## Tips for performance optimizations
 


### PR DESCRIPTION
As a follow-up from [#157](https://github.com/ClickHouse/clickhouse-js/issues/157), a found issue should be noted in the docs.