### PR TITLE
Disable compress_primary_key in the sparse primary indexes introduction

### DIFF
--- a/docs/en/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/en/guides/best-practices/sparse-primary-indexes.md
@@ -164,7 +164,7 @@ ENGINE = MergeTree
 // highlight-next-line
 PRIMARY KEY (UserID, URL)
 ORDER BY (UserID, URL, EventTime)
-SETTINGS index_granularity = 8192, index_granularity_bytes = 0;
+SETTINGS index_granularity = 8192, index_granularity_bytes = 0, compress_primary_key = 0;
 ```
 
 [//]: # (<details open>)
@@ -189,6 +189,9 @@ In order to simplify the discussions later on in this guide, as well as  make th
 <li>if n is less than 8192 and the size of the combined row data for that n rows is larger than or equal to 10 MB (the default value for index_granularity_bytes) or</li>
 <li>if the combined row data size for n rows is less than 10 MB but n is 8192.</li>
 </ul>
+</li>
+<br/>
+<li>`compress_primary_key`: set to 0 to disable <a href="https://github.com/ClickHouse/ClickHouse/issues/34437" target="_blank">compression of the primary index</a>. This will allow us to optionally inspect its contents later.
 </li>
 </ul>
 </ul>
@@ -917,7 +920,7 @@ ENGINE = MergeTree
 // highlight-next-line
 PRIMARY KEY (URL, UserID)
 ORDER BY (URL, UserID, EventTime)
-SETTINGS index_granularity = 8192, index_granularity_bytes = 0;
+SETTINGS index_granularity = 8192, index_granularity_bytes = 0, compress_primary_key = 0;
 ```
 
 Insert all 8.87 million rows from our [original table](#a-table-with-a-primary-key) into the additional table:


### PR DESCRIPTION
## Summary
Inspecting the primary index file (an optional part of this guide) only works if it's not compressed. Compression was enabled by default in https://github.com/ClickHouse/ClickHouse/pull/42587, so these instructions currently don't work easily.

To "fix" this we could:
1. **Either:** Disable `compress_primary_key` on the relevant DDL queries. This PR proposes this approach.
2. **Or:** Include a note in the expandable optional instructions "Inspecting the content of the primary index", explaining that for these instructions to work, the tables will need to be recreated with `compress_primary_key = 0`. I'm open to this (and it's not too hard) but thought it might be more cumbersome for readers.

Or perhaps there is a way to modify the instructions to inspect the primary index file to decompress it in the `file()` function, but I couldn't figure it out. If this can be done, perhaps this is preferred.

I'm open to any other suggestions here — just wanted to put something concrete on the table to potentially ease this for future readers.

## Checklist
[all items in checklist are not relevant to this PR]
