### PR TITLE
Privatelink doc updates for cells

### DIFF
--- a/docs/en/_snippets/_aws_regions.md
+++ b/docs/en/_snippets/_aws_regions.md
@@ -6,6 +6,7 @@
 |eu-central-1  | com.amazonaws.vpce.eu-central-1.vpce-svc-0536fc4b80a82b8ed  | euc1-az2 euc1-az3 euc1-az1   |
 |eu-west-1     | com.amazonaws.vpce.eu-west-1.vpce-svc-066b03c9b5f61c6fc     | euw1-az2 euw1-az3 euw1-az1   |
 |us-east-1     | com.amazonaws.vpce.us-east-1.vpce-svc-0a0218fa75c646d81     | use1-az6 use1-az1 use1-az2   |
+|us-east-1 c1  | com.amazonaws.vpce.us-east-1.vpce-svc-096c118db1ff20ea4     | use1-az6 use1-az4 use1-az2   |
 |us-east-2     | com.amazonaws.vpce.us-east-2.vpce-svc-0b99748bf269a86b4     | use2-az1 use2-az2 use2-az3   |
 |us-west-2     | com.amazonaws.vpce.us-west-2.vpce-svc-049bbd33f61271781     | usw2-az2 usw2-az1 usw2-az3   |
 

--- a/docs/en/_snippets/_aws_regions.md
+++ b/docs/en/_snippets/_aws_regions.md
@@ -5,7 +5,7 @@
 |ap-southeast-2| com.amazonaws.vpce.ap-southeast-2.vpce-svc-0ca446409b23f0c01| apse2-az1 apse2-az2 apse2-az3|
 |eu-central-1  | com.amazonaws.vpce.eu-central-1.vpce-svc-0536fc4b80a82b8ed  | euc1-az2 euc1-az3 euc1-az1   |
 |eu-west-1     | com.amazonaws.vpce.eu-west-1.vpce-svc-066b03c9b5f61c6fc     | euw1-az2 euw1-az3 euw1-az1   |
-|us-east-1     | com.amazonaws.vpce.us-east-1.vpce-svc-0a0218fa75c646d81     | use1-az6 use1-az1 use1-az2   |
+|us-east-1 c0  | com.amazonaws.vpce.us-east-1.vpce-svc-0a0218fa75c646d81     | use1-az6 use1-az1 use1-az2   |
 |us-east-1 c1  | com.amazonaws.vpce.us-east-1.vpce-svc-096c118db1ff20ea4     | use1-az6 use1-az4 use1-az2   |
 |us-east-2     | com.amazonaws.vpce.us-east-2.vpce-svc-0b99748bf269a86b4     | use2-az1 use2-az2 use2-az3   |
 |us-west-2     | com.amazonaws.vpce.us-west-2.vpce-svc-049bbd33f61271781     | usw2-az2 usw2-az1 usw2-az3   |

--- a/docs/en/cloud/security/aws-privatelink.md
+++ b/docs/en/cloud/security/aws-privatelink.md
@@ -16,7 +16,7 @@ This table lists the AWS Regions where ClickHouse Cloud services can be deployed
 
 If you require two or more AWS Private Links within the same AWS region, then please note: In ClickHouse, we have a VPC Endpoint service at a regional level. When you setup two or more VPC Endpoints in the same VPC - from the AWS VPC perspective - you are utilizing just a single AWS Private Link. In such a situation where you need two or more AWS Private Links configured within the same region, please just create just one VPC Endpoint in your VPC, and request that ClickHouse configure the same VPC Endpoint ID for all of your ClickHouse services in the same AWS region.
 
-For us-east-1 region, you could ask ClickHouse support team to determine which VPC endpoint service you should use. Please provide ClickHouse service hostname to ClickHouse support, and we will provide VPC Service Name back to you. (Click on **Help** in the ClickHouse Cloud console and choose Support to open a case.)
+For the `us-east-1` region, you can ask the ClickHouse support team to determine which VPC endpoint service you should use. Please provide your ClickHouse service hostname to ClickHouse support, and we will return the VPC Service Name. (Click on **Help** in the ClickHouse Cloud console and choose **Support** to open a case.)
 
 :::note
 AWS PrivateLink can be enabled only on ClickHouse Cloud Production services
@@ -155,7 +155,7 @@ telnet: connect to address 172.31.25.195: No route to host
 Trying 172.31.3.200...
 ```
 
-The error below is likely caused by missing security group attached to VPC endpoint to allow ClickHouse ports:
+The error below is likely caused by a missing attached security group for the VPC endpoint that allows ClickHouse ports:
 ```response
 telnet iyc9vhhplz.us-east-1.aws.clickhouse.cloud 9440
 Trying 172.31.30.46...

--- a/docs/en/cloud/security/aws-privatelink.md
+++ b/docs/en/cloud/security/aws-privatelink.md
@@ -16,6 +16,8 @@ This table lists the AWS Regions where ClickHouse Cloud services can be deployed
 
 If you require two or more AWS Private Links within the same AWS region, then please note: In ClickHouse, we have a VPC Endpoint service at a regional level. When you setup two or more VPC Endpoints in the same VPC - from the AWS VPC perspective - you are utilizing just a single AWS Private Link. In such a situation where you need two or more AWS Private Links configured within the same region, please just create just one VPC Endpoint in your VPC, and request that ClickHouse configure the same VPC Endpoint ID for all of your ClickHouse services in the same AWS region.
 
+For us-east-1 region, you could ask ClickHouse support team to determine which VPC endpoint service you should use. Please provide ClickHouse service hostname to ClickHouse support, and we will provide VPC Service Name back to you. (Click on **Help** in the ClickHouse Cloud console and choose Support to open a case.)
+
 :::note
 AWS PrivateLink can be enabled only on ClickHouse Cloud Production services
 :::
@@ -151,6 +153,16 @@ Trying 172.31.25.195...
 # highlight-next-line
 telnet: connect to address 172.31.25.195: No route to host
 Trying 172.31.3.200...
+```
+
+The error below is likely caused by missing security group attached to VPC endpoint to allow ClickHouse ports:
+```response
+telnet iyc9vhhplz.us-east-1.aws.clickhouse.cloud 9440
+Trying 172.31.30.46...
+
+
+
+telnet: connect to address 172.31.30.46: Connection timed out
 ```
 
 ## Shift network traffic to VPC Endpoint


### PR DESCRIPTION
Privatelink doc updates for new cell in us-east-1

Corresponding support knowledge base updated here: https://github.com/ClickHouse/internal-knowledge-base/issues/24

Description: we are introducing a new cell in us-east-1 production in aws. Customer before creating a private link VPC endpoint needs to know which cell their instance is in, so that they know which VPC endpoint service their privatelink needs to connect against.

As a result, we provide c0 and c1 two service DNS endpoints for customer, and ask customer to create support case to ask about cell before set up private link endpoint on their end.

This is just a temporary measure for a few weeks, before we have automated privatelink set up for customers.