### PR TITLE
Clarify multiple MySQL users in the Cloud doc

### DIFF
--- a/docs/en/_snippets/_clickhouse_mysql_cloud_setup.mdx
+++ b/docs/en/_snippets/_clickhouse_mysql_cloud_setup.mdx
@@ -9,3 +9,41 @@ Alternatively, in order to enable the MySQL interface for an existing service:
 ![Connection screen - Prompt MySQL](./images/mysql4.png)
 5. After entering the password, you will get prompted the MySQL connection string for this service
 ![Connection screen -  MySQL Enabled](./images/mysql5.png)
+
+## Creating multiple MySQL users in ClickHouse Cloud
+
+By default, there is a built-in `mysql4<subdomain>` user. The `<subdomain>` part is the first segment of your ClickHouse Cloud hostname. This format is necessary to work with the tools that implement secure connection, but don't provide [SNI information in their TLS handshake](https://www.cloudflare.com/learning/ssl/what-is-sni), which makes it impossible to do the internal routing without an extra hint in the username. When not sure whether a tool supports TLS SNI, it is better to follow `mysql4<subdomain>_<username>` format, where `<subdomain>` is a hint to identify your Cloud service, and `<username>` is an arbitrary suffix of your choice; if a tool supports TLS SNI, then an arbitrary name can be used for custom MySQL users.
+
+:::tip
+For ClickHouse Cloud hostname like `foobar.us-east1.aws.clickhouse.cloud`, the `<subdomain>` part equals to `foobar`, and a custom MySQL username could look like `mysql4foobar_team1`.
+:::
+
+You can create extra users to use with the MySQL interface if, for example, you need to apply extra settings.
+
+1. Optional - create a [settings profile](https://clickhouse.com/docs/en/sql-reference/statements/create/settings-profile) to apply for your custom user. For example, `my_custom_profile` with an extra setting which will be applied by default when we connect with the user we create later:
+
+    ```sql
+    CREATE SETTINGS PROFILE my_custom_profile SETTINGS prefer_column_name_to_alias=1;
+    ```
+
+    `prefer_column_name_to_alias` is used just as an example, you can use other settings there.
+2. [Create a user](https://clickhouse.com/docs/en/sql-reference/statements/create/user) using the following format: `mysql4<subdomain>_<username>` ([see above](#creating-multiple-mysql-users-in-clickhouse-cloud)). The password must be in double SHA1 format. For example:
+
+    ```sql
+    CREATE USER mysql4foobar_team1 IDENTIFIED WITH double_sha1_password BY 'YourPassword42$';
+    ```
+
+    or if you want to use a custom profile for this user:
+
+    ```sql
+    CREATE USER mysql4foobar_team1 IDENTIFIED WITH double_sha1_password BY 'YourPassword42$' SETTINGS PROFILE 'my_custom_profile';
+    ```
+
+    where `my_custom_profile` is the name of the profile you created earlier.
+3. [Grant](https://clickhouse.com/docs/en/sql-reference/statements/grant) the new user the necessary permissions to interact with the desired tables or databases. For example, if you want to grant access to `system.query_log` only:
+
+    ```sql
+    GRANT SELECT ON system.query_log TO mysql4foobar_team1;
+    ```
+
+4. Use the created user to connect to your ClickHouse Cloud service with the MySQL interface.

--- a/docs/en/integrations/data-visualization/looker-studio-and-clickhouse.md
+++ b/docs/en/integrations/data-visualization/looker-studio-and-clickhouse.md
@@ -66,21 +66,3 @@ In the Looker Studio UI, choose the "Enable SSL" option. ClickHouse Cloud's SSL 
 <br/>
 
 The rest of the steps are the same as listed above in the previous section.
-
-## Create Multiple MySQL Users in Cloud
-
-Besides the built-in `mysql4<subdomain>` user, you can also create multiple users for the MySQL interface.
-
-1. Create a user using the following format: `mysql4<subdomain>_<suffix>`. The password must be in double SHA1 format. For example:
-
-  ```sql
-  CREATE USER mysql4abcdefg123_team1 IDENTIFIED WITH double_sha1_password BY 'YourPassword42$';
-  ```
-
-2. Grant the new user the necessary permission to interact with the database:
-
-  ```sql
-  GRANT SELECT ON system.query_log TO mysql4abcdefg123_team1;
-  ```
-
-3. Use the created user to connect to the MySQL interface.


### PR DESCRIPTION
* Provide more hints and explanations, better examples with custom profiles
* Move it from Looker Studio to `_clickhouse_mysql_cloud_setup.mdx` cause it's useful for every tool and it should be in every doc entry where this snippet is included.