### PR TITLE
[AWS/GCP] PL / PSC docs improvement

### DIFF
--- a/docs/en/cloud/security/aws-privatelink.md
+++ b/docs/en/cloud/security/aws-privatelink.md
@@ -39,16 +39,16 @@ SERVICE_NAME=<Your ClickHouse service name>
 Get the desired instance ID by filtering by region, provider, and service name:
 
 ```shell
-export INSTANCE_ID=$(curl --silent --user $KEY_ID:$KEY_SECRET \
+export INSTANCE_ID=$(curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services | \
-jq ".result[] | select (.region==\"${REGION}\" and .provider==\"${PROVIDER}\" and .name==\"${SERVICE_NAME}\") | .id " -r)
+jq ".result[] | select (.region==\"${REGION:?}\" and .provider==\"${PROVIDER:?}\" and .name==\"${SERVICE_NAME:?}\") | .id " -r)
 ```
 
 Obtain an AWS Service Name for your Private Link configuration:
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID/privateEndpointConfig | \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?}/privateEndpointConfig | \
 jq .result
 ```
 
@@ -186,18 +186,18 @@ cat <<EOF | tee pl_config_org.json
     "add": [
       {
         "cloudProvider": "aws",
-        "id": "${ENDPOINT_ID}",
+        "id": "${ENDPOINT_ID:?}",
         "description": "An aws private endpoint",
-        "region": "${REGION}"
+        "region": "${REGION:?}"
       }
     ]
   }
 }
 EOF
 
-curl --silent --user $KEY_ID:$KEY_SECRET \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 -X PATCH -H "Content-Type: application/json" \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?} \
 -d @pl_config_org.json
 ```
 
@@ -210,17 +210,17 @@ cat <<EOF | tee pl_config_org.json
     "remove": [
       {
         "cloudProvider": "aws",
-        "id": "${ENDPOINT_ID}",
-        "region": "${REGION}"
+        "id": "${ENDPOINT_ID:?}",
+        "region": "${REGION:?}"
       }
     ]
   }
 }
 EOF
 
-curl --silent --user $KEY_ID:$KEY_SECRET \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 -X PATCH -H "Content-Type: application/json" \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?} \
 -d @pl_config_org.json
 ```
 
@@ -246,15 +246,15 @@ cat <<EOF | tee pl_config.json
 {
   "privateEndpointIds": {
     "add": [
-      "${ENDPOINT_ID}"
+      "${ENDPOINT_ID:?}"
     ]
   }
 }
 EOF
 
-curl --silent --user $KEY_ID:$KEY_SECRET \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 -X PATCH -H "Content-Type: application/json" \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?} \
 -d @pl_config.json | jq
 ```
 
@@ -265,15 +265,15 @@ cat <<EOF | tee pl_config.json
 {
   "privateEndpointIds": {
     "remove": [
-      "${ENDPOINT_ID}"
+      "${ENDPOINT_ID:?}"
     ]
   }
 }
 EOF
 
-curl --silent --user $KEY_ID:$KEY_SECRET \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 -X PATCH -H "Content-Type: application/json" \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?} \
 -d @pl_config.json | jq
 ```
 
@@ -297,8 +297,8 @@ INSTANCE_ID=<Instance ID>
 ```
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID/privateEndpointConfig | \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?}/privateEndpointConfig | \
 jq .result
 ```
 
@@ -345,9 +345,9 @@ INSTANCE_ID=<Instance ID>
 ```
 
 ```shell
-curl --silent --user $KEY_ID:$KEY_SECRET \
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} \
 -X GET -H "Content-Type: application/json" \
-https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID | \
+https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?} | \
 jq .result.privateEndpointIds
 ```
 

--- a/docs/en/cloud/security/gcp-private-service-connect.md
+++ b/docs/en/cloud/security/gcp-private-service-connect.md
@@ -53,7 +53,7 @@ You need at least one instance deployed in the region to perform this step.
 Get an instance ID from your region.
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services | jq ".result[] | select (.region==\"${REGION}\" and .provider==\"${PROVIDER}\") | .id " -r | head -1 | tee instance_id
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services | jq ".result[] | select (.region==\"${REGION:?}\" and .provider==\"${PROVIDER:?}\") | .id " -r | head -1 | tee instance_id
 ```
 
 Create an `INSTANCE_ID` environment variable using the ID you received in the previous step:
@@ -65,7 +65,7 @@ INSTANCE_ID=$(cat instance_id)
 Obtain GCP service attachment for Private Service Connect:
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID/privateEndpointConfig | jq  .result 
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?}/privateEndpointConfig | jq  .result 
 {
   "endpointServiceId": "projects/.../regions/xxx/serviceAttachments/...-xxx-clickhouse-cloud",
 ...
@@ -268,9 +268,9 @@ cat <<EOF | tee pl_config_org.json
     "add": [
       {
         "cloudProvider": "gcp",
-        "id": "${ENDPOINT_ID}",
+        "id": "${ENDPOINT_ID:?}",
         "description": "A GCP private endpoint",
-        "region": "${REGION}"
+        "region": "${REGION:?}"
       }
     ]
   }
@@ -287,8 +287,8 @@ cat <<EOF | tee pl_config_org.json
     "remove": [
       {
         "cloudProvider": "gcp",
-        "id": "${ENDPOINT_ID}",
-        "region": "${REGION}"
+        "id": "${ENDPOINT_ID:?}",
+        "region": "${REGION:?}"
       }
     ]
   }
@@ -299,7 +299,7 @@ EOF
 Add/remove Private Endpoint to an organization:
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID -d @pl_config_org.json
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?} -d @pl_config_org.json
 ```
 
 ## Add Endpoint ID to service(s) allow list
@@ -354,7 +354,7 @@ EOF
 ```
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID -d @pl_config.json | jq
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} -X PATCH -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?} -d @pl_config.json | jq
 ```
 
 ## Accessing instance using Private Service Connect
@@ -456,7 +456,7 @@ INSTANCE_ID=<Instance ID>
 ```
 
 ```bash
-curl --silent --user $KEY_ID:$KEY_SECRET -X GET -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$INSTANCE_ID | jq .result.privateEndpointIds
+curl --silent --user ${KEY_ID:?}:${KEY_SECRET:?} -X GET -H "Content-Type: application/json" https://api.clickhouse.cloud/v1/organizations/${ORG_ID:?}/services/${INSTANCE_ID:?} | jq .result.privateEndpointIds
 []
 ```
 


### PR DESCRIPTION
Update documents: fail if some of env vars are not set.


using ${var_name:?} approach will error if env var is not set:

```
TEST_VAR=test
echo ${TEST_VAR:?}
test
unset TEST_VAR
echo ${TEST_VAR:?}
-bash: TEST_VAR: parameter null or not set
```