### PR TITLE
Add _sequence_number as supported Kinesis virtual column

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/kinesis.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/kinesis.md
@@ -96,12 +96,13 @@ The following ClickHouse data types are currently supported in ClickPipes:
 
 The following virtual columns are supported for Kinesis stream.  When creating a new destination table virtual columns can be added by using the `Add Column` button.
 
-| Name         | Description                                                   | Recommended Data Type |
-|--------------|---------------------------------------------------------------|-----------------------|
-| _key         | Kinesis Partition Key                                         | String                |
-| _timestamp   | Kinesis Approximate Arrival Timestamp (millisecond precision) | DateTime64(3)         |
-| _stream      | Kafka Stream Name                                             | String                |
-| _raw_message | Full Kinesis Message                                          | String                |
+| Name             | Description                                                   | Recommended Data Type |
+|------------------|---------------------------------------------------------------|-----------------------|
+| _key             | Kinesis Partition Key                                         | String                |
+| _timestamp       | Kinesis Approximate Arrival Timestamp (millisecond precision) | DateTime64(3)         |
+| _stream          | Kinesis Stream Name                                           | String                |
+| _sequence_number | Kinesis Sequence Number                                       | String                |
+| _raw_message     | Full Kinesis Message                                          | String                |
 
 The _raw_message field can be used in cases where only full Kinesis JSON record is required (such as using ClickHouse [`JsonExtract*`](https://clickhouse.com/docs/en/sql-reference/functions/json-functions#jsonextract-functions) functions to populate a downstream materialized
 view).  For such pipes, it may improve ClickPipes performance to delete all the "non-virtual" columns.


### PR DESCRIPTION
## Summary
Updates ClickPipes docs to add  `_sequence_number` as supported Kinesis virtual column

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
