### PR TITLE
Fixes link in Java Integration page.

### DIFF
--- a/docs/en/integrations/language-clients/java/index.md
+++ b/docs/en/integrations/language-clients/java/index.md
@@ -383,9 +383,6 @@ These properties ensure that your Java application communicates with the ClickHo
   }
 ```
 
-For more detailed guidance on SSL configuration, please review the [Configuring SSL-TLS](../../../guides/sre/configuring-ssl.md) section.
-
-
 #### Handling DateTime and time zones
 
 Please to use `java.time.LocalDateTime` or `java.time.OffsetDateTime` instead of `java.sql.Timestamp`, and `java.time.LocalDate` instead of `java.sql.Date`.

--- a/docs/en/integrations/language-clients/java/index.md
+++ b/docs/en/integrations/language-clients/java/index.md
@@ -383,7 +383,7 @@ These properties ensure that your Java application communicates with the ClickHo
   }
 ```
 
-For more detailed guidance on SSL configuration, please review the [Configuring SSL-TLS](/docs/en/guides/sre/configuring-ssl.md) section.
+For more detailed guidance on SSL configuration, please review the [Configuring SSL-TLS](../../../guides/sre/configuring-ssl.md) section.
 
 
 #### Handling DateTime and time zones


### PR DESCRIPTION
The build process ran into some issues causing Vercel to not serve new versions of the docs. This PR aims to fix these issues so that the docs site serves the correct content.