### PR TITLE
Fix prep-from-master on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
     "prep-from-local": "bash -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);for folder in ${array_en[@]}; do cp -r $0/$folder docs/en;echo \"Copied $folder from [$0]\";done;for folder in ${array_root[@]}; do cp -r $0/$folder docs/;echo \"Copied $folder from [$0]\";done;echo \"Prep completed\";'",
-    "prep-from-master": "array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo \"Copied $folder from ClickHouse master branch\";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo \"Copied $folder from ClickHouse master branch\";done;rm -rf $ch_temp && echo \"Prep completed\";",
+    "prep-from-master": "bash -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo \"Copied $folder from ClickHouse master branch\";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo \"Copied $folder from ClickHouse master branch\";done;rm -rf $ch_temp && echo \"Prep completed\";'",
     "serve": "docusaurus serve",
     "build-api-doc": "node clickhouseapi.js",
     "build-swagger": "npx @redocly/cli build-docs  https://api.clickhouse.cloud/v1 --output build/en/cloud/manage/api/swagger.html",


### PR DESCRIPTION
This PR fixes error when executing 

`yarn prep-from-master`

on linux

tested on linux mint/ubuntu

```
user@zeus:/opt/clickhouse-docs$ uname -a
Linux zeus 5.15.0-60-generic #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

nellicus@zeus:/opt$ git clone https://github.com/ClickHouse/clickhouse-docs
Cloning into 'clickhouse-docs'...
remote: Enumerating objects: 27725, done.
remote: Counting objects: 100% (2922/2922), done.
remote: Compressing objects: 100% (1832/1832), done.
remote: Total 27725 (delta 1145), reused 2773 (delta 1061), pack-reused 24803
Receiving objects: 100% (27725/27725), 262.58 MiB | 16.49 MiB/s, done.
Resolving deltas: 100% (15576/15576), done.
nellicus@zeus:/opt$ cd clickhouse-docs/
nellicus@zeus:/opt/clickhouse-docs$ git branch
* main
nellicus@zeus:/opt/clickhouse-docs$ git checkout fix_prep_master_linux
Branch 'fix_prep_master_linux' set up to track remote branch 'fix_prep_master_linux' from 'origin'.
Switched to a new branch 'fix_prep_master_linux'
nellicus@zeus:/opt/clickhouse-docs$ git branch
* fix_prep_master_linux
  main
nellicus@zeus:/opt/clickhouse-docs$ yarn prep-from-master
yarn run v1.22.19
$ bash -c 'array_root=($npm_package_config_prep_array_root);array_en=($npm_package_config_prep_array_en);ch_temp=/tmp/ch_temp_$RANDOM && mkdir -p $ch_temp && git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse $ch_temp; for folder in ${array_en[@]}; do cp -r $ch_temp/$folder docs/en;echo "Copied $folder from ClickHouse master branch";done;for folder in ${array_root[@]}; do cp -r $ch_temp/$folder docs/;echo "Copied $folder from ClickHouse master branch";done;rm -rf $ch_temp && echo "Prep completed";'
Cloning into '/tmp/ch_temp_12633'...
remote: Enumerating objects: 25005, done.
remote: Counting objects: 100% (25005/25005), done.
remote: Compressing objects: 100% (20631/20631), done.
remote: Total 25005 (delta 3258), reused 11650 (delta 2142), pack-reused 0
Receiving objects: 100% (25005/25005), 86.32 MiB | 20.74 MiB/s, done.
Resolving deltas: 100% (3258/3258), done.
Updating files: 100% (25673/25673), done.
Copied docs/en/development from ClickHouse master branch
Copied docs/en/engines from ClickHouse master branch
Copied docs/en/getting-started from ClickHouse master branch
Copied docs/en/interfaces from ClickHouse master branch
Copied docs/en/operations from ClickHouse master branch
Copied docs/en/sql-reference from ClickHouse master branch
Copied docs/ru from ClickHouse master branch
Copied docs/zh from ClickHouse master branch
Prep completed
Done in 11.11s.
```

closes https://github.com/ClickHouse/clickhouse-docs/issues/1588