### PR TITLE
docs: Add a warning for users upgrading to 22.12

### DIFF
--- a/docs/en/whats-new/changelog/2022.md
+++ b/docs/en/whats-new/changelog/2022.md
@@ -7,6 +7,14 @@ title: 2022 Changelog
 
 ### <a id="2212"></a> ClickHouse release 22.12, 2022-12-15
 
+:::warning
+
+This release contains a faulty systemd service comment that might break the ClickHouse installation on upgrade for some Linux distributions. The systemd service changes the directory owner permissions on `/run/systemd`, causing all subsequent systemd operations to fail. It is advised that you skip upgrading to this version and instead upgrade to a newer version of ClickHouse.
+
+Refer to this issue on GitHub for more details: https://github.com/ClickHouse/ClickHouse/issues/48285
+
+:::
+
 #### Upgrade Notes
 * Fixed backward incompatibility in (de)serialization of states of `min`, `max`, `any*`, `argMin`, `argMax` aggregate functions with `String` argument. The incompatibility affects 22.9, 22.10 and 22.11 branches (fixed since 22.9.6, 22.10.4 and 22.11.2 correspondingly). Some minor releases of 22.3, 22.7 and 22.8 branches are also affected: 22.3.13...22.3.14 (fixed since 22.3.15), 22.8.6...22.8.9 (fixed since 22.8.10), 22.7.6 and newer (will not be fixed in 22.7, we recommend upgrading from 22.7.* to 22.8.10 or newer). This release note does not concern users that have never used affected versions. Incompatible versions append an extra `'\0'` to strings when reading states of the aggregate functions mentioned above. For example, if an older version saved state of `anyState('foobar')` to `state_column` then the incompatible version will print `'foobar\0'` on `anyMerge(state_column)`. Also incompatible versions write states of the aggregate functions without trailing `'\0'`. Newer versions (that have the fix) can correctly read data written by all versions including incompatible versions, except one corner case. If an incompatible version saved a state with a string that actually ends with null character, then newer version will trim trailing `'\0'` when reading state of affected aggregate function. For example, if an incompatible version saved state of `anyState('abrac\0dabra\0')` to `state_column` then newer versions will print `'abrac\0dabra'` on `anyMerge(state_column)`. The issue also affects distributed queries when an incompatible version works in a cluster together with older or newer versions. [#43038](https://github.com/ClickHouse/ClickHouse/pull/43038) ([Alexander Tokmakov](https://github.com/tavplubix), [Raúl Marín](https://github.com/Algunenano)). Note: all the official ClickHouse builds already include the patches. This is not necessarily true for unofficial third-party builds that should be avoided.
 


### PR DESCRIPTION
A faulty systemd service comment may cause upgrade issues on some Linux distributions, where the `/run/systemd` directory permissions are changed to the `clickhouse` user and group, causing all systemd operations to fail after upgrade.

See: https://github.com/ClickHouse/ClickHouse/issues/65862