### PR TITLE
Add a redirect from `invertedindexes` to `fulltextindexes`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -847,6 +847,10 @@ const config = {
 						from: '/en/guides/developer/full-text-search',
 						to: '/en/engines/table-engines/mergetree-family/invertedindexes',
 					},
+					{
+						from: '/en/engines/table-engines/mergetree-family/invertedindexes',
+						to: '/en/engines/table-engines/mergetree-family/fulltextindexes',
+					},
 					{ from: '/en/operations/troubleshooting', to: '/knowledgebase' },
 					{
 						from: '/en/operations/table_engines',


### PR DESCRIPTION
Doc Check in https://github.com/ClickHouse/ClickHouse/pull/63260 complains about missing redirects ...