### PR TITLE
Fix heading of airbyte-and-clickhouse.md page

### DIFF
--- a/docs/en/integrations/data-ingestion/etl-tools/airbyte-and-clickhouse.md
+++ b/docs/en/integrations/data-ingestion/etl-tools/airbyte-and-clickhouse.md
@@ -6,11 +6,11 @@ slug: /en/integrations/airbyte
 description: Stream data into ClickHouse using Airbyte data pipelines
 ---
 
+# Connect Airbyte to ClickHouse
+
 :::note
 Please note that the Airbyte source and destination for ClickHouse are currently in Alpha status and not suitable for moving large datasets (> 10 million rows)
 :::
-
-# Connect Airbyte to ClickHouse
 
 <a href="https://www.airbyte.com/" target="_blank">Airbyte</a> is an open-source data integration platform. It allows the creation of <a href="https://airbyte.com/blog/why-the-future-of-etl-is-not-elt-but-el" target="_blank">ELT</a> data pipelines and is shipped with more than 140 out-of-the-box connectors. This step-by-step tutorial shows how to connect Airbyte to ClickHouse as a destination and load a sample dataset.
 


### PR DESCRIPTION
The "note" should not be before the header because it messes up the page title. This fixes it.