### PR TITLE
Add legacy approach to import GPG keys

### DIFF
--- a/docs/en/guides/troubleshooting.md
+++ b/docs/en/guides/troubleshooting.md
@@ -25,6 +25,14 @@ sudo rm -rf "$GNUPGHOME"
 sudo chmod +r /usr/share/keyrings/clickhouse-keyring.gpg
 ```
 
+If you still cannot use the above commands to import GPG keys, please use the following legacy approach to import GPG keys:
+
+```shell
+GNUPGHOME=$(mktemp -d)
+GNUPGHOME="$GNUPGHOME" gpg --primary-keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv-keys 8919F6BD2B48D754
+rm -rf "$GNUPGHOME"
+```
+
 2. Ensuring the `dirmngr` package is installed:
 
 ```shell


### PR DESCRIPTION
# Changed log

- Add the alternative way about importing the GPG keys with `gpg` command.
- It will be used when the GPG versions are `1.x` or `2.0.x`.
- This approach is legacy because the GPG key will be stored/imported in the global primary keyring.