### PR TITLE
Removes lingering reference to analytics.js.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,6 @@ const config = {
 		mermaid: true,
 	},
 	themes: ['@docusaurus/theme-mermaid'],
-	scripts: ['/docs/js/analytics.js'],
 	presets: [
 		[
 			'classic',


### PR DESCRIPTION
Gets rid of this error:

![Screenshot 2023-11-28 at 12 11 23 PM](https://github.com/ClickHouse/clickhouse-docs/assets/9611008/3339d4f8-7edb-4a9c-866e-5f86106fdc37)
