### PR TITLE
[kb-article] Update python example to close connection

### DIFF
--- a/knowledgebase/python-clickhouse-connect-example.md
+++ b/knowledgebase/python-clickhouse-connect-example.md
@@ -68,6 +68,8 @@ result = client.query(QUERY)
 
 sys.stdout.write("query: ["+QUERY + "] returns:\n\n")
 print(result.result_rows)
+
+client.close()
 ```
 
 5. Create the virtual environment:


### PR DESCRIPTION
This PR updates this [KB](https://clickhouse.com/docs/knowledgebase/python-clickhouse-connect-example) article to close the connection `client.close()`