### PR TITLE
fix-docs/en/tutorial.md_4.-Create-a-Dictionary/7.-'dropoff'-to-'pickup'

### DIFF
--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -426,7 +426,7 @@ If you are new to ClickHouse, it is important to understand how ***dictionaries*
     ORDER BY total DESC
     ```
 
-    This query sums up the number of taxi rides per borough that end at either the LaGuardia or JFK airport. The result looks like the following, and notice there are quite a few trips where the dropoff neighborhood is unknown:
+    This query sums up the number of taxi rides per borough that end at either the LaGuardia or JFK airport. The result looks like the following, and notice there are quite a few trips where the pickup neighborhood is unknown:
     ```response
     ┌─total─┬─borough_name──┐
     │ 23683 │ Unknown       │


### PR DESCRIPTION
Hello !


```
SELECT
    count(1) AS total,
    dictGetOrDefault('taxi_zone_dictionary','Borough', toUInt64(pickup_nyct2010_gid), 'Unknown') AS borough_name
FROM trips
WHERE dropoff_nyct2010_gid = 132 OR dropoff_nyct2010_gid = 138
GROUP BY borough_name
ORDER BY total DESC
```
From this query, in the `docs/en/tutorial.md` file, at "4. Create a Dictionary" step 7,  the current docs state ```The result looks like the following, and notice there are quite a few trips where the *dropoff* neighborhood is unknown``` instead of, I think, ```The result looks like the following, and notice there are quite a few trips where the *pickup* neighborhood is unknown```,

As we already know the dropoff which are either `dropoff_nyct2010_gid = 132` or `dropoff_nyct2010_gid = 138` and we're looking at the pickup locations for these two dropoff with ```dictGetOrDefault('taxi_zone_dictionary','Borough', toUInt64(pickup_nyct2010_gid), 'Unknown')``` which set to 'Unknown' the pickup Borough if the given pickup id `pickup_nyct2010_gid` isn't found in the dictionary.

