### PR TITLE
add table-of-content to dbt docs

### DIFF
--- a/docs/en/integrations/data-ingestion/etl-tools/dbt/index.md
+++ b/docs/en/integrations/data-ingestion/etl-tools/dbt/index.md
@@ -4,6 +4,7 @@ slug: /en/integrations/dbt
 sidebar_position: 1
 description: Users can transform and model their data in ClickHouse using dbt
 ---
+import TOCInline from '@theme/TOCInline';
 
 # Integrating dbt and ClickHouse
 
@@ -12,6 +13,8 @@ description: Users can transform and model their data in ClickHouse using dbt
 Within dbt, these models can be cross-referenced and layered to allow the construction of higher-level concepts. The boilerplate SQL required to connect models is automatically generated. Furthermore, dbt identifies dependencies between models and ensures they are created in the appropriate order using a directed acyclic graph (DAG).
 
 Dbt is compatible with ClickHouse through a [ClickHouse-supported plugin](https://github.com/ClickHouse/dbt-clickhouse). We describe the process for connecting ClickHouse with a simple example based on a publicly available IMDB dataset. We additionally highlight some of the limitations of the current connector.
+
+<TOCInline toc={toc}  maxHeadingLevel={2} />
 
 ## Concepts
 


### PR DESCRIPTION
The `dbt` doc is getting bigger, so I added this TOC to make it easier for users to navigate and consume.
Any heading above 2 on the page will be added automatically. 