### PR TITLE
Corrects direct link url for multi-org SSO.

### DIFF
--- a/docs/en/cloud/security/saml-sso-setup.md
+++ b/docs/en/cloud/security/saml-sso-setup.md
@@ -263,7 +263,7 @@ ClickHouse Cloud currently implements SAML for SSO. We have not yet implemented 
 
 ### Multi-Org SSO
 
-ClickHouse Cloud supports multi-organization SSO by providing a separate connection for each organization. Use the direct link (`https://console.clickhouse.cloud?organization={organizationid}`) to log in to each respective organziation. Be sure to log out of one organization before logging into another.
+ClickHouse Cloud supports multi-organization SSO by providing a separate connection for each organization. Use the direct link (`https://console.clickhouse.cloud?connection={organizationid}`) to log in to each respective organziation. Be sure to log out of one organization before logging into another.
 
 ## Additional Information
 


### PR DESCRIPTION
## Summary
This corrects the direct link url for multi-org SSO setup per this case:
https://clickhouse.lightning.force.com/lightning/r/Case/500Uy00000GP2f1IAD/view

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
