### PR TITLE
Clickpipe staging tables are not visible when using cloud SQL Console

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
@@ -124,6 +124,9 @@ ClickPipes supports continuous ingestion from both S3 and GCS. When enabled, Cli
 ## Archive table
 ClickPipes will create a table next to your destination table with the postfix `s3_clickpipe_<clickpipe_id>_archive`. This table will contain a list of all the files that have been ingested by the ClickPipe. This table is used to track files during ingestion and can be used to verify files have been ingested. The archive table has a [TTL](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl) of 7 days.
 
+:::note
+These tables will not be visible using ClickHouse Cloud SQL Console, you will need to connect via an external client either using HTTPS or Native connection to read them.
+
 ## Authentication
 
 ### S3


### PR DESCRIPTION
## Summary
Updates `clickpipe_*` staging table docs, clarifying that tables are not visibile using ClickHouse Cloud SQL Console. 
