### PR TITLE
More details on insert_deduplication_token

### DIFF
--- a/docs/en/guides/developer/deduplication.md
+++ b/docs/en/guides/developer/deduplication.md
@@ -332,3 +332,10 @@ FROM hackernews_views_vcmt
 ```
 
 A `VersionedCollapsingMergeTree` table is quite handy when you want to implement deduplication while inserting rows from multiple clients and/or threads.
+
+## Why aren’t my rows being deduplicated?
+
+One reason inserted rows may not be deduplicated is if you are using a non-idempotent function or expression in your `INSERT` statement. For example, if you are inserting rows with the column `createdAt DateTime64(3) DEFAULT now()`, your rows are guaranteed to be unique because each row will have a unique default value for the `createdAt` column. The MergeTree / ReplicatedMergeTree table engine will not know to deduplicate the rows as each inserted row will generate a unique checksum.
+
+In this case, you can specify your own `insert_deduplication_token` for each batch of rows to ensure that multiple inserts of the same batch will not result in the same rows being re-inserted. Please see the [documentation on `insert_deduplication_token`](/docs/en/operations/settings/settings#insert_deduplication_token) for more details about how to use this setting.
+


### PR DESCRIPTION
Suggest using `insert_deduplication_token` in Deduplication Strategies guide if deduplication fails

Context: https://clickhouse-inc.slack.com/archives/C02F2LML5UG/p1689611489370029