### PR TITLE
Add Java links to sidebar

### DIFF
--- a/docs/en/integrations/language-clients/java/index.md
+++ b/docs/en/integrations/language-clients/java/index.md
@@ -1,6 +1,5 @@
 ---
-sidebar_label: Java
-sidebar_position: 1
+title: Java
 keywords: [clickhouse, java, jdbc, client, integrate, r2dbc]
 description: Options for connecting to ClickHouse from Java
 slug: /en/integrations/java

--- a/sidebars.js
+++ b/sidebars.js
@@ -654,7 +654,7 @@ const sidebars = {
       ],
     },
     {
-          type: "category",
+      type: "category",
       label: "Clients and Drivers",
       collapsed: false,
       collapsible: false,
@@ -665,22 +665,26 @@ const sidebars = {
         "en/integrations/sql-clients/sql-console",
         "en/getting-started/playground",
         "en/integrations/language-clients/js",
-        "en/integrations/language-clients/java/index",
-        "en/integrations/language-clients/python/index",
-        "en/integrations/language-clients/rust",
         {
           type: "category",
-          label: "View all languages",
+          label: "Java",
           collapsed: true,
           collapsible: true,
           items: [
-            "en/integrations/language-clients/js",
-            "en/integrations/language-clients/java/index",
-            "en/integrations/language-clients/go/index",
-            "en/integrations/language-clients/python/index",
-            "en/integrations/language-clients/rust",
-          ],
+            {
+              type: "doc",
+              label: "Overview",
+              id: "en/integrations/language-clients/java/index"
+            },
+            // "en/integrations/language-clients/java/index",
+            "en/integrations/language-clients/java/client-v2",
+            "en/integrations/language-clients/java/client-v1",
+            "en/integrations/language-clients/java/jdbc-driver",
+            "en/integrations/language-clients/java/r2dbc"
+          ]
         },
+        "en/integrations/language-clients/python/index",
+        "en/integrations/language-clients/rust",
         {
           type: "category",
           label: "Drivers and Interfaces",


### PR DESCRIPTION
## Summary
Add Java links to sidebar

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
