### PR TITLE
Add release notes section for cloud

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -670,7 +670,23 @@ const sidebars = {
         "en/cloud/reference/architecture",
         "en/cloud/reference/shared-merge-tree",
         "en/cloud/reference/compute-compute-separation",
-        "en/cloud/reference/changelog",
+        {
+          type: "category",
+          label: "Changelogs",
+          collapsed: true,
+          items: [
+            "en/cloud/reference/changelog",
+            {
+              type: "category",
+              label: "Release Notes",
+              collapsed: true,
+              items: [
+                "en/cloud/changelogs/changelog-24-6",
+                "en/cloud/changelogs/changelog-24-5"
+              ]
+            }
+          ],
+        },
         "en/cloud/reference/cloud-compatibility",
         "en/cloud/reference/supported-regions",
       ],


### PR DESCRIPTION
## Summary
Add release notes section for cloud

<img width="299" alt="Screenshot 2024-08-15 at 10 24 42 AM" src="https://github.com/user-attachments/assets/3fca8957-4b57-4984-b5e3-2ae915706ee6">


## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
