### PR TITLE
Add scrollbar to left-hand nav

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -60,8 +60,8 @@ body {
   width: 100%;
 }
 /* Rich's attempt to add scrollbar to nav */
-.sidebar_src-theme-DocSidebar-Desktop-styles-module {
-  position: fixed;
+.sidebar_mhZE {
+  position: fixed !important;
 }
 /* Make the navbar move with the page */
 /* .sidebarViewport_node_modules-\@docusaurus-theme-classic-lib-theme-DocPage-Layout-Sidebar-styles-module {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -59,7 +59,10 @@ body {
   position: fixed;
   width: 100%;
 }
-
+/* Rich's attempt to add scrollbar to nav */
+.sidebar_src-theme-DocSidebar-Desktop-styles-module {
+  position: fixed;
+}
 /* Make the navbar move with the page */
 /* .sidebarViewport_node_modules-\@docusaurus-theme-classic-lib-theme-DocPage-Layout-Sidebar-styles-module {
   max-height: unset !important;


### PR DESCRIPTION
Let's see if it works...this should keep the left-hand nav in place as a user scrolls down a long docs page