### PR TITLE
Moves kafka dropdown further down list.

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -91,6 +91,8 @@ const sidebars = {
       collapsed: false,
       collapsible: false,
       items: [
+        'en/integrations/data-ingestion/s3/index',
+        'en/integrations/data-ingestion/gcs/index',
         {
           type: 'category',
           label: 'Kafka',
@@ -101,9 +103,6 @@ const sidebars = {
             'en/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink',
           ],
         },
-        'en/integrations/data-ingestion/s3/index',
-        'en/integrations/data-ingestion/gcs/index',
-        'en/integrations/data-ingestion/kafka/index',
         'en/migrations/bigquery',
         'en/migrations/snowflake',
         'en/integrations/data-ingestion/clickpipes/index',


### PR DESCRIPTION
The [ClickHouse Kafka Connect Sink](https://clickhouse.com/docs/en/integrations/kafka/clickhouse-kafka-connect-sink) page wasn't in the sidebar nav. Commit f10b2b65b144c7cdcdbaf3700f7b311019437a1c added the item into the a dropdown under Kafka, but I forgot to remove the existing Kafka link. This PR removes that original link in favour of the dropdown version.