### PR TITLE
Update the java client documentation

### DIFF
--- a/docs/en/integrations/language-clients/java/index.md
+++ b/docs/en/integrations/language-clients/java/index.md
@@ -82,7 +82,7 @@ Since version `0.5.0`, the driver uses a new client http library that needs to b
 - `tcp://localhost?!auto_discovery#experimental),(grpc://localhost#experimental)?failover=3#test`
 
 
-Connect to cluster with multiple nodes:
+Connect to a cluster with multiple nodes:
 
 ```java
 ClickHouseNodes servers = ClickHouseNodes.of(
@@ -110,10 +110,10 @@ The client will by default use LZ4 compression, which requires this dependency:
 
 You can choose to use gzip instead by setting `compress_algorithm=gzip` in the connection URL.
 
-Alternatively you can disable compression a few ways.
+Alternatively, you can disable compression a few ways.
 
 1. Disable by setting `compress=0` in the connection URL: `http://localhost:8123/default?compress=0`
-2. Disable via the client configuration
+2. Disable via the client configuration:
 
 ```java
 ClickHouseClient client = ClickHouseClient.builder()


### PR DESCRIPTION
While approaching using the client for the first time, I encountered a few things that took me a while to sort out, so I wanted to contribute to the docs so it might be more clear. 

I also came across other related issues where others discuss these same issues: 
* https://github.com/ClickHouse/clickhouse-java/issues/1510
* https://github.com/ClickHouse/clickhouse-java/issues/1317

What I changed in this PR:

* I added another example for how to connect to a cluster with a single node using a connection string that doesn't include the `jdbc:ch` prefix. I had originally tried copying the example code with that included and got all kinds of errors with using the `jdbc:ch:http://server1.domain` format. I am not sure if the original code is correct or not, but if someone can help me confirm i can either leave it or update it if it needs changing
* I added a section about the LZ4 dependency, showing how to add it or how to work around it. This tripped me up for a bit figuring out how to change/disable it.
* I updated the `limit` syntax in the queries. I couldn't get the syntax in the examples to work with the limit in parenthesis. 

I am new to using this client, so I apologize if I'm misunderstanding something or missing something obvious. I think these additions might make it easier for others who try to use the example code snippets as a starting point.