### PR TITLE
Add note about S3 virtual columns for clickpipes and integrations

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
@@ -44,6 +44,10 @@ You have familiarized yourself with the [ClickPipes intro](./index.md).
 
   ![Use and existing table](./images/cp_step4b.png)
 
+:::info
+You can also map [virtual columns](../../sql-reference/table-functions/s3#virtual-columns), like `_path` or `_size`, to fields.
+:::
+
 8. Finally, you can configure permissions for the internal clickpipes user.
 
   **Permissions:** ClickPipes will create a dedicated user for writing data into a destination table. You can select a role for this internal user using a custom role or one of the predefined role:

--- a/docs/en/integrations/data-ingestion/s3/index.md
+++ b/docs/en/integrations/data-ingestion/s3/index.md
@@ -91,9 +91,9 @@ Note the use of [partitioning](/docs/en/engines/table-engines/mergetree-family/c
 
 Each entry in our taxi dataset contains a taxi trip. This anonymized data consists of 20M records compressed in the S3 bucket https://datasets-documentation.s3.eu-west-3.amazonaws.com/ under the folder **nyc-taxi**. The data is in the TSV format with approximately 1M rows per file.
 
-### Reading Data from s3
+### Reading Data from S3
 
-We can query s3 data as a source without requiring persistence in ClickHouse.  In the following query, we sample 10 rows. Note the absence of credentials here as the bucket is publicly accessible:
+We can query S3 data as a source without requiring persistence in ClickHouse.  In the following query, we sample 10 rows. Note the absence of credentials here as the bucket is publicly accessible:
 
 ```sql
 SELECT *
@@ -103,7 +103,7 @@ LIMIT 10;
 
 Note that we are not required to list the columns since the `TabSeparatedWithNames` format encodes the column names in the first row. Other formats, such as `CSV` or `TSV`, will return auto-generated columns for this query, e.g., `c1`, `c2`, `c3` etc.
 
-Queries additionally support the virtual columns `_path` and `_file` that provide information regarding the bucket path and filename respectively. For example:
+Queries additionally support [virtual columns](../sql-reference/table-functions/s3#virtual-columns), like `_path` and `_file`, that provide information regarding the bucket path and filename respectively. For example:
 
 ```sql
 SELECT  _path, _file, trip_id


### PR DESCRIPTION
Virtual columns are supported in ClickPipes, so added a callout about this with a link to the list of virtual columns.
S3 Integration already mentioned it, but this adds a link to the page so it's more discoverable what virtual columns are available.