### PR TITLE
CHJS: Fix data formats table

### DIFF
--- a/docs/en/integrations/language-clients/js.md
+++ b/docs/en/integrations/language-clients/js.md
@@ -704,10 +704,10 @@ It's only that formats like [ClickHouse JSON](https://clickhouse.com/docs/en/sql
 | Format                                     | Input (array) | Input (object) | Input/Output (Stream) | Output (JSON) | Output (text)  |
 |--------------------------------------------|---------------|----------------|-----------------------|---------------|----------------|
 | JSON                                       | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
-| JSONObjectEachRow                          | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
-| JSONStrings                                | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
 | JSONCompact                                | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
+| JSONObjectEachRow                          | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
 | JSONColumnsWithMetadata                    | ❌             | ✔️             | ❌                     | ✔️            | ✔️             |
+| JSONStrings                                | ❌             | ❌️             | ❌                     | ✔️            | ✔️             |
 | JSONCompactStrings                         | ❌             | ❌              | ❌                     | ✔️            | ✔️             |
 | JSONEachRow                                | ✔️            | ❌              | ✔️                    | ✔️            | ✔️             |
 | JSONStringsEachRow                         | ✔️            | ❌              | ✔️                    | ✔️            | ✔️             |


### PR DESCRIPTION
JSONStrings is marked as [acceptable input here](https://clickhouse.com/docs/en/interfaces/formats), but at least with CHJS, it is not accepted as input for insert operations.

```
ClickHouseError: Format JSONStrings is not suitable for input. 
  code: '85',
  type: 'FORMAT_IS_NOT_SUITABLE_FOR_INPUT'
```