### PR TITLE
Remove unnecessary ClickPipes FAQ question

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/index.md
@@ -70,10 +70,6 @@ If ClickPipes cannot connect to a data source or destination after 15min., Click
 
   ClickPipes is a ClickHouse Cloud feature that makes it easy for users to connect their ClickHouse services to external data sources, specifically Kafka. With ClickPipes for Kafka, users can easily continuously load data into ClickHouse, making it available for real-time analytics.
 
-- **What types of data sources does ClickPipes support?**
-
-  Currently, ClickPipes supports Confluent Cloud, AWS MSK, and Apache Kafka as data sources. However, we are committed to expand our support for more data sources in the future. Don't hesitate to [contact us](https://clickhouse.com/company/contact?loc=clickpipes) if you want to know more.
-
 - **Does ClickPipes support data transformation?**
 
   Yes, ClickPipes supports basic data transformation by exposing the DDL creation. You can then apply more advanced transformations to the data as it is loaded into its destination table in a ClickHouse Cloud service leveraging ClickHouse's [materialized views feature](https://clickhouse.com/docs/en/guides/developer/cascading-materialized-views).


### PR DESCRIPTION
## Summary
Remove unnecessary ClickPipes FAQ question. There's a table above in the page that already shows the supported data sources.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
