### PR TITLE
make Parameter Binding appear on sidebar

### DIFF
--- a/docs/en/integrations/language-clients/go/index.md
+++ b/docs/en/integrations/language-clients/go/index.md
@@ -1598,7 +1598,7 @@ if err := batch.Send(); err != nil {
 
 Additional compression techniques are available if using the standard interface over HTTP. See [database/sql API - Compression](#compression) for further details.
 
-#### Parameter Binding
+### Parameter Binding
 
 The client supports parameter binding for the Exec, Query, and QueryRow methods. As shown in the example below, this is supported using named, numbered, and positional parameters. We provide examples of these below.
 


### PR DESCRIPTION
In Go client docs Parameter Binding section is included in sidebar for `database/sql` api, but not for client-specific.