### PR TITLE
Warn about Datadog Custom Metrics

### DIFF
--- a/docs/en/integrations/prometheus.md
+++ b/docs/en/integrations/prometheus.md
@@ -240,7 +240,7 @@ Note the `honor_labels` configuration parameter needs to be set to `true` for th
 
 ## Integrating with Datadog
 
-You can use the Datadog [Agent](https://docs.datadoghq.com/agent/?tab=Linux) and [OpenMetrics integration](https://docs.datadoghq.com/integrations/openmetrics/) to collect metrics from the ClickHouse Cloud endpoint. Below is a simple example configuration for this agent and integration.
+You can use the Datadog [Agent](https://docs.datadoghq.com/agent/?tab=Linux) and [OpenMetrics integration](https://docs.datadoghq.com/integrations/openmetrics/) to collect metrics from the ClickHouse Cloud endpoint. Below is a simple example configuration for this agent and integration. Please note though that you may want to select only those metrics that you care about the most. The catchall example below will export many thousands of metric-instance combinations which Datadog will treat as custom metrics.
 
 ```yaml
 init_config:

--- a/docs/en/integrations/prometheus.md
+++ b/docs/en/integrations/prometheus.md
@@ -240,7 +240,7 @@ Note the `honor_labels` configuration parameter needs to be set to `true` for th
 
 ## Integrating with Datadog
 
-You can use the Datadog [Agent](https://docs.datadoghq.com/agent/?tab=Linux) and [OpenMetrics integration](https://docs.datadoghq.com/integrations/openmetrics/) to collect metrics from the ClickHouse Cloud endpoint. Below is a simple example configuration for this agent and integration. Please note though that you may want to select only those metrics that you care about the most. The catchall example below will export many thousands of metric-instance combinations which Datadog will treat as custom metrics.
+You can use the Datadog [Agent](https://docs.datadoghq.com/agent/?tab=Linux) and [OpenMetrics integration](https://docs.datadoghq.com/integrations/openmetrics/) to collect metrics from the ClickHouse Cloud endpoint. Below is a simple example configuration for this agent and integration. Please note though that you may want to select only those metrics that you care about the most. The catch-all example below will export many thousands of metric-instance combinations which Datadog will treat as custom metrics.
 
 ```yaml
 init_config:


### PR DESCRIPTION
## Summary
There are 1410 `TYPE Clickhouse` matches in my endpoint's output, which would make it 4230 custom metrics which could end up costing some $200 a month or more.  It seems wise to alert people to this, so they can decide for themselves whether it is worth it.




