### PR TITLE
minor fixes to documentation around setting up TLS

### DIFF
--- a/docs/en/guides/sre/configuring-ssl.md
+++ b/docs/en/guides/sre/configuring-ssl.md
@@ -66,9 +66,9 @@ Using self-signed certificates are for demonstration purposes only and should no
 
 5. Using the CSR and CA, create new certificate and key pairs:
     ```bash
-    openssl x509 -req -in chnode1.csr -out chnode1.crt -CAcreateserial -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
-    openssl x509 -req -in chnode2.csr -out chnode2.crt -CAcreateserial -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
-    openssl x509 -req -in chnode3.csr -out chnode3.crt -CAcreateserial -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
+    openssl x509 -req -in chnode1.csr -out chnode1.crt -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365 -copy_extensions copy
+    openssl x509 -req -in chnode2.csr -out chnode2.crt -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365 -copy_extensions copy
+    openssl x509 -req -in chnode3.csr -out chnode3.crt -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365 -copy_extensions copy
     ```
 
 6. Verify the certs for subject and issuer:

--- a/docs/en/guides/sre/user-management/ssl-user-auth.md
+++ b/docs/en/guides/sre/user-management/ssl-user-auth.md
@@ -39,11 +39,11 @@ This example uses self-signed certificates with a self-signed CA. For production
 
 2.  Generate and sign the new user certificate that will be used for authentication. The basic format is the following:
     ```bash
-    openssl x509 -req -in <my_cert_name>.csr -out <my_cert_name>.crt -CAcreateserial -CA <my_ca_cert>.crt -CAkey <my_ca_cert>.key -days 365
+    openssl x509 -req -in <my_cert_name>.csr -out <my_cert_name>.crt -CA <my_ca_cert>.crt -CAkey <my_ca_cert>.key -days 365
     ```
     In this example, we'll use this for the domain and user that will be used in this sample environment:
     ```bash
-    openssl x509 -req -in chnode1_cert_user.csr -out chnode1_cert_user.crt -CAcreateserial -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
+    openssl x509 -req -in chnode1_cert_user.csr -out chnode1_cert_user.crt -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
     ```
 
 ## 2. Create a SQL user and grant permissions


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

1. `-CAcreateserial` isn't recommended by OpenSSL docs anymore:
```If the -CA option is specified and neither <-CAserial> or <-CAcreateserial> is given and the default serial number file does not exist, a random number is generated; this is the recommended practice.```
2. Need to specify `-copy_extensions copy` otherwise the `subjectAltName` in the CSR isn't added to the certificate.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
