### PR TITLE
Add Flyway to list of migration tools supporting ClickHouse

### DIFF
--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -7,7 +7,7 @@ date: 2023-06-07
 We often get asked about a good schema migration tool for ClickHouse and what is the best practice to manage database schemas in ClickHouse that might change over time? There is no standard schema migration tool for ClickHouse, but we have compiled the following list (in no particular order) of automatic schema migration tools with support for ClickHouse that we know:
 
 - [Bytebase](https://www.bytebase.com/)
-- [Flyway](https://www.red-gate.com/products/flyway/)
+- [Flyway](https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases/clickhouse-database)
 - [Liquibase](https://www.liquibase.com/)
 - A [simple community tool](https://github.com/VVVi/clickhouse-migrations) named `clickhouse-migrations`
 - Another [community tool](https://github.com/golang-migrate/migrate/tree/master/database/clickhouse) written in Go

--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -7,6 +7,7 @@ date: 2023-06-07
 We often get asked about a good schema migration tool for ClickHouse and what is the best practice to manage database schemas in ClickHouse that might change over time? There is no standard schema migration tool for ClickHouse, but we have compiled the following list (in no particular order) of automatic schema migration tools with support for ClickHouse that we know:
 
 - [Bytebase](https://www.bytebase.com/)
+- [Flyway](https://www.red-gate.com/products/flyway/)
 - [Liquibase](https://www.liquibase.com/)
 - A [simple community tool](https://github.com/VVVi/clickhouse-migrations) named `clickhouse-migrations`
 - Another [community tool](https://github.com/golang-migrate/migrate/tree/master/database/clickhouse) written in Go


### PR DESCRIPTION
Reverts ClickHouse/clickhouse-docs#1857

As of version 10.7.0 Flyway [officially supports ClickHouse](https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases/clickhouse-database) 🎉 