### PR TITLE
Update CHJS docs, change the CHJS slug

### DIFF
--- a/docs/en/integrations/language-clients/js.md
+++ b/docs/en/integrations/language-clients/js.md
@@ -2,7 +2,7 @@
 sidebar_label: JavaScript
 sidebar_position: 4
 keywords: [clickhouse, js, javascript, nodejs, web, browser, cloudflare, workers, client, connect, integrate]
-slug: /en/integrations/language-clients/javascript
+slug: /en/integrations/javascript
 description: The official JS client for connecting to ClickHouse.
 ---
 import ConnectionDetails from '@site/docs/en/_snippets/_gather_your_details_http.mdx';
@@ -33,7 +33,7 @@ Current Node.js versions support:
 
 | Node.js version | Supported?  |
 |-----------------|-------------|
-| 21.x            | ✔           |
+| 22.x            | ✔           |
 | 20.x            | ✔           |
 | 18.x            | ✔           |
 | 16.x            | Best effort |
@@ -60,7 +60,7 @@ npm i @clickhouse/client-web
 
 | Client version | ClickHouse |
 |----------------|------------|
-| 1.2.0          | 23.3+      |
+| 1.5.0          | 23.3+      |
 
 Likely, the client will work with the older versions, too; however, this is best-effort support and is not guaranteed. If you have ClickHouse version older than 23.3, please refer to [ClickHouse security policy](https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md) and consider upgrading.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ export const ConnectToClickHouse = ({ children, color}) => {
                 <div className='home-page-button-container'>
                     <HomePageOptionButton svgIcon={<IconTerminal iconWidth='28px' />} link='/docs/en/integrations/sql-clients/clickhouse-client-local'>ClickHouse CLI</HomePageOptionButton>
                     <HomePageOptionButton svgIcon={<IconSQLConsole iconWidth='28px' />} link='/docs/en/get-started/sql-console'>Cloud SQL Console</HomePageOptionButton>
-                    <HomePageOptionButton icon='/docs/images/logo-nodejs.svg' link='/docs/en/integrations/language-clients/javascript'>Node.js</HomePageOptionButton>
+                    <HomePageOptionButton icon='/docs/images/logo-nodejs.svg' link='/docs/en/integrations/javascript'>Node.js</HomePageOptionButton>
                 </div>
                 <div className='home-page-button-container'>
                     <HomePageOptionButton icon='/docs/images/logo-java.svg' link='/docs/en/integrations/java'>Java</HomePageOptionButton>


### PR DESCRIPTION
## Summary
Changes the JS client slug from `/en/integrations/language-clients/javascript` to just `/en/integrations/javascript`, bumps versions in a few places.