### PR TITLE
[Cloud][PSC] Add disclaimer PSC only on Prod

### DIFF
--- a/docs/en/cloud/security/gcp-private-service-connect.md
+++ b/docs/en/cloud/security/gcp-private-service-connect.md
@@ -26,6 +26,10 @@ allow list on an instance level by creating a Support request.
 The support request will be covered later in this document.
 :::
 
+:::note
+GCP Private Service Connect can be enabled only on ClickHouse Cloud Production services
+:::
+
 
 ## Supported regions
 


### PR DESCRIPTION
this PR adds the important disclaimer, that enabling PSC in GCP service is reserved only for Production tiers.