### PR TITLE
Remove MySQL binlog settings in sidebars

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1023,7 +1023,7 @@ const sidebars = {
         // "en/operations/settings/settings-formats",
         "en/operations/settings/memory-overcommit",
         "en/operations/settings/merge-tree-settings",
-        "en/operations/settings/mysql-binlog-client",
+        // "en/operations/settings/mysql-binlog-client",
         "en/operations/settings/permissions-for-queries",
         "en/operations/settings/query-complexity",
         "en/operations/settings/settings-query-level",


### PR DESCRIPTION
## Summary
Remove MySQL binlog settings in sidebars

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
