### PR TITLE
Fixes link to PrivateLink Terraform example.

### DIFF
--- a/docs/en/cloud/security/aws-privatelink.md
+++ b/docs/en/cloud/security/aws-privatelink.md
@@ -19,7 +19,7 @@ Please complete the following steps to enable AWS Private Link:
 1. Add Endpoint ID to service(s) allow list.
 
 
-Find complete Terraform example for AWS Private Link [here](https://github.com/ClickHouse/terraform-provider-clickhouse/tree/main/examples/PrivateLink).
+Find complete Terraform example for AWS Private Link [here](https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/examples/resources/clickhouse_private_endpoint_registration/resource.tf).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
The AWS PrivateLink doc page links to a Terraform example and that page no longer exists. I have updated the link.
