### PR TITLE
Revert "Add a redirect from `invertedindexes` to `fulltextindexes`"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -847,10 +847,6 @@ const config = {
 						from: '/en/guides/developer/full-text-search',
 						to: '/en/engines/table-engines/mergetree-family/invertedindexes',
 					},
-					{
-						from: '/en/engines/table-engines/mergetree-family/invertedindexes',
-						to: '/en/engines/table-engines/mergetree-family/fulltextindexes',
-					},
 					{ from: '/en/operations/troubleshooting', to: '/knowledgebase' },
 					{
 						from: '/en/operations/table_engines',


### PR DESCRIPTION
Reverts ClickHouse/clickhouse-docs#2277

Doesn't work, breaks https://github.com/ClickHouse/ClickHouse/pull/63260 over and over and over.