### PR TITLE
Fix TOC scroll and increase highlight

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -258,7 +258,7 @@ code {
 }
 
 .table-of-contents__link:hover, .table-of-contents__link:hover code, .table-of-contents__link--active, .table-of-contents__link--active code {
-  font-weight: 400;
+  font-weight: 600;
   color: var(--click-color-text);
 }
 

--- a/src/theme/DocItem/TOC/Desktop/styles.module.css
+++ b/src/theme/DocItem/TOC/Desktop/styles.module.css
@@ -11,6 +11,8 @@
   position: sticky;
   gap: 24px;
   padding-bottom: 3.5rem;
+  overflow-y: auto;
+  top: calc(var(--ifm-navbar-height) + 1rem);
 }
 
 .docCloudCard {


### PR DESCRIPTION
Fixes : https://github.com/ClickHouse/clickhouse-docs/issues/1762

Now TOC section will be fixed at the top
and increased the font size for a better view

<img width="1677" alt="Screenshot 2023-12-26 at 8 10 02 PM" src="https://github.com/ClickHouse/clickhouse-docs/assets/37499632/41fcf0f1-e979-4d3c-8093-d78fb5796ef8">
