### PR TITLE
fix(docs): Update InsertSettings configuration methods

### DIFF
--- a/docs/en/integrations/language-clients/java/client-v2.md
+++ b/docs/en/integrations/language-clients/java/client-v2.md
@@ -255,16 +255,13 @@ Configuration options for insert operations.
 
 <dl>
   <dt>setQueryId(String queryId)</dt>
-  <dd>Sets query ID that will be assigned to the operation</dd>
+  <dd>Sets query ID that will be assigned to the operation. Default: null</dd>
 
   <dt>setDeduplicationToken(String token)</dt>
-  <dd>Sets the deduplication token. This token will be sent to the server and can be used to identify the query.</dd>
-
-  <dt>waitEndOfQuery(Boolean waitEndOfQuery)</dt>
-  <dd>Requests the server to wait for the and of the query before sending response.</dd>
+  <dd>Sets the deduplication token. This token will be sent to the server and can be used to identify the query. Default: null</dd>
 
   <dt>setInputStreamCopyBufferSize(int size)</dt>
-  <dd>Copy buffer size. The buffer is used during write operations to copy data from user provided input stream to an output stream.</dd>
+  <dd>Copy buffer size. The buffer is used during write operations to copy data from user provided input stream to an output stream. Default: 8196</dd>
 </dl>
 
 ### InsertResponse 


### PR DESCRIPTION
## Summary
Removes `waitEndOfQuery`, which is only applicable to `QuerySettings`.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
