### PR TITLE
Remove duplicate sidebar link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1007,7 +1007,6 @@ const sidebars = {
         "en/guides/troubleshooting",
         "en/operations/tips",
         "en/sql-reference/distributed-ddl",
-        "en/sql-reference/distributed-ddl",
       ],
     },
     {


### PR DESCRIPTION
## Summary
Remove duplicate sidebar link

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
