### PR TITLE
fix: Resolve underscores causing italics

### DIFF
--- a/docs/en/guides/best-practices/skipping-indexes.md
+++ b/docs/en/guides/best-practices/skipping-indexes.md
@@ -28,8 +28,8 @@ Users can only employ Data Skipping Indexes on the MergeTree family of tables. E
 
 When a user creates a data skipping index, there will be two additional files in each data part directory for the table.
 
-- skp_idx_{index_name}.idx, which contains the ordered expression values
-- skp_idx_{index_name}.mrk2, which contains the corresponding offsets into the associated data column files.
+- `skp_idx_{index_name}.idx`, which contains the ordered expression values
+- `skp_idx_{index_name}.mrk2`, which contains the corresponding offsets into the associated data column files.
 
 If some portion of the WHERE clause filtering condition matches the skip index expression when executing a query and reading the relevant column files, ClickHouse will use the index file data to determine whether each relevant block of data must be processed or can be bypassed (assuming that the block has not already been excluded by applying the primary key). To use a very simplified example, consider the following table loaded with predictable data.
 
@@ -97,7 +97,7 @@ were skipped without reading from disk:
 ![Simple Skip](images/simple_skip.svg)
 
 Users can access detailed information about skip index usage by enabling the trace when executing queries.  From
-clickhouse-client, set the send_logs_level:
+clickhouse-client, set the `send_logs_level`:
 
 ```
 SET send_logs_level='trace';


### PR DESCRIPTION
On https://clickhouse.com/docs/en/optimize/skipping-indexes there's a section where the double underscores cause Markdown to incorrectly render italics.

![image](https://github.com/ClickHouse/clickhouse-docs/assets/206988/e20738ab-217c-4c2e-b6da-c7aaea2030fa)

Wrapping these texts in `code blocks` will resolve the issue.