### PR TITLE
Update aws private link INSTANCE_ID jq command

### DIFF
--- a/docs/en/cloud/security/aws-privatelink.md
+++ b/docs/en/cloud/security/aws-privatelink.md
@@ -36,7 +36,7 @@ ORG_ID=<Your ClickHouse organization ID>
 SERVICE_NAME=<Your ClickHouse service name>
 ```
 
-Get the desired instance ID by filtering on region, provider and service name:
+Get the desired instance ID by filtering by region, provider, and service name:
 
 ```shell
 export INSTANCE_ID=$(curl --silent --user $KEY_ID:$KEY_SECRET \


### PR DESCRIPTION
In case of an organization with multiple services, the current command will populate INSTANCE_ID with the first service_id.
With this change, the filter will match also on the desired instance name.