### PR TITLE
Update contrib-writing-guide.md to encourage to use yarn v1

### DIFF
--- a/contrib-writing-guide.md
+++ b/contrib-writing-guide.md
@@ -32,6 +32,7 @@ The documentation is built with Docusaurus, which requires Node.js. We recommend
 
 ```bash
 brew install npm
+# note: we use [yarn classic](https://classic.yarnpkg.com/lang/en/) to build the ClickHouse docs.
 brew install yarn # make sure yarn v1.x is installed
 git clone https://github.com/ClickHouse/clickhouse-docs.git
 cd clickhouse-docs # local docs repo

--- a/contrib-writing-guide.md
+++ b/contrib-writing-guide.md
@@ -32,7 +32,7 @@ The documentation is built with Docusaurus, which requires Node.js. We recommend
 
 ```bash
 brew install npm
-brew install yarn
+brew install yarn # make sure yarn v1.x is installed
 git clone https://github.com/ClickHouse/clickhouse-docs.git
 cd clickhouse-docs # local docs repo
 


### PR DESCRIPTION
This commit updates `contrib-writing-guide.md` to have developers make sure that they install yarn v1. This information is helpful because the latest version of yarn doesn't work well.