### PR TITLE
Fix incorrect categorization as database engines

### DIFF
--- a/docs/en/cloud/reference/cloud-compatibility.md
+++ b/docs/en/cloud/reference/cloud-compatibility.md
@@ -47,8 +47,6 @@ ClickHouse Cloud provides a highly-available, replicated service by default. As 
   - ReplacingMergeTree (converted to ReplicatedReplacingMergeTree)
   - CollapsingMergeTree (converted to ReplicatedCollapsingMergeTree)
   - VersionedCollapsingMergeTree (converted to ReplicatedVersionedCollapsingMergeTree)
-  
-**Supported Database Engines**
   - URL
   - View
   - MaterializedView


### PR DESCRIPTION
## Summary
Fix incorrect categorization as database engines

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
