### PR TITLE
Adds redirect from `home` to `docs`.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2224,6 +2224,10 @@ const config = {
           {
 						from: '/en/architecture/single-node-deployment',
 						to: '/en/install'
+					},
+          {
+						from: '/en/home',
+						to: '/docs'
 					}
 				],
 			},

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2227,7 +2227,7 @@ const config = {
 					},
           {
 						from: '/en/home',
-						to: '/docs'
+						to: '/'
 					}
 				],
 			},


### PR DESCRIPTION
Control Plane devs found an old link in their UI. Users who go to `/en/home` are now directed to `/docs`.