### PR TITLE
Fix for broken LaTex rendering

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,7 @@
 const darkTheme = require('prism-react-renderer/themes/vsDark')
 const path = require("path")
+const math = require('remark-math');
+const katex = require('rehype-katex');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -66,6 +68,8 @@ const config = {
 					showLastUpdateTime: false,
 					sidebarCollapsed: true,
 					routeBasePath: '/',
+					remarkPlugins: [math],
+          				rehypePlugins: [katex],
 				},
 				blog: {
 					path: 'knowledgebase',
@@ -107,7 +111,16 @@ const config = {
 			}),
 		],
 	],
-
+	stylesheets: 
+	[
+    		{
+      			href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+      			type: 'text/css',
+      			integrity:
+        			'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+      			crossorigin: 'anonymous',
+    		},
+  	],
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "docusaurus-plugin-sass": "^0.2.5",
     "esbuild": "^0.20.1",
     "esbuild-loader": "^4.0.3",
+    "hast-util-is-element": "1.1.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "rehype-katex": "5",
     "remark-docusaurus-tabs": "^0.2.0",
-    "remark-math": "6",
+    "remark-math": "3",
     "sass": "^1.71.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Opening this PR as a potential fix to #2199.

**Original issue**: 

Latex equations do not render correctly:

![windows_functions_latex_display_issue](https://github.com/ClickHouse/clickhouse-docs/assets/41984034/928897fd-284c-4899-9e82-f4521fb1c42f)

Initially I thought it was a syntax issue with the LaTex in the .md file but after many unsuccessful attempts I concluded that LaTex/KaTex is just not supported in the docs, yet. (it doesn't seem commonly used across the docs site in any case which is why we didn't pick it up). 

**Changes made**:

I added in the plugins required for KaTex rendering as per the docusaurus documentation for version 2:
[docusuarus version 2 - adding math support](https://docusaurus.io/docs/2.x/markdown-features/math-equations)

**Result**:

LaTex now renders correctly:

![windows_functions_latex_display_after_fix](https://github.com/ClickHouse/clickhouse-docs/assets/41984034/0a49166c-102e-4e63-a461-d4892def200c)
