### PR TITLE
Update security-changelog.md

### DIFF
--- a/docs/en/whats-new/security-changelog.md
+++ b/docs/en/whats-new/security-changelog.md
@@ -6,6 +6,18 @@ sidebar_label: Security Changelog
 
 # Security Changelog
 
+## Fixed in ClickHouse v24.5, 2024-06-01 {#fixed-in-clickhouse-release-2024-06-01}
+
+### [CVE-2024-6873](https://github.com/ClickHouse/ClickHouse/security/advisories/GHSA-432f-r822-j66f) {#CVE-2024-6873}
+
+It is possible to redirect the execution flow of the ClickHouse server process from an unauthenticated vector by sending a specially crafted request to the ClickHouse server native interface. This redirection is limited to what is available within a 256-byte range of memory at the time of execution. This vulnerability was identified through our Bugbounty program and no known Proof of Concept Remote Code Execution (RCE) code has been produced or exploited.
+
+Fix has been pushed to the following open-source versions: v23.8.15.35-lts, v24.3.4.147-lts, v24.4.2.141-stable, v24.5.1.1763, v24.6.1.4423-stable
+
+ClickHouse Cloud uses different versioning and a fix for this vulnerability was applied to all instances running v24.2 onward.
+
+Credits:  malacupa (Independent researcher)
+
 ## Fixed in ClickHouse v24.1, 2024-01-30 {#fixed-in-clickhouse-release-24-01-30}
 
 ### [CVE-2024-22412](https://github.com/ClickHouse/ClickHouse/security/advisories/GHSA-45h5-f7g3-gr8r) {#CVE-2024-22412}


### PR DESCRIPTION
Releasing the lastest CVE after the end of embargo notification. 

CVE published through CNA program - https://www.cve.org/CVERecord?id=CVE-2024-6873