### PR TITLE
Fix client ssl cert auth example config.

### DIFF
--- a/docs/en/guides/sre/user-management/ssl-user-auth.md
+++ b/docs/en/guides/sre/user-management/ssl-user-auth.md
@@ -93,9 +93,11 @@ For details on how to enable SQL users and set roles, refer to [Defining SQL Use
 
     ```xml
     <openSSL>
-        <certificateFile>my_cert_name.crt</certificateFile>
-        <privateKeyFile>my_cert_name.key</privateKeyFile>
-        <caConfig>my_ca_cert.crt</caConfig>
+        <client>
+            <certificateFile>my_cert_name.crt</certificateFile>
+            <privateKeyFile>my_cert_name.key</privateKeyFile>
+            <caConfig>my_ca_cert.crt</caConfig>
+        </client>
     </openSSL>
     ```
 


### PR DESCRIPTION
The given example does not work for me. There needs to be a `<client>` level in the middle between `<openSSL>` and cert files.