### PR TITLE
revert PSC docs

### DIFF
--- a/docs/en/cloud/security/gcp-private-service-connect.md
+++ b/docs/en/cloud/security/gcp-private-service-connect.md
@@ -1,100 +1,63 @@
 ---
-sidebar_label: "GCP Private Service Connect"
 slug: /en/manage/security/gcp-private-service-connect
+sidebar_label: GCP Private Service Connect
+title: Setting up GCP Private Service Connect
 ---
+import GCPRegions from '@site/docs/en/_snippets/_gcp_regions.md';
 
 ## Private Service Connect
 
-Private Service Connect is a Google Cloud networking feature that allows consumers to access managed services privately inside their VPC network. Similarly, it allows managed service producers to host these services in their own separate VPC networks and offer a private connection to their consumers.
+Private Service Connect is a capability of Google Cloud networking that allows consumers
+to access managed services privately from inside their VPC network. Similarly, it allows
+managed service producers to host these services in their own separate VPC networks and
+offer a private connection to their consumers.
 
-Service producers publish their applications to consumers by creating Private Service Connect services. Service consumers access those Private Service Connect services directly through one of these Private Service Connect types.
+Service producers publish their applications to consumers by creating Private Service
+Connect services. Service consumers access those Private Service Connect services directly
+through one of these Private Service Connect types.
 
 ![Overview of PSC](@site/docs/en/cloud/security/images/gcp-psc-overview.png)
 
 :::important
