### PR TITLE
[Docs] Fix python install chdb misspell

### DIFF
--- a/docs/en/chdb/install/python.md
+++ b/docs/en/chdb/install/python.md
@@ -51,7 +51,7 @@ You can execute SQL and return desired format data.
 
 ```python
 import chdb
-res = chdb.query('select version()', 'Pretty'; print(res)
+res = chdb.query('select version()', 'Pretty'); print(res)
 ```
 
 **Work with Parquet or CSV**


### PR DESCRIPTION
## Summary
Tiny python misspell fix.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
