### PR TITLE
docs: update supported types by `clickhouse-kafka-connect-sink`

### DIFF
--- a/docs/en/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
+++ b/docs/en/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
@@ -111,23 +111,23 @@ Sink, use [Kafka Connect Transformations](https://docs.confluent.io/platform/cur
 
 **With a schema declared:**
 
-| Kafka Connect Type                      | ClickHouse Type           | Supported | Primitive |
-| --------------------------------------- | ------------------------- | --------- | --------- |
-| STRING                                  | String                    | ✅        | Yes       |
-| INT8                                    | Int8                      | ✅        | Yes       |
-| INT16                                   | Int16                     | ✅        | Yes       |
-| INT32                                   | Int32                     | ✅        | Yes       |
-| INT64                                   | Int64                     | ✅        | Yes       |
-| FLOAT32                                 | Float32                   | ✅        | Yes       |
-| FLOAT64                                 | Float64                   | ✅        | Yes       |
-| BOOLEAN                                 | Boolean                   | ✅        | Yes       |
-| ARRAY                                   | Array(Primitive)          | ✅        | No        |
-| MAP                                     | Map(Primitive, Primitive) | ✅        | No        |
-| STRUCT                                  | N/A                       | ❌        | No        |
-| BYTES                                   | String                    | ✅        | No        |
-| org.apache.kafka.connect.data.Time      | Int64 / DateTime64        | ✅        | No        |
-| org.apache.kafka.connect.data.Timestamp | Int32 / Date32            | ✅        | No        |
-| org.apache.kafka.connect.data.Decimal   | Decimal                   | ✅        | No        |
+| Kafka Connect Type                      | ClickHouse Type    | Supported | Primitive |
+| --------------------------------------- |--------------------| --------- | --------- |
+| STRING                                  | String             | ✅        | Yes       |
+| INT8                                    | Int8               | ✅        | Yes       |
+| INT16                                   | Int16              | ✅        | Yes       |
+| INT32                                   | Int32              | ✅        | Yes       |
+| INT64                                   | Int64              | ✅        | Yes       |
+| FLOAT32                                 | Float32            | ✅        | Yes       |
+| FLOAT64                                 | Float64            | ✅        | Yes       |
+| BOOLEAN                                 | Boolean            | ✅        | Yes       |
+| ARRAY                                   | Array(T)           | ✅        | No        |
+| MAP                                     | Map(Primitive, T)  | ✅        | No        |
+| STRUCT                                  | N/A                | ❌        | No        |
+| BYTES                                   | String             | ✅        | No        |
+| org.apache.kafka.connect.data.Time      | Int64 / DateTime64 | ✅        | No        |
+| org.apache.kafka.connect.data.Timestamp | Int32 / Date32     | ✅        | No        |
+| org.apache.kafka.connect.data.Decimal   | Decimal            | ✅        | No        |
 
 **Without a schema declared:**
 


### PR DESCRIPTION
This PR depends on https://github.com/ClickHouse/clickhouse-kafka-connect/pull/323

Documentation must be updated as soon as mentioned PR is merged.