### PR TITLE
Clickhouse keeper: Add name of clickhouse-server/config.xml

### DIFF
--- a/docs/en/guides/sre/keeper/index.md
+++ b/docs/en/guides/sre/keeper/index.md
@@ -119,7 +119,7 @@ Examples of configuration for quorum with three nodes can be found in [integrati
 
 ### How to run {#how-to-run}
 
-ClickHouse Keeper is bundled into the ClickHouse server package, just add configuration of `<keeper_server>` and start ClickHouse server as always. If you want to run standalone ClickHouse Keeper you can start it in a similar way with:
+ClickHouse Keeper is bundled into the ClickHouse server package, just add configuration of `<keeper_server>` to your `/etc/your_path_to_config/clickhouse-server/config.xml` and start ClickHouse server as always. If you want to run standalone ClickHouse Keeper you can start it in a similar way with:
 
 ```bash
 clickhouse-keeper --config /etc/your_path_to_config/config.xml


### PR DESCRIPTION
I struggled with this a bit when starting ClickHouse as the documentation didn't specify where to add `<keeper_server>`. I added an explicit mention of the `clickhouse-server/config.xml` to help avoid people mistaking the `clickhouse-keeper/keeper_config.xml` (which also contains `<keeper_server>` definitions). 

I think this is a small change that will help newer users who may be unaware of the `clickhouse-server/config.xml` file.