### PR TITLE
Adds 2024 roadmap.

### DIFF
--- a/docs/en/whats-new/roadmap.md
+++ b/docs/en/whats-new/roadmap.md
@@ -1,18 +1,18 @@
 ---
+title: "Roadmap"
 slug: /en/whats-new/roadmap
 sidebar_position: 50
-sidebar_label: Roadmap
-title: Roadmap
 ---
 
 ## Current Roadmap
 
 The current roadmap is published for open discussion:
 
-- [2023](https://github.com/ClickHouse/ClickHouse/issues/44767)
+- [2024](https://github.com/ClickHouse/ClickHouse/issues/58392)
 
 ## Previous Roadmaps
 
+- [2023](https://github.com/ClickHouse/ClickHouse/issues/44767)
 - [2022](https://github.com/ClickHouse/ClickHouse/issues/44767)
 - [2021](https://github.com/ClickHouse/ClickHouse/issues/17623)
 - [2020](https://github.com/ClickHouse/ClickHouse/blob/be29057de1835f6f4a17e03a422b45b81efe6833/docs/ru/whats-new/extended-roadmap.md)


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/1818.