### PR TITLE
Admonitions for `experimental` and `obsolete`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,9 @@ const config = {
 			/** @type {import('@docusaurus/preset-classic').Options} */
 			({
 				docs: {
+					admonitions: {
+						keywords: ['note', 'tip', 'info', 'caution', 'danger', 'experimental', 'obsolete']
+					},
 					sidebarPath: require.resolve('./sidebars.js'),
 					editCurrentVersion: true,
 					breadcrumbs: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,7 +51,15 @@ const config = {
 			({
 				docs: {
 					admonitions: {
-						keywords: ['note', 'tip', 'info', 'caution', 'danger', 'experimental', 'obsolete']
+						keywords: [
+							'note',
+							'tip',
+							'info',
+							'caution',
+							'danger',
+							'experimental',
+							'obsolete'
+						]
 					},
 					sidebarPath: require.resolve('./sidebars.js'),
 					editCurrentVersion: true,

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -5,79 +5,80 @@ import Translate from '@docusaurus/Translate'
 import styles from './styles.module.css'
 
 function NoteIcon () {
-  return (<svg viewBox="0 0 14 16">
+  return (
+    <svg viewBox="0 0 14 16">
       <path
         fillRule="evenodd"
         d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
       />
-    </svg>)
+    </svg>
+  )
 }
 
-function TipIcon () {
-  return (<svg viewBox="0 0 12 16">
+function TipIcon() {
+  return (
+    <svg viewBox="0 0 12 16">
       <path
         fillRule="evenodd"
         d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
       />
-    </svg>)
+    </svg>
+  );
 }
 
-function DangerIcon () {
-  return (<svg viewBox="0 0 12 16">
+function DangerIcon() {
+  return (
+    <svg viewBox="0 0 12 16">
       <path
         fillRule="evenodd"
         d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
       />
-    </svg>)
+    </svg>
+  );
 }
 
-function InfoIcon () {
-  return (<svg viewBox="0 0 14 16">
+function InfoIcon() {
+  return (
+    <svg viewBox="0 0 14 16">
       <path
         fillRule="evenodd"
         d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
       />
-    </svg>)
+    </svg>
+  );
 }
 
-function CautionIcon () {
-  return (<svg viewBox="0 0 16 16">
+function CautionIcon() {
+  return (
+    <svg viewBox="0 0 16 16">
       <path
         fillRule="evenodd"
         d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
       />
-    </svg>)
+    </svg>
+  );
 }
 
-// Custom icon for custom experimental admonition
+// Icon for custom :::experimental admonition
 function ExperimentIcon () {
-  return (<svg viewBox="0 0 20 20">
+  return (
+    <svg viewBox="0 0 20 20">
       <path
         fillRule="evenodd"
         d="M15 2a1 1 0 0 1 0 2v4.826l3.932 10.814l.034 .077a1.7 1.7 0 0 1 -.002 1.193l-.07 .162a1.7 1.7 0 0 1 -1.213 .911l-.181 .017h-11l-.181 -.017a1.7 1.7 0 0 1 -1.285 -2.266l.039 -.09l3.927 -10.804v-4.823a1 1 0 1 1 0 -2h6zm-2 2h-2v4h2v-4z"
       />
-    </svg>)
+    </svg>
+  );
 }
 
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-     viewBox="0 0 24 24" fill="none" stroke="currentColor"
-     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-     className="icon icon-tabler icons-tabler-outline icon-tabler-plug-connected-x">
-  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-  <path d="M20 16l-4 4"/>
-  <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"/>
-  <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z"/>
-  <path d="M3 21l2.5 -2.5"/>
-  <path d="M18.5 5.5l2.5 -2.5"/>
-  <path d="M10 11l-2 2"/>
-  <path d="M13 14l-2 2"/>
-  <path d="M16 16l4 4"/>
-</svg>
-
-// Custom icon for custom obsolete admonition
+// Icon for custom :::obsolete admonition
 function ObsoleteIcon () {
-  return (<svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
-               stroke-linecap="round" stroke-linejoin="round">
+  return (
+    <svg viewBox="0 0 24 24"
+         stroke="currentColor"
+         stroke-width="2"
+         stroke-linecap="round"
+         stroke-linejoin="round">
       <path d="M20 16l-4 4"/>
       <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"
             fill="none"/>
@@ -88,110 +89,153 @@ function ObsoleteIcon () {
       <path d="M10 11l-2 2"/>
       <path d="M13 14l-2 2"/>
       <path d="M16 16l4 4"/>
-    </svg>)
+    </svg>
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 const AdmonitionConfigs = {
   note: {
-    infimaClassName: 'secondary', iconComponent: NoteIcon, label: (<Translate
+    infimaClassName: 'secondary',
+    iconComponent: NoteIcon,
+    label: (
+      <Translate
         id="theme.admonition.note"
         description="The default label used for the Note admonition (:::note)">
         Note
-      </Translate>),
-  }, tip: {
-    infimaClassName: 'success', iconComponent: TipIcon, label: (<Translate
+      </Translate>
+    ),
+  },
+  tip: {
+    infimaClassName: 'success',
+    iconComponent: TipIcon,
+    label: (
+      <Translate
         id="theme.admonition.tip"
         description="The default label used for the Tip admonition (:::tip)">
         Tip
-      </Translate>),
-  }, danger: {
-    infimaClassName: 'danger', iconComponent: DangerIcon, label: (<Translate
+      </Translate>
+    ),
+  },
+  danger: {
+    infimaClassName: 'danger',
+    iconComponent: DangerIcon,
+    label: (
+      <Translate
         id="theme.admonition.danger"
         description="The default label used for the Danger admonition (:::danger)">
         Danger
-      </Translate>),
-  }, info: {
-    infimaClassName: 'info', iconComponent: InfoIcon, label: (<Translate
+      </Translate>
+    ),
+  },
+  info: {
+    infimaClassName: 'info',
+    iconComponent: InfoIcon,
+    label: (
+      <Translate
         id="theme.admonition.info"
         description="The default label used for the Info admonition (:::info)">
         Info
-      </Translate>),
-  }, caution: {
-    infimaClassName: 'warning', iconComponent: CautionIcon, label: (<Translate
+      </Translate>
+    ),
+  },
+  caution: {
+    infimaClassName: 'warning',
+    iconComponent: CautionIcon,
+    label: (
+      <Translate
         id="theme.admonition.caution"
         description="The default label used for the Caution admonition (:::caution)">
         Caution
-      </Translate>),
-  }, experimental: {
+      </Translate>
+    ),
+  },
+  experimental: {
     infimaClassName: 'experimental',
     iconComponent: ExperimentIcon,
-    label: (<Translate
+    label: (
+      <Translate
         id="theme.admonition.experimental"
         description="The default label used for the Experimental admonition (:::experimental)">
         EXPERIMENTAL
-      </Translate>),
-  }, obsolete: {
-    infimaClassName: 'obsolete', iconComponent: ObsoleteIcon, label: (<Translate
+      </Translate>
+    ),
+  },
+  obsolete: {
+    infimaClassName: 'obsolete',
+    iconComponent: ObsoleteIcon,
+    label: (
+      <Translate
         id="theme.admonition.obsolete"
         description="The default label used for the Obsolete admonition (:::obsolete)">
         OBSOLETE
-      </Translate>),
+      </Translate>
+    ),
   },
-}
+};
 // Legacy aliases, undocumented but kept for retro-compatibility
 const aliases = {
-  secondary: 'note', important: 'info', success: 'tip', warning: 'danger',
-}
-
-function getAdmonitionConfig (unsafeType) {
-  const type = aliases[unsafeType] ?? unsafeType
-  const config = AdmonitionConfigs[type]
+  secondary: 'note',
+  important: 'info',
+  success: 'tip',
+  warning: 'danger',
+};
+function getAdmonitionConfig(unsafeType) {
+  const type = aliases[unsafeType] ?? unsafeType;
+  const config = AdmonitionConfigs[type];
   if (config) {
-    return config
+    return config;
   }
   console.warn(
-    `No admonition config found for admonition type "${type}". Using Info as fallback.`)
-  return AdmonitionConfigs.info
+    `No admonition config found for admonition type "${type}". Using Info as fallback.`,
+  );
+  return AdmonitionConfigs.info;
 }
-
 // Workaround because it's difficult in MDX v1 to provide a MDX title as props
 // See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
-function extractMDXAdmonitionTitle (children) {
-  const items = React.Children.toArray(children)
+function extractMDXAdmonitionTitle(children) {
+  const items = React.Children.toArray(children);
   const mdxAdmonitionTitle = items.find(
-    (item) => React.isValidElement(item) && item.props?.mdxType ===
-      'mdxAdmonitionTitle')
-  const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>
+    (item) =>
+      React.isValidElement(item) &&
+      item.props?.mdxType === 'mdxAdmonitionTitle',
+  );
+  const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
   return {
-    mdxAdmonitionTitle, rest,
-  }
+    mdxAdmonitionTitle,
+    rest,
+  };
 }
-
-function processAdmonitionProps (props) {
-  const { mdxAdmonitionTitle, rest } = extractMDXAdmonitionTitle(props.children)
+function processAdmonitionProps(props) {
+  const {mdxAdmonitionTitle, rest} = extractMDXAdmonitionTitle(props.children);
   return {
-    ...props, title: props.title ?? mdxAdmonitionTitle, children: rest,
-  }
+    ...props,
+    title: props.title ?? mdxAdmonitionTitle,
+    children: rest,
+  };
 }
-
-export default function Admonition (props) {
-  const { children, type, title, icon: iconProp } = processAdmonitionProps(
-    props)
-  const typeConfig = getAdmonitionConfig(type)
-  const titleLabel = title ?? typeConfig.label
-  const { iconComponent: IconComponent } = typeConfig
-  const icon = iconProp ?? <IconComponent/>
-  return (<div
-      className={clsx(ThemeClassNames.common.admonition,
-        ThemeClassNames.common.admonitionType(props.type), 'alert',
-        `alert--${typeConfig.infimaClassName}`, styles.admonition)}>
+export default function Admonition(props) {
+  const {children, type, title, icon: iconProp} = processAdmonitionProps(props);
+  const typeConfig = getAdmonitionConfig(type);
+  const titleLabel = title ?? typeConfig.label;
+  const {iconComponent: IconComponent} = typeConfig;
+  const icon = iconProp ?? <IconComponent />;
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.common.admonition,
+        ThemeClassNames.common.admonitionType(props.type),
+        'alert',
+        `alert--${typeConfig.infimaClassName}`,
+        styles.admonition,
+      )}>
       <div className={clsx('alert-icon', styles.admonitionIcon)}>{icon}</div>
-      <div className={clsx('alert-content', styles.admonitionContent)}>
+      <div className={clsx('alert-content',styles.admonitionContent)}>
         <div className={styles.admonitionHeading}>
           {titleLabel}
         </div>
         {children}
       </div>
-    </div>)
+    </div>
+  );
 }

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -1,8 +1,8 @@
-import React from 'react'
-import clsx from 'clsx'
-import { ThemeClassNames } from '@docusaurus/theme-common'
-import Translate from '@docusaurus/Translate'
-import styles from './styles.module.css'
+import React from 'react';
+import clsx from 'clsx';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import Translate from '@docusaurus/Translate';
+import styles from './styles.module.css';
 
 function NoteIcon () {
   return (
@@ -12,9 +12,8 @@ function NoteIcon () {
         d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
       />
     </svg>
-  )
+  );
 }
-
 function TipIcon() {
   return (
     <svg viewBox="0 0 12 16">
@@ -25,7 +24,6 @@ function TipIcon() {
     </svg>
   );
 }
-
 function DangerIcon() {
   return (
     <svg viewBox="0 0 12 16">
@@ -36,7 +34,6 @@ function DangerIcon() {
     </svg>
   );
 }
-
 function InfoIcon() {
   return (
     <svg viewBox="0 0 14 16">
@@ -47,7 +44,6 @@ function InfoIcon() {
     </svg>
   );
 }
-
 function CautionIcon() {
   return (
     <svg viewBox="0 0 16 16">
@@ -58,7 +54,6 @@ function CautionIcon() {
     </svg>
   );
 }
-
 // Icon for custom :::experimental admonition
 function ExperimentIcon () {
   return (
@@ -70,7 +65,6 @@ function ExperimentIcon () {
     </svg>
   );
 }
-
 // Icon for custom :::obsolete admonition
 function ObsoleteIcon () {
   return (

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -3,177 +3,251 @@ import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import Translate from '@docusaurus/Translate';
 import styles from './styles.module.css';
+
 function NoteIcon() {
-  return (
-    <svg viewBox="0 0 14 16">
-      <path
-        fillRule="evenodd"
-        d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
-      />
-    </svg>
-  );
+    return (
+        <svg viewBox="0 0 14 16">
+            <path
+                fillRule="evenodd"
+                d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
+            />
+        </svg>
+    );
 }
+
 function TipIcon() {
-  return (
-    <svg viewBox="0 0 12 16">
-      <path
-        fillRule="evenodd"
-        d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
-      />
-    </svg>
-  );
+    return (
+        <svg viewBox="0 0 12 16">
+            <path
+                fillRule="evenodd"
+                d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
+            />
+        </svg>
+    );
 }
+
 function DangerIcon() {
-  return (
-    <svg viewBox="0 0 12 16">
-      <path
-        fillRule="evenodd"
-        d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
-      />
-    </svg>
-  );
+    return (
+        <svg viewBox="0 0 12 16">
+            <path
+                fillRule="evenodd"
+                d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
+            />
+        </svg>
+    );
 }
+
 function InfoIcon() {
-  return (
-    <svg viewBox="0 0 14 16">
-      <path
-        fillRule="evenodd"
-        d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
-      />
-    </svg>
-  );
+    return (
+        <svg viewBox="0 0 14 16">
+            <path
+                fillRule="evenodd"
+                d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+            />
+        </svg>
+    );
 }
+
 function CautionIcon() {
-  return (
-    <svg viewBox="0 0 16 16">
-      <path
-        fillRule="evenodd"
-        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
-      />
-    </svg>
-  );
+    return (
+        <svg viewBox="0 0 16 16">
+            <path
+                fillRule="evenodd"
+                d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+            />
+        </svg>
+    );
 }
+
+// Custom icon for custom experimental admonition
+function ExperimentIcon() {
+    return (
+        <svg viewBox="0 0 20 20">
+            <path
+                fillRule="evenodd"
+                d="M15 2a1 1 0 0 1 0 2v4.826l3.932 10.814l.034 .077a1.7 1.7 0 0 1 -.002 1.193l-.07 .162a1.7 1.7 0 0 1 -1.213 .911l-.181 .017h-11l-.181 -.017a1.7 1.7 0 0 1 -1.285 -2.266l.039 -.09l3.927 -10.804v-4.823a1 1 0 1 1 0 -2h6zm-2 2h-2v4h2v-4z"
+            />
+        </svg>
+    );
+}
+
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+     className="icon icon-tabler icons-tabler-outline icon-tabler-plug-connected-x">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 16l-4 4"/>
+    <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"/>
+    <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z"/>
+    <path d="M3 21l2.5 -2.5"/>
+    <path d="M18.5 5.5l2.5 -2.5"/>
+    <path d="M10 11l-2 2"/>
+    <path d="M13 14l-2 2"/>
+    <path d="M16 16l4 4"/>
+</svg>
+
+// Custom icon for custom obsolete admonition
+function ObsoleteIcon() {
+    return (
+        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20 16l-4 4" />
+            <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z" fill="none" />
+            <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z" fill="none" />
+            <path d="M3 21l2.5 -2.5"/>
+            <path d="M18.5 5.5l2.5 -2.5"/>
+            <path d="M10 11l-2 2"/>
+            <path d="M13 14l-2 2"/>
+            <path d="M16 16l4 4"/>
+        </svg>
+    );
+}
+
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 const AdmonitionConfigs = {
-  note: {
-    infimaClassName: 'secondary',
-    iconComponent: NoteIcon,
-    label: (
-      <Translate
-        id="theme.admonition.note"
-        description="The default label used for the Note admonition (:::note)">
-        Note
-      </Translate>
-    ),
-  },
-  tip: {
-    infimaClassName: 'success',
-    iconComponent: TipIcon,
-    label: (
-      <Translate
-        id="theme.admonition.tip"
-        description="The default label used for the Tip admonition (:::tip)">
-        Tip
-      </Translate>
-    ),
-  },
-  danger: {
-    infimaClassName: 'danger',
-    iconComponent: DangerIcon,
-    label: (
-      <Translate
-        id="theme.admonition.danger"
-        description="The default label used for the Danger admonition (:::danger)">
-        Danger
-      </Translate>
-    ),
-  },
-  info: {
-    infimaClassName: 'info',
-    iconComponent: InfoIcon,
-    label: (
-      <Translate
-        id="theme.admonition.info"
-        description="The default label used for the Info admonition (:::info)">
-        Info
-      </Translate>
-    ),
-  },
-  caution: {
-    infimaClassName: 'warning',
-    iconComponent: CautionIcon,
-    label: (
-      <Translate
-        id="theme.admonition.caution"
-        description="The default label used for the Caution admonition (:::caution)">
-        Caution
-      </Translate>
-    ),
-  },
+    note: {
+        infimaClassName: 'secondary',
+        iconComponent: NoteIcon,
+        label: (
+            <Translate
+                id="theme.admonition.note"
+                description="The default label used for the Note admonition (:::note)">
+                Note
+            </Translate>
+        ),
+    },
+    tip: {
+        infimaClassName: 'success',
+        iconComponent: TipIcon,
+        label: (
+            <Translate
+                id="theme.admonition.tip"
+                description="The default label used for the Tip admonition (:::tip)">
+                Tip
+            </Translate>
+        ),
+    },
+    danger: {
+        infimaClassName: 'danger',
+        iconComponent: DangerIcon,
+        label: (
+            <Translate
+                id="theme.admonition.danger"
+                description="The default label used for the Danger admonition (:::danger)">
+                Danger
+            </Translate>
+        ),
+    },
+    info: {
+        infimaClassName: 'info',
+        iconComponent: InfoIcon,
+        label: (
+            <Translate
+                id="theme.admonition.info"
+                description="The default label used for the Info admonition (:::info)">
+                Info
+            </Translate>
+        ),
+    },
+    caution: {
+        infimaClassName: 'warning',
+        iconComponent: CautionIcon,
+        label: (
+            <Translate
+                id="theme.admonition.caution"
+                description="The default label used for the Caution admonition (:::caution)">
+                Caution
+            </Translate>
+        ),
+    },
+    experimental: {
+        infimaClassName: 'experimental',
+        iconComponent: ExperimentIcon,
+        label: (
+            <Translate
+                id="theme.admonition.experimental"
+                description="The default label used for the Experimental admonition (:::experimental)">
+                EXPERIMENTAL
+            </Translate>
+        ),
+    },
+    obsolete: {
+        infimaClassName: 'obsolete',
+        iconComponent: ObsoleteIcon,
+        label: (
+            <Translate
+                id="theme.admonition.obsolete"
+                description="The default label used for the Obsolete admonition (:::obsolete)">
+                OBSOLETE
+            </Translate>
+        ),
+    },
 };
 // Legacy aliases, undocumented but kept for retro-compatibility
 const aliases = {
-  secondary: 'note',
-  important: 'info',
-  success: 'tip',
-  warning: 'danger',
+    secondary: 'note',
+    important: 'info',
+    success: 'tip',
+    warning: 'danger',
 };
+
 function getAdmonitionConfig(unsafeType) {
-  const type = aliases[unsafeType] ?? unsafeType;
-  const config = AdmonitionConfigs[type];
-  if (config) {
-    return config;
-  }
-  console.warn(
-    `No admonition config found for admonition type "${type}". Using Info as fallback.`,
-  );
-  return AdmonitionConfigs.info;
+    const type = aliases[unsafeType] ?? unsafeType;
+    const config = AdmonitionConfigs[type];
+    if (config) {
+        return config;
+    }
+    console.warn(
+        `No admonition config found for admonition type "${type}". Using Info as fallback.`,
+    );
+    return AdmonitionConfigs.info;
 }
+
 // Workaround because it's difficult in MDX v1 to provide a MDX title as props
 // See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
 function extractMDXAdmonitionTitle(children) {
-  const items = React.Children.toArray(children);
-  const mdxAdmonitionTitle = items.find(
-    (item) =>
-      React.isValidElement(item) &&
-      item.props?.mdxType === 'mdxAdmonitionTitle',
-  );
-  const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
-  return {
-    mdxAdmonitionTitle,
-    rest,
-  };
+    const items = React.Children.toArray(children);
+    const mdxAdmonitionTitle = items.find(
+        (item) =>
+            React.isValidElement(item) &&
+            item.props?.mdxType === 'mdxAdmonitionTitle',
+    );
+    const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
+    return {
+        mdxAdmonitionTitle,
+        rest,
+    };
 }
+
 function processAdmonitionProps(props) {
-  const {mdxAdmonitionTitle, rest} = extractMDXAdmonitionTitle(props.children);
-  return {
-    ...props,
-    title: props.title ?? mdxAdmonitionTitle,
-    children: rest,
-  };
+    const {mdxAdmonitionTitle, rest} = extractMDXAdmonitionTitle(props.children);
+    return {
+        ...props,
+        title: props.title ?? mdxAdmonitionTitle,
+        children: rest,
+    };
 }
+
 export default function Admonition(props) {
-  const {children, type, title, icon: iconProp} = processAdmonitionProps(props);
-  const typeConfig = getAdmonitionConfig(type);
-  const titleLabel = title ?? typeConfig.label;
-  const {iconComponent: IconComponent} = typeConfig;
-  const icon = iconProp ?? <IconComponent />;
-  return (
-    <div
-      className={clsx(
-        ThemeClassNames.common.admonition,
-        ThemeClassNames.common.admonitionType(props.type),
-        'alert',
-        `alert--${typeConfig.infimaClassName}`,
-        styles.admonition,
-      )}>
-      <div className={clsx('alert-icon', styles.admonitionIcon)}>{icon}</div>
-      <div className={clsx('alert-content',styles.admonitionContent)}>
-        <div className={styles.admonitionHeading}>
-          {titleLabel}
+    const {children, type, title, icon: iconProp} = processAdmonitionProps(props);
+    const typeConfig = getAdmonitionConfig(type);
+    const titleLabel = title ?? typeConfig.label;
+    const {iconComponent: IconComponent} = typeConfig;
+    const icon = iconProp ?? <IconComponent/>;
+    return (
+        <div
+            className={clsx(
+                ThemeClassNames.common.admonition,
+                ThemeClassNames.common.admonitionType(props.type),
+                'alert',
+                `alert--${typeConfig.infimaClassName}`,
+                styles.admonition,
+            )}>
+            <div className={clsx('alert-icon', styles.admonitionIcon)}>{icon}</div>
+            <div className={clsx('alert-content', styles.admonitionContent)}>
+                <div className={styles.admonitionHeading}>
+                    {titleLabel}
+                </div>
+                {children}
+            </div>
         </div>
-        {children}
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -1,252 +1,197 @@
-import React from 'react';
-import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import Translate from '@docusaurus/Translate';
-import styles from './styles.module.css';
-function NoteIcon() {
-    return (
-        <svg viewBox="0 0 14 16">
-            <path
-                fillRule="evenodd"
-                d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
-            />
-        </svg>
-    );
+import React from 'react'
+import clsx from 'clsx'
+import { ThemeClassNames } from '@docusaurus/theme-common'
+import Translate from '@docusaurus/Translate'
+import styles from './styles.module.css'
+
+function NoteIcon () {
+  return (<svg viewBox="0 0 14 16">
+      <path
+        fillRule="evenodd"
+        d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
+      />
+    </svg>)
 }
 
-function TipIcon() {
-    return (
-        <svg viewBox="0 0 12 16">
-            <path
-                fillRule="evenodd"
-                d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
-            />
-        </svg>
-    );
+function TipIcon () {
+  return (<svg viewBox="0 0 12 16">
+      <path
+        fillRule="evenodd"
+        d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
+      />
+    </svg>)
 }
 
-function DangerIcon() {
-    return (
-        <svg viewBox="0 0 12 16">
-            <path
-                fillRule="evenodd"
-                d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
-            />
-        </svg>
-    );
+function DangerIcon () {
+  return (<svg viewBox="0 0 12 16">
+      <path
+        fillRule="evenodd"
+        d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
+      />
+    </svg>)
 }
 
-function InfoIcon() {
-    return (
-        <svg viewBox="0 0 14 16">
-            <path
-                fillRule="evenodd"
-                d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
-            />
-        </svg>
-    );
+function InfoIcon () {
+  return (<svg viewBox="0 0 14 16">
+      <path
+        fillRule="evenodd"
+        d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+      />
+    </svg>)
 }
 
-function CautionIcon() {
-    return (
-        <svg viewBox="0 0 16 16">
-            <path
-                fillRule="evenodd"
-                d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
-            />
-        </svg>
-    );
+function CautionIcon () {
+  return (<svg viewBox="0 0 16 16">
+      <path
+        fillRule="evenodd"
+        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+      />
+    </svg>)
 }
 
 // Custom icon for custom experimental admonition
-function ExperimentIcon() {
-    return (
-        <svg viewBox="0 0 20 20">
-            <path
-                fillRule="evenodd"
-                d="M15 2a1 1 0 0 1 0 2v4.826l3.932 10.814l.034 .077a1.7 1.7 0 0 1 -.002 1.193l-.07 .162a1.7 1.7 0 0 1 -1.213 .911l-.181 .017h-11l-.181 -.017a1.7 1.7 0 0 1 -1.285 -2.266l.039 -.09l3.927 -10.804v-4.823a1 1 0 1 1 0 -2h6zm-2 2h-2v4h2v-4z"
-            />
-        </svg>
-    );
+function ExperimentIcon () {
+  return (<svg viewBox="0 0 20 20">
+      <path
+        fillRule="evenodd"
+        d="M15 2a1 1 0 0 1 0 2v4.826l3.932 10.814l.034 .077a1.7 1.7 0 0 1 -.002 1.193l-.07 .162a1.7 1.7 0 0 1 -1.213 .911l-.181 .017h-11l-.181 -.017a1.7 1.7 0 0 1 -1.285 -2.266l.039 -.09l3.927 -10.804v-4.823a1 1 0 1 1 0 -2h6zm-2 2h-2v4h2v-4z"
+      />
+    </svg>)
 }
 
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+     viewBox="0 0 24 24" fill="none" stroke="currentColor"
      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
      className="icon icon-tabler icons-tabler-outline icon-tabler-plug-connected-x">
-    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-    <path d="M20 16l-4 4"/>
-    <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"/>
-    <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z"/>
-    <path d="M3 21l2.5 -2.5"/>
-    <path d="M18.5 5.5l2.5 -2.5"/>
-    <path d="M10 11l-2 2"/>
-    <path d="M13 14l-2 2"/>
-    <path d="M16 16l4 4"/>
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M20 16l-4 4"/>
+  <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"/>
+  <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z"/>
+  <path d="M3 21l2.5 -2.5"/>
+  <path d="M18.5 5.5l2.5 -2.5"/>
+  <path d="M10 11l-2 2"/>
+  <path d="M13 14l-2 2"/>
+  <path d="M16 16l4 4"/>
 </svg>
 
 // Custom icon for custom obsolete admonition
-function ObsoleteIcon() {
-    return (
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M20 16l-4 4" />
-            <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z" fill="none" />
-            <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z" fill="none" />
-            <path d="M3 21l2.5 -2.5"/>
-            <path d="M18.5 5.5l2.5 -2.5"/>
-            <path d="M10 11l-2 2"/>
-            <path d="M13 14l-2 2"/>
-            <path d="M16 16l4 4"/>
-        </svg>
-    );
+function ObsoleteIcon () {
+  return (<svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+               stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20 16l-4 4"/>
+      <path d="M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5z"
+            fill="none"/>
+      <path d="M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5z"
+            fill="none"/>
+      <path d="M3 21l2.5 -2.5"/>
+      <path d="M18.5 5.5l2.5 -2.5"/>
+      <path d="M10 11l-2 2"/>
+      <path d="M13 14l-2 2"/>
+      <path d="M16 16l4 4"/>
+    </svg>)
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 const AdmonitionConfigs = {
-    note: {
-        infimaClassName: 'secondary',
-        iconComponent: NoteIcon,
-        label: (
-            <Translate
-                id="theme.admonition.note"
-                description="The default label used for the Note admonition (:::note)">
-                Note
-            </Translate>
-        ),
-    },
-    tip: {
-        infimaClassName: 'success',
-        iconComponent: TipIcon,
-        label: (
-            <Translate
-                id="theme.admonition.tip"
-                description="The default label used for the Tip admonition (:::tip)">
-                Tip
-            </Translate>
-        ),
-    },
-    danger: {
-        infimaClassName: 'danger',
-        iconComponent: DangerIcon,
-        label: (
-            <Translate
-                id="theme.admonition.danger"
-                description="The default label used for the Danger admonition (:::danger)">
-                Danger
-            </Translate>
-        ),
-    },
-    info: {
-        infimaClassName: 'info',
-        iconComponent: InfoIcon,
-        label: (
-            <Translate
-                id="theme.admonition.info"
-                description="The default label used for the Info admonition (:::info)">
-                Info
-            </Translate>
-        ),
-    },
-    caution: {
-        infimaClassName: 'warning',
-        iconComponent: CautionIcon,
-        label: (
-            <Translate
-                id="theme.admonition.caution"
-                description="The default label used for the Caution admonition (:::caution)">
-                Caution
-            </Translate>
-        ),
-    },
-    experimental: {
-        infimaClassName: 'experimental',
-        iconComponent: ExperimentIcon,
-        label: (
-            <Translate
-                id="theme.admonition.experimental"
-                description="The default label used for the Experimental admonition (:::experimental)">
-                EXPERIMENTAL
-            </Translate>
-        ),
-    },
-    obsolete: {
-        infimaClassName: 'obsolete',
-        iconComponent: ObsoleteIcon,
-        label: (
-            <Translate
-                id="theme.admonition.obsolete"
-                description="The default label used for the Obsolete admonition (:::obsolete)">
-                OBSOLETE
-            </Translate>
-        ),
-    },
-};
+  note: {
+    infimaClassName: 'secondary', iconComponent: NoteIcon, label: (<Translate
+        id="theme.admonition.note"
+        description="The default label used for the Note admonition (:::note)">
+        Note
+      </Translate>),
+  }, tip: {
+    infimaClassName: 'success', iconComponent: TipIcon, label: (<Translate
+        id="theme.admonition.tip"
+        description="The default label used for the Tip admonition (:::tip)">
+        Tip
+      </Translate>),
+  }, danger: {
+    infimaClassName: 'danger', iconComponent: DangerIcon, label: (<Translate
+        id="theme.admonition.danger"
+        description="The default label used for the Danger admonition (:::danger)">
+        Danger
+      </Translate>),
+  }, info: {
+    infimaClassName: 'info', iconComponent: InfoIcon, label: (<Translate
+        id="theme.admonition.info"
+        description="The default label used for the Info admonition (:::info)">
+        Info
+      </Translate>),
+  }, caution: {
+    infimaClassName: 'warning', iconComponent: CautionIcon, label: (<Translate
+        id="theme.admonition.caution"
+        description="The default label used for the Caution admonition (:::caution)">
+        Caution
+      </Translate>),
+  }, experimental: {
+    infimaClassName: 'experimental',
+    iconComponent: ExperimentIcon,
+    label: (<Translate
+        id="theme.admonition.experimental"
+        description="The default label used for the Experimental admonition (:::experimental)">
+        EXPERIMENTAL
+      </Translate>),
+  }, obsolete: {
+    infimaClassName: 'obsolete', iconComponent: ObsoleteIcon, label: (<Translate
+        id="theme.admonition.obsolete"
+        description="The default label used for the Obsolete admonition (:::obsolete)">
+        OBSOLETE
+      </Translate>),
+  },
+}
 // Legacy aliases, undocumented but kept for retro-compatibility
 const aliases = {
-    secondary: 'note',
-    important: 'info',
-    success: 'tip',
-    warning: 'danger',
-};
+  secondary: 'note', important: 'info', success: 'tip', warning: 'danger',
+}
 
-function getAdmonitionConfig(unsafeType) {
-    const type = aliases[unsafeType] ?? unsafeType;
-    const config = AdmonitionConfigs[type];
-    if (config) {
-        return config;
-    }
-    console.warn(
-        `No admonition config found for admonition type "${type}". Using Info as fallback.`,
-    );
-    return AdmonitionConfigs.info;
+function getAdmonitionConfig (unsafeType) {
+  const type = aliases[unsafeType] ?? unsafeType
+  const config = AdmonitionConfigs[type]
+  if (config) {
+    return config
+  }
+  console.warn(
+    `No admonition config found for admonition type "${type}". Using Info as fallback.`)
+  return AdmonitionConfigs.info
 }
 
 // Workaround because it's difficult in MDX v1 to provide a MDX title as props
 // See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
-function extractMDXAdmonitionTitle(children) {
-    const items = React.Children.toArray(children);
-    const mdxAdmonitionTitle = items.find(
-        (item) =>
-            React.isValidElement(item) &&
-            item.props?.mdxType === 'mdxAdmonitionTitle',
-    );
-    const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
-    return {
-        mdxAdmonitionTitle,
-        rest,
-    };
+function extractMDXAdmonitionTitle (children) {
+  const items = React.Children.toArray(children)
+  const mdxAdmonitionTitle = items.find(
+    (item) => React.isValidElement(item) && item.props?.mdxType ===
+      'mdxAdmonitionTitle')
+  const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>
+  return {
+    mdxAdmonitionTitle, rest,
+  }
 }
 
-function processAdmonitionProps(props) {
-    const {mdxAdmonitionTitle, rest} = extractMDXAdmonitionTitle(props.children);
-    return {
-        ...props,
-        title: props.title ?? mdxAdmonitionTitle,
-        children: rest,
-    };
+function processAdmonitionProps (props) {
+  const { mdxAdmonitionTitle, rest } = extractMDXAdmonitionTitle(props.children)
+  return {
+    ...props, title: props.title ?? mdxAdmonitionTitle, children: rest,
+  }
 }
 
-export default function Admonition(props) {
-    const {children, type, title, icon: iconProp} = processAdmonitionProps(props);
-    const typeConfig = getAdmonitionConfig(type);
-    const titleLabel = title ?? typeConfig.label;
-    const {iconComponent: IconComponent} = typeConfig;
-    const icon = iconProp ?? <IconComponent/>;
-    return (
-        <div
-            className={clsx(
-                ThemeClassNames.common.admonition,
-                ThemeClassNames.common.admonitionType(props.type),
-                'alert',
-                `alert--${typeConfig.infimaClassName}`,
-                styles.admonition,
-            )}>
-            <div className={clsx('alert-icon', styles.admonitionIcon)}>{icon}</div>
-            <div className={clsx('alert-content', styles.admonitionContent)}>
-                <div className={styles.admonitionHeading}>
-                    {titleLabel}
-                </div>
-                {children}
-            </div>
+export default function Admonition (props) {
+  const { children, type, title, icon: iconProp } = processAdmonitionProps(
+    props)
+  const typeConfig = getAdmonitionConfig(type)
+  const titleLabel = title ?? typeConfig.label
+  const { iconComponent: IconComponent } = typeConfig
+  const icon = iconProp ?? <IconComponent/>
+  return (<div
+      className={clsx(ThemeClassNames.common.admonition,
+        ThemeClassNames.common.admonitionType(props.type), 'alert',
+        `alert--${typeConfig.infimaClassName}`, styles.admonition)}>
+      <div className={clsx('alert-icon', styles.admonitionIcon)}>{icon}</div>
+      <div className={clsx('alert-content', styles.admonitionContent)}>
+        <div className={styles.admonitionHeading}>
+          {titleLabel}
         </div>
-    );
+        {children}
+      </div>
+    </div>)
 }

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -3,7 +3,6 @@ import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import Translate from '@docusaurus/Translate';
 import styles from './styles.module.css';
-
 function NoteIcon() {
     return (
         <svg viewBox="0 0 14 16">


### PR DESCRIPTION
## Summary
Adds two new admonitions: `experimental` and `obsolete` as a way to standardise the way we communicate to users which features are experimental or obsolete. 

The new admonitions can be used as:

```
:::experimental
This database engine is experimental. To use it, set `allow_experimental_database_materialized_postgresql` to `1` in your configuration files or by using the `SET` command:
:::
```
Renders:

![image](https://github.com/user-attachments/assets/808257c2-d9d6-4b3a-93b8-fd2755b0c262)

```
:::obsolete
This database engine is obsolete and can no longer be used.
:::
```
Renders:

![image](https://github.com/user-attachments/assets/a8925f71-ba8c-4155-9932-258d712b6099)

Currently we just use the `info` admonitions for these (see [here](https://clickhouse.com/docs/en/engines/database-engines/materialized-postgresql) and [here](http://localhost:3000/docs/en/engines/database-engines/materialized-mysql))

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
