### PR TITLE
Update Grafana docs for v4.0.3

### DIFF
--- a/docs/en/integrations/data-visualization/grafana/config.md
+++ b/docs/en/integrations/data-visualization/grafana/config.md
@@ -12,7 +12,7 @@ The easiest way to modify a configuration is in the Grafana UI on the plugin con
 
 This page shows a list of options available for configuration in the ClickHouse plugin, as well as config snippets for those provisioning a data source with YAML.
 
-For a quick overview of all the options, a full example config can be found [here](#full-example-config).
+For a quick overview of all the options, a full list of config options can be found [here](#all-yaml-options).
 
 ## Common Settings
 
@@ -105,6 +105,7 @@ jsonData:
 ### OpenTelemetry
 
 OpenTelemetry (OTel) is deeply integrated within the plugin.
+OpenTelemetry data can be exported to ClickHouse with our [exporter plugin](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter).
 For the best usage, it is recommended to configure OTel for both [logs](#logs) and [traces](#traces).
 
 It is also required to configure these defaults for enabling [data links](./query-builder.md#data-links), a feature that enables powerful observability workflows.
@@ -172,7 +173,7 @@ jsonData:
 ```
 
 
-## Full Example YAML
+## All YAML Options
 
 These are all of the YAML configuration options made available by the plugin.
 Some fields have example values while others simply show the field's type.

--- a/docs/en/integrations/data-visualization/grafana/index.md
+++ b/docs/en/integrations/data-visualization/grafana/index.md
@@ -61,7 +61,7 @@ Before Grafana can connect to ClickHouse, you need to install the appropriate Gr
 
   <img src={require('./images/quick_config.png').default} class="image" alt="Connection configuration page" />
 
-1. Enter your server settings and credentials. The key settings are:
+3. Enter your server settings and credentials. The key settings are:
 
 - **Server host address:** the hostname of your ClickHouse service.
 - **Server port:** the port for your ClickHouse service. Will be different depending on server configuration and protocol.
@@ -71,7 +71,7 @@ Before Grafana can connect to ClickHouse, you need to install the appropriate Gr
 
 For more settings, check the [plugin configuration](./config.md) documentation.
 
-1. Click the **Save & test** button to verify that Grafana can connect to your ClickHouse service. If successful, you will see a **Data source is working** message:
+4. Click the **Save & test** button to verify that Grafana can connect to your ClickHouse service. If successful, you will see a **Data source is working** message:
 
     <img src={require('./images/valid_ds.png').default} class="image" alt="Select Save & test" />
 

--- a/docs/en/integrations/data-visualization/grafana/query-builder.md
+++ b/docs/en/integrations/data-visualization/grafana/query-builder.md
@@ -10,12 +10,19 @@ description: Using the Query Builder in the ClickHouse Grafana plugin
 Any query can be run with the ClickHouse plugin.
 The query builder is a convenient option for simpler queries, but for complicated queries you will need to use the [SQL Editor](#sql-editor).
 
-Queries in the query builder all have a [query type](#query-types), and require at least one column to be selected.
+All queries in the query builder have a [query type](#query-types), and require at least one column to be selected.
+
+The available query types are:
+- [Table](#table): the simplest query type for showing data in table format. Works well as a catch-all for both simple and complex queries containing aggregate functions.
+- [Logs](#logs): optimized for building queries for logs. Works best in explore view with [defaults configured](./config.md#logs).
+- [Time Series](#time-series): best used for building time series queries. Allows selecting a dedicated time column and adding aggregate functions.
+- [Traces](#traces): optimized for searching/viewing traces. Works best in explore view with [defaults configured](./config.md#traces).
+- [SQL Editor](#sql-editor): the SQL Editor can be used when you want full control over the query. In this mode, any SQL query can be executed.
 
 ## Query Types
 
 The *Query Type* setting will change the layout of the query builder to match the type of query being built.
-In explore view, the query type also determines which panel is used when visualizing data.
+The query type also determines which panel is used when visualizing data.
 
 ### Table
 
@@ -25,15 +32,15 @@ The most flexible query type is the table query. This is a catch-all for the oth
 |----|----|
 | Builder Mode  | Simple queries exclude Aggregates and Group By, while aggregate queries include these options.  |
 | Columns | The selected columns. Raw SQL can be typed into this field to allow for functions and column aliasing. |
-| Aggregates | A list of aggregate functions. Allows for custom values for function and column. Only visible in Aggregate mode. |
-| Group By | A list of `GROUP BY` names. Only visible in Aggregate mode. |
-| Order By | A list of `ORDER BY` names. |
-| Limit | Appends a `LIMIT` statement to the end of the query. If set to `0` then it will be excluded. Some visualizations might need this set to `0` to show all the data. |
+| Aggregates | A list of [aggregate functions](/docs/en/sql-reference/aggregate-functions/index.md). Allows for custom values for function and column. Only visible in Aggregate mode. |
+| Group By | A list of [GROUP BY](/docs/en/sql-reference/statements/select/group-by.md) expressions. Only visible in Aggregate mode. |
+| Order By | A list of [ORDER BY](/docs/en/sql-reference/statements/select/order-by.md) expressions. |
+| Limit | Appends a [LIMIT](/docs/en/sql-reference/statements/select/limit.md) statement to the end of the query. If set to `0` then it will be excluded. Some visualizations might need this set to `0` to show all the data. |
 | Filters | A list of filters to be applied in the `WHERE` clause. |
 
 <img src={require('./images/demo_table_query.png').default} class="image" alt="Example aggregate table query" />
 
-In explore view, this query type will render the data as a table.
+This query type will render the data as a table.
 
 ### Logs
 
@@ -51,18 +58,18 @@ The logs query type supports [data links](#data-links).
 |----|----|
 | Use OTel | Enables OpenTelemetry columns. Will overwrite the selected columns to use columns defined by the selected OTel schema version (Disables column selection). |
 | Columns | Extra columns to be added to the log rows. Raw SQL can be typed into this field to allow for functions and column aliasing. |
-| Time | The primary timestamp column for the log. Allows for custom values/functions. |
+| Time | The primary timestamp column for the log. Will display time-like types, but allows for custom values/functions. |
 | Log Level | Optional. The *level* or *severity* of the log. Values typically look like `INFO`, `error`, `Debug`, etc. |
 | Message | The log message content. |
-| Order By | A list of `ORDER BY` names. |
-| Limit | Appends a `LIMIT` statement to the end of the query. If set to `0` then it will be excluded, but this isn't recommended for large log datasets. |
+| Order By | A list of [ORDER BY](/docs/en/sql-reference/statements/select/order-by.md) expressions. |
+| Limit | Appends a [LIMIT](/docs/en/sql-reference/statements/select/limit.md) statement to the end of the query. If set to `0` then it will be excluded, but this isn't recommended for large log datasets. |
 | Filters | A list of filters to be applied in the `WHERE` clause. |
 | Message Filter | A text input for conveniently filtering logs using a `LIKE %value%`. Excluded when input is empty. |
 
 <img src={require('./images/demo_logs_query.png').default} class="image" alt="Example OTel logs query" />
 
 <br/>
-In explore view, this query type will render the data in the logs panel along with a logs histogram panel.
+This query type will render the data in the logs panel along with a logs histogram panel at the top.
 
 Extra columns that are selected in the query can be viewed in the expanded log row:
 <img src={require('./images/demo_logs_query_fields.png').default} class="image" alt="Example of extra fields on logs query" />
@@ -87,17 +94,17 @@ Try removing the `LIMIT` clause by setting it to `0` (if your dataset allows).
 | Field | Description |
 |----|----|
 | Builder Mode  | Simple queries exclude Aggregates and Group By, while aggregate queries include these options.  |
-| Time | The primary time column for the query. Allows for custom values/functions. |
+| Time | The primary time column for the query. Will display time-like types, but allows for custom values/functions. |
 | Columns | The selected columns. Raw SQL can be typed into this field to allow for functions and column aliasing. Only visible in Simple mode. |
-| Aggregates | A list of aggregate functions. Allows for custom values for function and column. Only visible in Aggregate mode. |
-| Group By | A list of `GROUP BY` names. Only visible in Aggregate mode. |
-| Order By | A list of `ORDER BY` names. |
-| Limit | Appends a `LIMIT` statement to the end of the query. If set to `0` then it will be excluded, this is recommended for some time series datasets in order to show the full visualization. |
+| Aggregates | A list of [aggregate functions](/docs/en/sql-reference/aggregate-functions/index.md). Allows for custom values for function and column. Only visible in Aggregate mode. |
+| Group By | A list of [GROUP BY](/docs/en/sql-reference/statements/select/group-by.md) expressions. Only visible in Aggregate mode. |
+| Order By | A list of [ORDER BY](/docs/en/sql-reference/statements/select/order-by.md) expressions. |
+| Limit | Appends a [LIMIT](/docs/en/sql-reference/statements/select/limit.md) statement to the end of the query. If set to `0` then it will be excluded, this is recommended for some time series datasets in order to show the full visualization. |
 | Filters | A list of filters to be applied in the `WHERE` clause. |
 
 <img src={require('./images/demo_time_series_query.png').default} class="image" alt="Example time series query" />
 
-In explore view, this query type will render the data with the time series panel.
+This query type will render the data with the time series panel.
 
 ### Traces
 
@@ -123,26 +130,30 @@ The trace query type supports [data links](#data-links).
 | Service Name Column | Service name. |
 | Operation Name Column | Operation name. |
 | Start Time Column | The primary time column for the trace span. The time when the span started. |
-| Duration Time Column | The duration of the span. |
-| Duration Unit | The unit of time used for the duration. Nanoseconds by default, but will be converted if a different unit is selected. |
+| Duration Time Column | The duration of the span. By default Grafana expects this to be a float in milliseconds. A conversion is automatically applied via the `Duration Unit` dropdown. |
+| Duration Unit | The unit of time used for the duration. Nanoseconds by default. The selected unit will be converted to a float in milliseconds as required by Grafana. |
 | Tags Column | Span Tags. Exclude this if not using an OTel based schema as it expects a specific Map column type. |
 | Service Tags Column | Service Tags. Exclude this if not using an OTel based schema as it expects a specific Map column type. |
-| Order By | A list of `ORDER BY` names. |
-| Limit | Appends a `LIMIT` statement to the end of the query. If set to `0` then it will be excluded, but this isn't recommended for large trace datasets. |
+| Order By | A list of [ORDER BY](/docs/en/sql-reference/statements/select/order-by.md) expressions. |
+| Limit | Appends a [LIMIT](/docs/en/sql-reference/statements/select/limit.md) statement to the end of the query. If set to `0` then it will be excluded, but this isn't recommended for large trace datasets. |
 | Filters | A list of filters to be applied in the `WHERE` clause. |
 | Trace ID | The Trace ID to filter by. Only used in Trace ID mode, and when opening a trace ID [data link](#data-links). |
 
 <img src={require('./images/demo_trace_query.png').default} class="image" alt="Example OTel trace query" />
 
+This query type will render the data with the table view for Trace Search mode, and the trace panel for Trace ID mode.
+
 ## SQL Editor
 
-For queries that are too complex for the query builder, you can use the SQL editor.
-This allows you to write plain ClickHouse SQL. The SQL editor can be opened by selecting "SQL Editor" at the top of the query editor.
+For queries that are too complex for the query builder, you can use the SQL Editor.
+This gives you full control over the query by allowing you to write and run plain ClickHouse SQL.
 
-Macro functions can still be used in this mode.
+The SQL editor can be opened by selecting "SQL Editor" at the top of the query editor.
 
-Note that the *Query Type* field is only visible in explore mode.
+[Macro functions](#macros) can still be used in this mode.
+
 You can switch between query types to get a visualization that best fits your query.
+This switch also has an effect even in dashboard view, notably with time series data.
 
 <img src={require('./images/demo_raw_sql_query.png').default} class="image" alt="Example raw SQL query" />
 
@@ -183,3 +194,54 @@ Having defaults configured for both [logs](./config.md#logs) and [traces](./conf
   Example of viewing a trace (right panel) from a logs query (left panel)
   <img src={require('./images/demo_data_links.png').default} class="image" alt="Example of data links linking" />
 </div>
+
+
+## Macros
+
+Macros are a simple way to add dynamic SQL to your query.
+Before a query gets sent to the ClickHouse server, the plugin will expand the macro and replace it will the full expression.
+
+Queries from both the SQL Editor and Query Builder can use macros.
+
+
+### Using Macros
+
+Macros can be included anywhere in the query, multiple times if needed.
+
+Here is an example of using the `$__timeFilter` macro:
+
+Input:
+```sql
+SELECT log_time, log_message
+FROM logs
+WHERE $__timeFilter(log_time)
+```
+
+Final query output:
+```sql
+SELECT log_time, log_message
+FROM logs
+WHERE log_time >= toDateTime(1415792726) AND log_time <= toDateTime(1447328726)
+```
+
+In this example, the Grafana dashboard's time range is applied to the `log_time` column.
+
+The plugin also supports notation using braces `{}`. Use this notation when queries are needed inside [parameters](/docs/en/sql-reference/syntax.md#defining-and-using-query-parameters).
+
+### List of Macros
+
+This is a list of all macros available in the plugin:
+
+| Macro                                        | Description                                                                                                                                                                         | Output example                                                                                                    |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `$__dateFilter(columnName)`                  | Replaced by a time range filter on the provided column using the Grafana panel's time range as a [Date](/docs/en/sql-reference/data-types/date.md).                                 | `columnName >= toDate('2022-10-21') AND columnName <= toDate('2022-10-23')`                                       |
+| `$__timeFilter(columnName)`                  | Replaced by a time range filter on the provided column using the Grafana panel's time range as a [DateTime](/docs/en/sql-reference/data-types/datetime.md).                         | `columnName >= toDateTime(1415792726) AND time <= toDateTime(1447328726)`                                         |
+| `$__timeFilter_ms(columnName)`               | Replaced by a time range filter on the provided column using the Grafana panel's time range as a [DateTime64](/docs/en/sql-reference/data-types/datetime64.md).                     | `columnName >= fromUnixTimestamp64Milli(1415792726123) AND columnName <= fromUnixTimestamp64Milli(1447328726456)` |
+| `$__fromTime`                                | Replaced by the starting time of the Grafana panel range casted to a [DateTime](/docs/en/sql-reference/data-types/datetime.md).                                                     | `toDateTime(1415792726)`                                                                                          |
+| `$__fromTime_ms`                             | Replaced by the starting time of the panel range casted to a [DateTime64](/docs/en/sql-reference/data-types/datetime64.md).                                                         | `fromUnixTimestamp64Milli(1415792726123)`                                                                         |
+| `$__toTime`                                  | Replaced by the ending time of the Grafana panel range casted to a [DateTime](/docs/en/sql-reference/data-types/datetime.md).                                                       | `toDateTime(1447328726)`                                                                                          |
+| `$__toTime_ms`                               | Replaced by the ending time of the panel range casted to a [DateTime64](/docs/en/sql-reference/data-types/datetime64.md).                                                           | `fromUnixTimestamp64Milli(1447328726456)`                                                                         |
+| `$__timeInterval(columnName)`                | Replaced by a function calculating the interval based on window size in seconds.                                                                                                    | `toStartOfInterval(toDateTime(columnName), INTERVAL 20 second)`                                                   |
+| `$__timeInterval_ms(columnName)`             | Replaced by a function calculating the interval based on window size in milliseconds.                                                                                               | `toStartOfInterval(toDateTime64(columnName, 3), INTERVAL 20 millisecond)`                                         |
+| `$__interval_s`                              | Replaced by the dashboard interval in seconds.                                                                                                                                      | `20`                                                                                                              |
+| `$__conditionalAll(condition, $templateVar)` | Replaced by the first parameter when the template variable in the second parameter does not select every value. Replaced by the 1=1 when the template variable selects every value. | `condition` or `1=1`                                                                                              |


### PR DESCRIPTION
Added some changes for v4.0.3 as well as some cleanup from the previous PR review:

- Added new section for Macro functions
- Fixed numbering of steps on quick start guide
- Changed phrasing config options so people don't mistake it as a copy/paste usable example
- Added links to referenced ClickHouse SQL statements
- Added link to our OpenTelemetry exporter in the OTel config section
- Misc. code review notes + changes