### PR TITLE
Remove Flyway from list of migration tools supporting ClickHouse

### DIFF
--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -7,7 +7,6 @@ date: 2023-06-07
 We often get asked about a good schema migration tool for ClickHouse and what is the best practice to manage database schemas in ClickHouse that might change over time? There is no standard schema migration tool for ClickHouse, but we have compiled the following list (in no particular order) of automatic schema migration tools with support for ClickHouse that we know:
 
 - [Bytebase](https://www.bytebase.com/)
-- [Flyway](https://www.red-gate.com/products/flyway/)
 - [Liquibase](https://www.liquibase.com/)
 - A [simple community tool](https://github.com/VVVi/clickhouse-migrations) named `clickhouse-migrations`
 - Another [community tool](https://github.com/golang-migrate/migrate/tree/master/database/clickhouse) written in Go


### PR DESCRIPTION
There are a number of PRs open to add support to ClickHouse, but as the time of this writing (Jan, 17th 2024) Flyway doesn't support ClickHouse yet, and trying to use it results in the error

```
Unsupported Database: ClickHouse 23.8
```

It is therefore misleading to have the link in the docs, as one might trust this information during an evaluation phase and get caught by surprise later on.