### PR TITLE
Fix spelling of custom SQL console roles

### DIFF
--- a/docs/en/cloud/security/cloud-access-management.md
+++ b/docs/en/cloud/security/cloud-access-management.md
@@ -98,8 +98,8 @@ GRANT DELETE ON * TO database_developer;
 2. Create a role for the SQL console user my.user@domain.com and assign it the database_developer role.
 
 ```
-CREATE ROLE OR REPLACE `sql_console_role:my.user@domain.com`;
-GRANT database_developer TO `sql_console_role:my.user@domain.com`;
+CREATE ROLE OR REPLACE `sql-console-role:my.user@domain.com`;
+GRANT database_developer TO `sql-console-role:my.user@domain.com`;
 ```
 
 When using this role construction, the query to show user access needs to be modified to include the role-to-role grant when the user is not present.


### PR DESCRIPTION
`sql_console_role:...` doesn't work, it should be `sql-console-role:...`.