### PR TITLE
Update kinesis secure role setup to include ListStreams as a separate section of the policy with an allow all

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/secure-kinesis.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/secure-kinesis.md
@@ -68,12 +68,18 @@ IAM policy (Please replace {STREAM_NAME} with your kinesis stream name):
                 "kinesis:DescribeStream",
                 "kinesis:GetShardIterator",
                 "kinesis:GetRecords",
-                "kinesis:ListStreams"
                 "kinesis:ListShards"
             ],
             "Resource": [
                 "arn:aws:kinesis:region:account-id:stream/{STREAM_NAME}"
             ],
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "kinesis:ListStreams"
+            ],
+            "Resource": "*",
             "Effect": "Allow"
         }
     ]


### PR DESCRIPTION
ListStreams unfortunately does not work without a `*` on the streams ([aws docs](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html#kinesis-using-iam-examples)). Adding this to our iam policy docs to avoid future confusion for customers.