### PR TITLE
Update index.md

### DIFF
--- a/docs/en/integrations/data-ingestion/etl-tools/dbt/index.md
+++ b/docs/en/integrations/data-ingestion/etl-tools/dbt/index.md
@@ -105,10 +105,10 @@ CREATE TABLE imdb.movies
 
 CREATE TABLE imdb.roles
 (
-    created_at DateTime DEFAULT now(),
     actor_id   UInt32,
     movie_id   UInt32,
-    role       String
+    role       String,
+    created_at DateTime DEFAULT now()
 ) ENGINE = MergeTree ORDER BY (actor_id, movie_id);
 ```
 


### PR DESCRIPTION
updated schema for imdb.role as the created_at on top was causing the insert script to fail 
```
Received exception from server (version 23.7.1):
Code: 27. DB::Exception: Received from localhost:9000. DB::ParsingException. DB::ParsingException: Cannot parse input: expected '\n' before: 'Stevie\n2\t396232\tVarious/lyricist\n3\t376687\tGitano 1\n4\t336265\tEl Cigala\n5\t135644\tHimself\n6\t12083\t""\n7\t252053\t""\n7\t402635\t""\n7\t409592\tStaff Humorist (1996)\n8\t10186': 
Row 1:
Column 0,   name: actor_id, type: DateTime, parsed text: "2"
Column 1,   name: movie_id, type: UInt32,   parsed text: "280088"
Column 2,   name: role,     type: UInt32,   ERROR: text "Stevie<LINE FEED>2<TAB>3" is not like UInt32

: While executing TabSeparatedRowInputFormat: While executing S3: (at row 1)
. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)

```