### PR TITLE
Adds note on no custom CA certificates.

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/index.md
@@ -34,6 +34,9 @@ import WarpStreamSVG from "../../images/logos/warpstream.svg";
   ![Select data source type](./images/cp_step1.png)
 
 4. Fill out the form by providing your ClickPipe with a name, a description (optional), your credentials, and other connection details.
+:::note
+Currently ClickPipes does not support loading custom CA certificates.
+:::
 
   ![Fill out connection details](./images/cp_step2.png)
 


### PR DESCRIPTION
Adds a note on no custom CA certificates to the ClickPipe docs.
![Screenshot 2024-02-27 at 12 18 02 PM](https://github.com/ClickHouse/clickhouse-docs/assets/65251165/ab1a2c01-984d-4c26-b50b-0fbb338234c9)
