### PR TITLE
Add note on API permission scope.

### DIFF
--- a/docs/en/cloud/manage/openapi.md
+++ b/docs/en/cloud/manage/openapi.md
@@ -22,7 +22,7 @@ This document covers the ClickHouse Cloud API. For database API endpoints, pleas
   
 3. To create an API key, specify the key name, permissions for the key, and expiration time, then click `Generate API Key`.
 :::note
-Permissions align with ClickHouse Cloud [predefined roles](https://clickhouse.com/docs/en/cloud/security/cloud-access-management#predefined-roles). The developer role has read-only permissions and the admin role has full read and write permissions.
+Permissions align with ClickHouse Cloud [predefined roles](/en/cloud/security/cloud-access-management#predefined-roles). The developer role has read-only permissions and the admin role has full read and write permissions.
 :::
 
   ![Create API Key](@site/docs/en/_snippets/images/openapi3.png)

--- a/docs/en/cloud/manage/openapi.md
+++ b/docs/en/cloud/manage/openapi.md
@@ -21,6 +21,9 @@ This document covers the ClickHouse Cloud API. For database API endpoints, pleas
   ![Initial API Screen](@site/docs/en/_snippets/images/openapi2.png) 
   
 3. To create an API key, specify the key name, permissions for the key, and expiration time, then click `Generate API Key`.
+:::note
+Permissions align with ClickHouse Cloud [predefined roles](https://clickhouse.com/docs/en/cloud/security/cloud-access-management#predefined-roles). The developer role has read-only permissions and the admin role has full read and write permissions.
+:::
 
   ![Create API Key](@site/docs/en/_snippets/images/openapi3.png)
   


### PR DESCRIPTION
## Summary
This adds a note to the Managing API Keys page to clarify what permissions the `developer` and `admin` API roles have.
A customer wanted clarification on this.

`/en/cloud/manage/openapi`

<img width="878" alt="Screenshot 2024-10-31 at 10 21 57 AM" src="https://github.com/user-attachments/assets/2f4d7899-9cba-41e4-9d70-3a548c5d4875">
