### PR TITLE
Update clickhouse-js docs as of 0.2.8

### DIFF
--- a/docs/en/integrations/language-clients/js.md
+++ b/docs/en/integrations/language-clients/js.md
@@ -93,6 +93,7 @@ When creating a client instance, the following connection settings can be adjust
 - **clickhouse_settings?: ClickHouseSettings** - ClickHouse settings to apply to all requests. Default value: `{}`.
 - **log?: { LoggerClass?: Logger, level?: ClickHouseLogLevel }** - configure logging. [Logging docs](#logging)
 - **session_id?: string**  - optional ClickHouse Session ID to send with every request.
+- **keep_alive?: { enabled?: boolean }** - enabled by default in both Node.js and Web versions.
 
 #### Node.js-specific configuration parameters
 
@@ -964,7 +965,7 @@ for [basic](https://github.com/ClickHouse/clickhouse-js/blob/main/examples/basic
 and [mutual](https://github.com/ClickHouse/clickhouse-js/blob/main/examples/mutual_tls.ts)
 TLS in the repository.
 
-## Keep Alive (Node.js only)
+## Keep-Alive configuration (Node.js only)
 
 By default, client enables Keep-Alive in the underlying HTTP agent. 
 If you are experiencing `socket hang up` errors, there are several options to resolve this issue:

--- a/docs/en/integrations/language-clients/js.md
+++ b/docs/en/integrations/language-clients/js.md
@@ -329,6 +329,12 @@ interface InsertParams<T> {
   abort_signal?: AbortSignal
   // query_id override; if not specified, a random identifier will be generated automatically.
   query_id?: string
+  // Allows to specify which columns the data will be inserted into.
+  // - An array such as `['a', 'b']` will generate: `INSERT INTO table (a, b) FORMAT DataFormat`
+  // - An object such as `{ except: ['a', 'b'] }` will generate: `INSERT INTO table (* EXCEPT (a, b)) FORMAT DataFormat`
+  // By default, the data is inserted into all columns of the table,
+  // and the generated statement will be: `INSERT INTO table FORMAT DataFormat`.
+  columns?: NonEmptyArray<string> | { except: NonEmptyArray<string> }
 }
 ```
 
@@ -481,6 +487,12 @@ interface InsertParams<T> {
   abort_signal?: AbortSignal
   // query_id override; if not specified, a random identifier will be generated automatically.
   query_id?: string
+  // Allows to specify which columns the data will be inserted into.
+  // - An array such as `['a', 'b']` will generate: `INSERT INTO table (a, b) FORMAT DataFormat`
+  // - An object such as `{ except: ['a', 'b'] }` will generate: `INSERT INTO table (* EXCEPT (a, b)) FORMAT DataFormat`
+  // By default, the data is inserted into all columns of the table,
+  // and the generated statement will be: `INSERT INTO table FORMAT DataFormat`.
+  columns?: NonEmptyArray<string> | { except: NonEmptyArray<string> }
 }
 ```
 


### PR DESCRIPTION
- Added an example of how to insert data to a database different from the one provided to the client instance
- Added an example for including/excluding columns for inserts
- Updated `InsertParams` interface overview
- Added a note about read-only users
- Removed web client Keep-Alive limitation as it is now configurable
- Updated Keep-Alive entry
- Bumped versions
- Fixed a dead link