### PR TITLE
Fix inline code typo

### DIFF
--- a/docs/en/integrations/language-clients/go/index.md
+++ b/docs/en/integrations/language-clients/go/index.md
@@ -117,7 +117,7 @@ func connect() (driver.Conn, error) {
 go mod tidy
 ```
 ### Set your connection details
-Earlier you looked up your connection details.  Set them in `main.go` in the `connect() function:
+Earlier you looked up your connection details.  Set them in `main.go` in the `connect()` function:
 
 ```go
 func connect() (driver.Conn, error) {


### PR DESCRIPTION
Now it looks \`connect(), instead of `connect()`
![image](https://github.com/ClickHouse/clickhouse-docs/assets/75482510/ee42724c-dec8-4016-9040-f301cc87f97d)