### PR TITLE
Update clickpipes object storage limitations

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
@@ -101,7 +101,7 @@ Materialized views created while an Object Storage ClickPipe is running will not
 For best results, we recommend stopping the pipe, creating the materialized views, and then restarting the pipe.
 
 ## Limitations
-
+- Any changes to the destination table, its materialized views (including cascading materialized views), or the materialized view's target tables won't be picked up automatically by the pipe and can result in errors. For best results, we recommend stopping the pipe, making the necessary modifications, and then restarting the pipe.
 - Role authentication is not available for S3 ClickPipes for ClickHouse Cloud instances deployed into GCP or Azure. It is only supported for AWS ClickHouse Cloud instances.
 - ClickPipes will only attempt to ingest objects at 1GB or smaller in size. If a file is greater than 1 GB an error will be appended to the ClickPipes dedicated error table.
 - S3 / GCS ClickPipes **does not** share a listing syntax with the [S3 Table Function](https://clickhouse.com/docs/en/sql-reference/table-functions/file#globs_in_path).
@@ -141,7 +141,3 @@ The Service Account permissions attached to the HMAC credentials should be `stor
 - **Does ClickPipes support GCS buckets prefixed with `gs://`?**
 
 No. For interoprability reasons we ask you to replace your `gs://` bucket prefix with `https://storage.googleapis.com/`.
-
-- **When will continuous ingestion be available?**
-
-Continuous ingestion is being actively developed and is available to select number of customers for feedback. It will be available to all customers in due course.


### PR DESCRIPTION
Add a note about modifications to destination table and materialized views.
In addition, remove FAQ about continuous ingest as it's already available.