### PR TITLE
only grab master, 1/12th of the size

### DIFF
--- a/copyClickhouseRepoDocs.sh
+++ b/copyClickhouseRepoDocs.sh
@@ -1,6 +1,6 @@
 #! ./bin/bash
 echo "Start Cloning"
-git clone https://github.com/ClickHouse/ClickHouse.git
+git clone --depth 1 https://github.com/ClickHouse/ClickHouse.git
 echo "Cloning completed"
 echo "Start Copying"
 cp -r ClickHouse/docs/en/development     docs/en/


### PR DESCRIPTION
Hi Vineeth, I think that you wrote the script to support Vercel build.  We only need the master branch of ClickHouse/ClickHouse.  This saves 88% of the clone.