### PR TITLE
fix: Replace some it's with its

### DIFF
--- a/docs/en/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/en/guides/best-practices/sparse-primary-indexes.md
@@ -766,7 +766,7 @@ However, [as we will see later](#query-on-url-fast) only 39 granules out of that
 
 Whilst the primary index based on the compound primary key (UserID, URL) was very useful for speeding up queries filtering for rows with a specific UserID value, the index is not providing significant help with speeding up the query that filters for rows with a specific URL value.
 
-The reason for this is that the URL column is not the first key column and therefore ClickHouse is using a generic exclusion search algorithm (instead of binary search) over the URL column's index marks, and **the effectiveness of that algorithm is dependant on the cardinality difference** between the URL column and it's predecessor key column UserID.
+The reason for this is that the URL column is not the first key column and therefore ClickHouse is using a generic exclusion search algorithm (instead of binary search) over the URL column's index marks, and **the effectiveness of that algorithm is dependant on the cardinality difference** between the URL column and its predecessor key column UserID.
 
 In order to illustrate that, we give some details about how the generic exclusion search works.
 
@@ -1115,7 +1115,7 @@ ClickHouse is storing the [column data files](#data-is-stored-on-disk-ordered-by
 :::
 
 
-The implicitly created table (and it's primary index) backing the materialized view can now be used to significantly speed up the execution of our example query filtering on the URL column:
+The implicitly created table (and its primary index) backing the materialized view can now be used to significantly speed up the execution of our example query filtering on the URL column:
 ```sql
 SELECT UserID, count(UserID) AS Count
 // highlight-next-line
@@ -1148,7 +1148,7 @@ Processed 335.87 thousand rows,
 13.54 MB (12.91 million rows/s., 520.38 MB/s.)
 ```
 
-Because effectively the implicitly created table (and it's primary index) backing the materialized view is identical to the [secondary table that we created explicitly](#multiple-primary-indexes-via-secondary-tables), the query is executed in the same effective way as with the explicitly created table.
+Because effectively the implicitly created table (and its primary index) backing the materialized view is identical to the [secondary table that we created explicitly](#multiple-primary-indexes-via-secondary-tables), the query is executed in the same effective way as with the explicitly created table.
 
 The corresponding trace log in the ClickHouse server log file confirms that ClickHouse is running binary search over the index marks:
 
@@ -1201,7 +1201,7 @@ ClickHouse is storing the [column data files](#data-is-stored-on-disk-ordered-by
 :::
 
 
-The hidden table (and it's primary index) created by the projection can now be (implicitly) used to significantly speed up the execution of our example query filtering on the URL column. Note that the query is syntactically targeting the source table of the projection.
+The hidden table (and its primary index) created by the projection can now be (implicitly) used to significantly speed up the execution of our example query filtering on the URL column. Note that the query is syntactically targeting the source table of the projection.
 ```sql
 SELECT UserID, count(UserID) AS Count
 // highlight-next-line
@@ -1234,7 +1234,7 @@ Processed 319.49 thousand rows, 1
 1.38 MB (11.05 million rows/s., 393.58 MB/s.)
 ```
 
-Because effectively the hidden table (and it's primary index) created by the projection is identical to the [secondary table that we created explicitly](#multiple-primary-indexes-via-secondary-tables), the query is executed in the same effective way as with the explicitly created table.
+Because effectively the hidden table (and its primary index) created by the projection is identical to the [secondary table that we created explicitly](#multiple-primary-indexes-via-secondary-tables), the query is executed in the same effective way as with the explicitly created table.
 
 The corresponding trace log in the ClickHouse server log file confirms that ClickHouse is running binary search over the index marks:
 


### PR DESCRIPTION
Sometimes "it's" is correct english. To check a specific instance, replace "it's" with "it is". If the sentence still makes sense, "it's" is totally fine! If it doesn't, "it's" is incorrect and "its" is correct.

This PR replaces some incorrect "it's" with "its".

I noticed this while reading this specific docs page. I scanned the repo for all uses of "it's" expecting to find more errors, but these were the only ones I found!