### PR TITLE
Update default GitHub star count

### DIFF
--- a/plugins/header.js
+++ b/plugins/header.js
@@ -14,7 +14,7 @@ async function chHeader(context, opts) {
         'https://api.github.com/repos/ClickHouse/ClickHouse'
       )
       const data = await githubData.json()
-      const stars = data?.stargazers_count ?? 28203
+      const stars = data?.stargazers_count ?? 36500
       return {
         github: {
           stars


### PR DESCRIPTION
## Summary
Update default GitHub star count in case of failed rate limits

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
