### PR TITLE
add more Kafka options to the sidebar

### DIFF
--- a/docs/en/integrations/data-ingestion/kafka/confluent/custom-connector.md
+++ b/docs/en/integrations/data-ingestion/kafka/confluent/custom-connector.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: ClickHouse Connector Sink on Confluent Platform
+sidebar_label: Kafka Connector Sink on Confluent Platform
 sidebar_position: 2
 slug: /en/integrations/kafka/cloud/confluent/custom-connector
 description: Using ClickHouse Connector Sink with Kafka Connect and ClickHouse

--- a/docs/en/integrations/data-ingestion/kafka/index.md
+++ b/docs/en/integrations/data-ingestion/kafka/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Kafka
+sidebar_label: Integrating Kafka with ClickHouse
 sidebar_position: 1
 slug: /en/integrations/kafka/
 description: Introduction to Kafka with ClickHouse

--- a/docs/en/integrations/data-ingestion/kafka/msk/index.md
+++ b/docs/en/integrations/data-ingestion/kafka/msk/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Amazon MSK with Kafka Connect Sink
+sidebar_label: Amazon MSK with Kafka Connector Sink
 sidebar_position: 1
 slug: /en/integrations/kafka/cloud/amazon-msk/
 description: The official Kafka connector from ClickHouse with Amazon MSK

--- a/sidebars.js
+++ b/sidebars.js
@@ -100,7 +100,12 @@ const sidebars = {
           collapsed: true,
           collapsible: true,
           items: [
+            'en/integrations/data-ingestion/kafka/index',
+            'en/integrations/data-ingestion/clickpipes/index',
             'en/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink',
+            'en/integrations/data-ingestion/kafka/confluent/custom-connector',
+            'en/integrations/data-ingestion/kafka/msk/index',
+            'en/integrations/data-ingestion/kafka/kafka-vector',
           ],
         },
         'en/migrations/bigquery',


### PR DESCRIPTION
The current sidebar creates the impression there is only 1 way to use Kafka with ClickHouse. I extended sidebar with a link to a cover page and a few recommended options:
- Clickpipes
- Kafka Connector Sink
- Kafka Connector Sink on Confluent
- Kafka Connector Sink on MSK
- Vector

![2023-11-16_12-01-39](https://github.com/ClickHouse/clickhouse-docs/assets/3198181/8da3bdc7-dc4b-4d4b-ab90-dd543c246697)
