### PR TITLE
Fix failing linkcheck action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -37,9 +37,9 @@ jobs:
 
       - name: move html files in place
         # Because our doc root is `/docs` and not `/` the generated
-        # HTML must be moved uner `/docs` for htmltest to work.
+        # HTML must be moved under `/docs` for htmltest to work.
         run: |
-          mkdir build/docs
+          mkdir -p build/docs
           cd build
           mv en js ru zh css images assets img opensearch.xml category docs
 


### PR DESCRIPTION
## Summary
Fixes failing linkcheck Github action:

![image](https://github.com/user-attachments/assets/9cfb2333-4ff6-44da-9b1e-a31c6d01dcaf)
![image](https://github.com/user-attachments/assets/ff0054d7-a054-4527-b258-8ea61eb80437)


## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
