### PR TITLE
Fix azure event hubs port

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/kafka.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/kafka.md
@@ -268,7 +268,7 @@ ClickPipes for Kafka is designed to scale horizontally. By default, we create a 
 
 - **Should I include the port number for Azure Event Hubs?**
 
-  Yes. ClickPipes expects you to include your port number for the Kafka surface, which should be `:8083`.
+  Yes. ClickPipes expects you to include your port number for the Kafka surface, which should be `:9093`.
 
 - **Are the ClickPipes IPs still relevant for Azure Event Hubs?**
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

The port is wrong in the docs

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