-By default, a ClickHouse service is not available over a Private Service connection even if the PSC connection is approved and established; you need explicitly add the PSC ID to the allow list on an instance level by completing [step](#add-endpoint-id-to-services-allow-list) below.
+By default a ClickHouse service is not available via Private Service connect even if the
+PSC connection is approved and established; you need explicitly add the PSC ID to the 
+allow list on an instance level by creating a Support request.
+
+The support request will be covered later in this document.
 :::
 
 :::note
 GCP Private Service Connect can be enabled only on ClickHouse Cloud Production services
 :::
 
-Cross-region connectivity is not supported. Producer and consumer regions should be the same. You will be able to connect from other regions within your VPC if you enable Global access on the PSC level (see below).
 
-The process is split into four steps:
+## Supported regions
 
-1. Obtain GCP service attachment for Private Service Connect.
-1. Create a service endpoint.
-1. Add Endpoint ID to ClickHouse Cloud organization.
-1. Add Endpoint ID to service(s) allow list.
+<GCPRegions/>
 
-## Obtain GCP service attachment for Private Service Connect
+Cross-region connectivity is not supported. Producer and consumer regions should be the same.
+You will be able to connect from other regions within your VPC if you enable Global access
+on the PSC level (see below).
 
-Before you get started, you'll need an API key. You can [create a new key](https://clickhouse.com/docs/en/cloud/manage/openapi) or use an existing one.
-
-### REST API 
-
-Set environment variables before running any commands:
-
-```bash
-REGION=<region code, use GCP format>
-PROVIDER=gcp
-KEY_ID=<Key ID>
-KEY_SECRET=<Key secret>
-ORG_ID=<set ClickHouse organization ID>
-```
-
-:::note
-You need at least one instance deployed in the region to perform this step.
-:::
-
-Get an instance ID from your region.
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services | jq ".result[] | select (.region==\"${REGION}\" and .provider==\"${PROVIDER}\") | .id " -r | head -1 | tee instance_id
-```
-
-Create an `INSTANCE_ID` environment variable using the ID you received in the previous step:
-
-```bash
-INSTANCE_ID=$(cat instance_id)
-```
-
-Obtain GCP service attachment for Private Service Connect:
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID/privateEndpointConfig | jq  .result 
-{
-  "endpointServiceId": "projects/.../regions/xxx/serviceAttachments/...-xxx-clickhouse-cloud",
-...
-}
-```
-
-Make a note of the `endpointServiceId`. You'll use it in the next step.
-
-## Create service endpoint
-
-In this section, we're going to create a service endpoint.
-
-### Adding a Private Service Connection (PSC)
-
-First up, we're going to create a PSC.
-
+## Setting up PSC
+### Adding a PSC Connection
 #### Using Google Cloud console
 
-In the Google Cloud console, navigate to **Network services -> Private Service Connect**.
+In the Google Cloud console, navigate to **Network services -> Private Service Connect**
 
 ![Open PSC](@site/docs/en/cloud/security/images/gcp-psc-open.png)
 
 Open the Private Service Connect creation dialog by clicking on the **Connect Endpoint** button.
 
-- **Target**: use **Published service**
-- **Target service**: use **endpointServiceId** from [Obtain GCP service attachment for Private Service Connect](#obtain-gcp-service-attachment-for-private-service-connect) step.
-- **Endpoint name**: set a name for the PSC **Endpoint name**.
-- **Network/Subnetwork/IP address**: choose the network you want to use for the connection. You will need to create an IP address or use an existing one for the Private Service Connect endpoint.
+
+- **Target**: Please use **Published service**
+- **Target service**: Please use the entry from the **Service Attachment** column from the **Supported regions** table.
+- **Endpoint name**: Please set a name for the PSC **Endpoint name**.
+- **Network/Subnetwork/IP address**: Please choose the network you want to use for the connection.  You will need to create an IP address or use an existing one for the Private Service Connect endpoint.
 - To make the endpoint available from any region, you can enable the **Enable global access** checkbox.
 
 ![Enable Global Access](@site/docs/en/cloud/security/images/gcp-psc-enable-global-access.png)
+
 
 To create the PSC Endpoint, use the **ADD ENDPOINT** button.
 
@@ -102,13 +65,14 @@ The **Status** column will change from **Pending** to **Accepted** once the conn
 
 ![Accepted](@site/docs/en/cloud/security/images/gcp-psc-copy-connection-id.png)
 
-Copy **PSC Connection ID** & **IP address**(10.142.0.2 in this example), you will need this information in the next steps.
+Please copy **PSC Connection ID** & **IP address**(10.142.0.2 in this example), you will
+need this information in next steps.
 
 #### Using Terraform
 
 ```json
 provider "google" {
-  # Specify your project here.
+  # please specify your project
   project = "my-gcp-project"
   region  = "us-central1"
 }
@@ -120,18 +84,18 @@ variable "region" {
 
 variable "subnetwork" {
   type = string
-  # Use the correct link to your subnetwork.
-  # Example: "https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/asia-southeast1/subnetworks/default"
+  # please use correct link to subnetwork
+  # example: "https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/asia-southeast1/subnetworks/default"
 }
 
 variable "network" {
   type = string
-  # Use the correct link to your network.
-  # Example: "https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/default"
+  # please use correct link to network
+  # example: "https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/default"
 }
 
 resource "google_compute_address" "psc_endpoint_ip" {
-  #  You can specify an IP address if needed.
+  #  you can specify IP address if needed
   #  address      = "10.148.0.2"
   address_type = "INTERNAL"
   name         = "clickhouse-cloud-psc-${var.region}"
@@ -146,44 +110,45 @@ resource "google_compute_forwarding_rule" "clickhouse_cloud_psc" {
   network               = var.network
   region                = var.region
   load_balancing_scheme = ""
-  # service attachment
-  target = "https://www.googleapis.com/compute/v1/<data from 'Obtain GCP service attachment for Private Service Connect' step>"
+  # service attachment, please find all values at https://clickhouse.com/docs/en/manage/security/gcp-private-service-connect#supported-regions
+  target = "https://www.googleapis.com/compute/v1/projects/dataplane-production/regions/${var.region}/serviceAttachments/production-${var.region}-clickhouse-cloud"
 }
 
 output "psc_connection_id" {
   value       = google_compute_forwarding_rule.clickhouse_cloud_psc.psc_connection_id
-  description = "Add GCP PSC Connection ID to allow list on instance level."
+  description = "Please add GCP PSC Connection ID to allow list on instance level."
 }
 ```
 
 ## Setting up DNS
 
-Two options are presented, using the Google Cloud console and using the `gcloud` CLI.
+Two options are presented, using the Google Cloud console, and using the gcloud CLI.
 
 ### Using the Google Cloud console
 
-- Create a Private DNS zone from **Supported regions**.
-- Open **Network services -> Cloud DNS**.
-- Select **Create Zone**:
+- Please create Private DNS zone from **Supported regions** part:
+- Please open **Network services -> Cloud DNS**.
+- Click **Create Zone**:
 
 ![Create Zone](@site/docs/en/cloud/security/images/gcp-psc-create-zone.png)
 
-In the Zone Type dialog, set:
-
+In the Zone Type dialog Please set:
 - Zone type: **Private**
-- Zone name: input an appropriate zone name.
-- DNS name: use the **Private DNS domain** column from the **Supported regions** table for your region.
-- Networks: attach a DNS zone to networks you are planning to use for connections to ClickHouse Cloud using PSC.
+- Zone name: please set zone name.
+- DNS name: please use the **Private DNS domain** column from the **Supported regions** table for your region.
+- Networks: please attach a DNS zone to networks you are planning to use for connections to ClickHouse Cloud via PSC
 
 ![Zone Type](@site/docs/en/cloud/security/images/gcp-psc-zone-type.png)
 
 #### Create a wildcard record
 
-Point it to the IP address created in the **Adding PSC Connection** step.
+Please point it to the IP address created in the **Adding PSC Connection** step.
 
 ![Wildcard DNS](@site/docs/en/cloud/security/images/gcp-psc-wildcard-dns.png)
 
-### Using the `gcloud` CLI
+
+### Using the gcloud CLI
+
 
 #### Create DNS zone
 
@@ -213,7 +178,7 @@ gcloud dns \
 
 ```json
 resource "google_dns_managed_zone" "clickhouse_cloud_private_service_connect" {
-  description   = "Private DNS zone for accessing ClickHouse Cloud using Private Service Connect"
+  description   = "Private DNS zone for accessing ClickHouse Cloud via Private Service Connect"
   dns_name      = "${var.region}.p.gcp.clickhouse.cloud."
   force_destroy = false
   name          = "clickhouse-cloud-private-service-connect-${var.region}"
@@ -230,195 +195,84 @@ resource "google_dns_record_set" "psc-wildcard" {
 
 ## Verify DNS setup
 
-Any record within the us-central1.p.gcp.clickhouse.cloud domain should be pointed to the Private Service Connect Endpoint IP. (10.142.0.2 in this example). 
+Any record within the us-central1.p.gcp.clickhouse.cloud domain should be pointed
+to Private Service Connect Endpoint IP. (10.142.0.2 in this example). 
 
 ```bash
 ping instance-id.us-central1.p.gcp.clickhouse.cloud.
 ```
-
 ```response
 PING instance-id.us-east1.p.gcp.clickhouse.cloud (10.142.0.2) 56(84) bytes of data.
 ```
 
-## Add Endpoint ID to ClickHouse Cloud organization
+## Reach out to ClickHouse Support
 
-### REST API
+Please open a [support case](https://clickhouse.cloud/support) and provide the following
+information about Private Service Connect:
+- PSC Connection ID(s) from the **Adding PSC Connection** step
+- GCP projectID(s)
+- ClickHouse Cloud service URL(s) that should be available via Private Service Connect.  To find the URL(s) click on a service that you need the URL for and open **Connect**.  The cluster hostname will be available:
 
-Set the following environment variables before running any commands:
+  ![Cluster URL](@site/docs/en/_snippets/images/connection-details-https.png)
 
-```bash
-PROVIDER=gcp
-KEY_ID=<Key ID>
-KEY_SECRET=<Key secret>
-ORG_ID=<set ClickHouse organization ID>
-ENDPOINT_ID=<PSC Connection ID from the previous step>
-REGION=<region code, use GCP format>
-```
 
-Set the `VPC_ENDPOINT` environment variable using data from the previous step.
+Once this request is processed, the PSC connection Status will change to **Accepted**
+and you will be able to connect to your instance using your Private DNS hostname.
 
-To add an endpoint, run:
+For example, if the hostname is `abcd.us-central1.gcp.clickhouse.cloud`, to connect via
+Private Service connect link, please use `abcd.us-central1.p.gcp.clickhouse.cloud` as the hostname. 
 
-```bash
-cat <<EOF | tee pl_config_org.json
-{
-  "privateEndpoints": {
-    "add": [
-      {
-        "cloudProvider": "gcp",
-        "id": "${ENDPOINT_ID}",
-        "description": "A GCP private endpoint",
-        "region": "${REGION}"
-      }
-    ]
-  }
-}
-EOF
-```
-
-To remove an endpoint, run:
-
-```bash
-cat <<EOF | tee pl_config_org.json
-{
-  "privateEndpoints": {
-    "remove": [
-      {
-        "cloudProvider": "gcp",
-        "id": "${ENDPOINT_ID}",
-        "region": "${REGION}"
-      }
-    ]
-  }
-}
-EOF
-```
-
-Add/remove Private Endpoint to an organization:
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID -d @pl_config_org.json
-```
-
-## Add Endpoint ID to service(s) allow list
-
-You need to add an Endpoint ID to the allow-list for each instance that should be available using Private Service Connect.
-
-:::note
-This step cannot be done for Development services.
+:::tip
+Note the `p` added to the private FQDN `abcd.us-central1.p.gcp.clickhouse.cloud`
 :::
 
-### REST API
 
-Set these envorinment variables before running any commands:
+## Connect to ClickHouse via Private Service Connect link
 
-```bash
-PROVIDER=gcp
-KEY_ID=<Key ID>
-KEY_SECRET=<Key secret>
-ORG_ID=<set ClickHouse organization ID>
-ENDPOINT_ID=<PSC Connection ID from the previous step>
-INSTANCE_ID=<Instance ID>
-```
-
-Execute it for each service that should be available using Private Service Connect. 
-
-To add:
+### Verify connectivity to ClickHouse instance via Private Service Connect:
 
 ```bash
-cat <<EOF | tee pl_config.json
-{
-  "privateEndpointIds": {
-    "add": [
-      "${ENDPOINT_ID}"
-    ]
-  }
-}
-EOF
+curl https://HOSTNAME.us-central1.p.gcp.clickhouse.cloud:8443
 ```
-
-To remove:
-
-```bash
-cat <<EOF | tee pl_config.json
-{
-  "privateEndpointIds": {
-    "remove": [
-      "${ENDPOINT_ID}"
-    ]
-  }
-}
-EOF
-```
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID -d @pl_config.json | jq
-```
-
-## Accessing instance using Private Service Connect
-
-Each instance with configured Private Service Connect filters has two endpoints: public and private. In order to connect using Private Service Connect, you need to use a private endpoint(`privateDnsHostname`).
-
-:::note
-private DNS hostname is only available from your GCP VPC. Do not try to resolve the DNS host from a machine that resides outside of GCP VPC.
-:::
-
-### Getting Private DNS Hostname
-
-#### REST API
-
-Set the following environment variables before running any commands:
-
-```bash
-KEY_ID=<Key ID>
-KEY_SECRET=<Key secret>
-ORG_ID=<set ClickHouse organization ID>
-INSTANCE_ID=<Instance ID>
-```
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID/privateEndpointConfig | jq  .result 
-```
-
 ```response
-{
-  ...
-  "privateDnsHostname": "xxxxxxx.<region code>.p.gcp.clickhouse.cloud"
-}
+Ok.
 ```
 
-In this example, connection to the `xxxxxxx.yy-xxxxN.p.gcp.clickhouse.cloud` hostname will be routed to Private Service Connect. Meanwhile, `xxxxxxx.yy-xxxxN.gcp.clickhouse.cloud` will be routed over the internet.
+```bash
+clickhouse-client --host HOSTNAME.us-central1.p.gcp.clickhouse.cloud \
+  --secure --port 9440 \
+  --password PASSWORD
+```
+```response
+1
+```
 
 ## Troubleshooting
-
 ### Test DNS setup
 
-All DNS records from the `${region}.p.gcp.clickhouse.cloud.` zone should be pointed to the internal IP address from **Adding PSC Connection** step. In this example, the region is us-central1.
+All DNS records from the `${region}.p.gcp.clickhouse.cloud.` zone should be pointed to
+the internal IP address from **Adding PSC Connection** step. In this example the region is
+us-central1.
 
 ```bash
 nslookup abcd.us-central1.p.gcp.clickhouse.cloud.
 ```
-
 ```response
 Non-authoritative answer:
 Name:	abcd.us-central1.p.gcp.clickhouse.cloud
 Address: 10.142.0.2
 ```
 
-### Connection reset by peer
-
-- Most likely, the Endpoint ID was not added to the service allow-list. Revisit the [_Add endpoint ID to services allow-list_ step](#add-endpoint-id-to-services-allow-list).
-
 ### Test connectivity
 
-If you have problems with connecting using PSC link, check your connectivity using `openssl`. Make sure the Private Service Connect endpoint status is `Accepted`:
+If you have problems with connecting via PSC link, please check connectivity using
+`openssl`. Make sure Private Service Connect endpoint status is Accepted before doing it:
 
-OpenSSL should be able to connect (see CONNECTED in the output). `errno=104` is expected.
+OpenSSL should be able to connect, (see CONNECTED in the output), `errno=104` is expected
 
 ```bash
 openssl s_client -connect abcd.us-central1.p.gcp.clickhouse.cloud:9440
 ```
-
 ```response
 # highlight-next-line
 CONNECTED(00000003)
@@ -440,24 +294,6 @@ Early data was not sent
 Verify return code: 0 (ok)
 ```
 
-### Checking Endpoint filters
-
-#### REST API
-
-Set the following environment variables before running any commands:
-
-```bash
-KEY_ID=<Key ID>
-KEY_SECRET=<Key secret>
-ORG_ID=<please set ClickHouse organization ID>
-INSTANCE_ID=<Instance ID>
-```
-
-```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X GET -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID | jq .result.privateEndpointIds
-[]
-```
-
 ## More information
 
-For more detailed information, visit [cloud.google.com/vpc/docs/configure-private-service-connect-services](https://cloud.google.com/vpc/docs/configure-private-service-connect-services).
+For more detailed information please visit [cloud.google.com/vpc/docs/configure-private-service-connect-services](https://cloud.google.com/vpc/docs/configure-private-service-connect-services).


### PR DESCRIPTION
due to bug in API customers cannot use self-service approach for GCP. reverting PSC doc to previous version