### PR TITLE
More explicit mention about object storage pipes and MVs

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
@@ -96,6 +96,8 @@ To increase the throughput on large ingest jobs, we recommend scaling the ClickH
 
 ## Materialized Views
 
+Object Storage ClickPipes with materialized views require `Full access` permissions to be selected when created. If this is not possible, ensure that the role used by the pipe can create tables and materialized views in the destination database.
+
 Materialized views created while an Object Storage ClickPipe is running will not be populated. Stopping and restarting the pipe will cause the pipe to pick up the materialized views and start populating them. See [Limitations](#limitations) below.
 
 ## Limitations


### PR DESCRIPTION
## Summary

The mention of "Full access" permissions needed for materialized views is a bit hidden under the whole setup instructions with screenshots and is very easy to miss.

This adds a note under "Materialized Views" section to be explicit about the permissions needed, or a workaround with roles.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
