### PR TITLE
Fix ugly looking navigation on mobile

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1399,6 +1399,286 @@ const sidebars = {
       dirName: "zh",
     },
   ],
-};
+  // Used for generating the secondary nav mobile menu (DocsCategoryDropdown)
+  dropdownCategories : [
+    {
+      type: 'category',
+      label: 'Getting Started',
+      //description: 'Learn how to use ClickHouse',
+      items: [
+        {
+          type: 'link',
+          label: 'Introduction',
+          //description: 'An introduction to ClickHouse',
+          href: '/docs'
+        },
+        {
+          type: 'link',
+          label: 'Starter Guides',
+          //description: 'Start here when learning ClickHouse',
+          href: '/docs/en/guides/creating-tables'
+        },
+        {
+          type: 'link',
+          label: 'Concepts',
+          //description: 'Core concepts to know',
+          href: '/docs/en/concepts/why-clickhouse-is-so-fast'
+        },
+        {
+          type: 'link',
+          label: 'Migration Guides',
+          //description: 'Migrate your database to ClickHouse',
+          href: '/docs/en/migrations/bigquery'
+        },
+        {
+          type: 'link',
+          label: 'Use Case Guides',
+          //description: 'Common use case guides for ClickHouse',
+          href: '/docs/en/migrations/bigquery'
+        },
+        {
+          type: 'link',
+          label: 'Example datasets',
+          //description: 'Helpful datasets and tutorials',
+          href: '/docs/en/getting-started/example-datasets'
+        },
+      ]
+    },
+    {
+        type: 'category',
+        label: 'Cloud',
+        //description: 'The fastest way to deploy ClickHouse',
+        items: [
+          {
+            type: 'link',
+            label: 'Get Started',
+            //description: 'Start quickly with ClickHouse Cloud',
+            href: '/docs/en/cloud/overview'
+          },
+          {
+            type: 'link',
+            label: 'Best Practices',
+            //description: 'How to get the most out of ClickHouse Cloud',
+            href: '/docs/en/cloud/bestpractices/bulk-inserts'
+          },
+          {
+            type: 'link',
+            label: 'Managing Cloud',
+            //description: 'Manage your ClickHouse Cloud services',
+            href: '/docs/en/cloud/manage/service-types'
+          },
+          {
+            type: 'link',
+            label: 'Security',
+            //description: 'Secure your ClickHouse Cloud services',
+            href: '/docs/en/cloud/security/shared-responsibility-model'
+          },
+          {
+            type: 'link',
+            label: 'Cloud API',
+            //description: 'Automate your ClickHouse Cloud services',
+            href: '/docs/en/cloud/manage/api/api-overview'
+          },
+          {
+            type: 'link',
+            label: 'Migrating to Cloud',
+            //description: 'Migrate your database to ClickHouse Cloud',
+            href: '/docs/en/integrations/migration'
+          },
+          {
+            type: 'link',
+            label: 'Cloud Reference',
+            //description: 'Understanding how ClickHouse Cloud works',
+            href: '/docs/en/cloud/reference/architecture'
+          },
+        ]
+    },
+    {
+        type: 'category',
+        label: 'Managing Data',
+        //description: 'How to manage data in ClickHouse',
+        items: [
+        {
+          type: 'link',
+          label: 'Updating Data',
+          //description: 'Updating and replacing data in ClickHouse',
+          href: '/docs/en/updating-data'
+        },
+        {
+          type: 'link',
+          label: 'Data Modeling',
+          //description: 'Optimize your schema and data model',
+          href: '/docs/en/data-modeling/schema-design'
+        },
+        {
+          type: 'link',
+          label: 'Deleting Data',
+          //description: 'Deleting data in ClickHouse',
+          href: '/docs/en/deletes'
+        },
+        {
+          type: 'link',
+          label: 'Performance and Optimizations',
+          //description: 'Guides to help you optimize ClickHouse',
+          href: '/docs/en/operations/optimizing-performance/profile-guided-optimization'
+        }
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Server Admin',
+      //description: 'Manage and deploy ClickHouse',
+      items: [
+        {
+          type: 'link',
+          label: 'Deployments and Scaling',
+          //description: 'How to deploy ClickHouse',
+          href: '/docs/en/architecture/cluster-deployment'
+        },
+        {
+          type: 'link',
+          label: 'Security and Authentication',
+          //description: 'Secure your ClickHouse deployment',
+          href: '/docs/en/operations/external-authenticators/http'
+        },
+        {
+          type: 'link',
+          label: 'Settings',
+          //description: 'Configure ClickHouse',
+          href: '/docs/en/operations/settings'
+        },
+        {
+          type: 'link',
+          label: 'Tools and Utilities',
+          //description: 'Tools to help you manage ClickHouse',
+          href: '/docs/en/operations/utilities/backupview'
+        },
+        {
+          type: 'link',
+          label: 'System Tables',
+          //description: 'Metadata tables to help you manage ClickHouse',
+          href: '/docs/en/operations/system-tables/asynchronous_insert_log'
+        }
+      ]
+    },
+    {
+      type: 'category',
+      label: 'SQL Reference',
+      //description: 'Reference documentation for ClickHouse features',
+      items: [
+        {
+          type: 'link',
+          label: 'Introduction',
+          //description: 'Learn ClickHouse syntax',
+          href: '/docs/en/sql-reference'
+        },
+        {
+          type: 'link',
+          label: 'Functions',
+          //description: 'Hundreds of built-in functions to help you analyze your data',
+          href: '/docs/en/sql-reference/functions'
+        },
+        {
+          type: 'link',
+          label: 'Engines',
+          //description: 'Use the right table and database engines for your data',
+          href: '/docs/en/engines/database-engines'
+        },
+        {
+          type: 'link',
+          label: 'Other Features',
+          //description: 'Learn about other features in ClickHouse',
+          href: '/docs/en/sql-reference/operators'
+        }
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Integrations',
+      //description: 'Integrations, clients, and drivers to use with ClickHouse',
+      items: [
+        {
+          type: 'link',
+          label: 'ClickPipes',
+          //description: 'The easiest way to ingest data into ClickHouse',
+          href: '/docs/en/integrations/clickpipes'
+        },
+        {
+          type: 'link',
+          label: 'Data Formats',
+          //description: 'Explore data formats supported by ClickHouse',
+          href: '/docs/en/integrations/data-formats'
+        },
+        {
+          type: 'link',
+          label: 'All Integrations',
+          //description: 'Integrate ClickHouse with other databases and applications',
+          href: '/docs/en/integrations'
+        },
+        {
+          type: 'link',
+          label: 'Clients and Drivers',
+          //description: 'Choose a client or driver to connect to ClickHouse',
+          href: '/docs/en/integrations/sql-clients/clickhouse-client-local'
+        },
+      ]
+    },
+    {
+      type: 'category',
+      label: 'chDB',
+      //description: 'chDB is an embedded version of ClickHouse',
+      items: [
+        {
+          type: 'link',
+          label: 'Learn chDB',
+          //description: 'Learn how to use chDB',
+          href: '/docs/en/chdb'
+        },
+        {
+          type: 'link',
+          label: 'Guides',
+          //description: 'Guides to help you use chDB',
+          href: '/docs/en/chdb/guides/jupysql'
+        },
+        {
+          type: 'link',
+          label: 'Language Clients',
+          //description: 'Connect to chDB using a language client',
+          href: '/docs/en/chdb/install/python'
+        },
+      ]
+    },
+    {
+      type: 'category',
+      label: 'About',
+      //description: 'Learn more about ClickHouse',
+      items: [
+        {
+          type: 'link',
+          label: 'About ClickHouse',
+          //description: 'Learn about ClickHouse',
+          href: '/docs/en/about-us/adopters'
+        },
+        {
+          type: 'link',
+          label: 'Changelogs',
+          //description: 'View the latest changes in ClickHouse',
+          href: '/docs/en/whats-new/security-changelog'
+        },
+        {
+          type: 'link',
+          label: 'Support',
+          //description: 'Get support from ClickHouse engineers',
+          href: '/docs/en/about-us/support'
+        },
+        {
+          type: 'link',
+          label: 'Development and Contributing',
+          //description: 'Learn how to contribute to ClickHouse',
+          href: '/docs/en/development/developer-instruction'
+        }
+      ]
+    },
+  ]};
 
 module.exports = sidebars;

--- a/src/components/DocsCategoryMobileNav/Hamburger.jsx
+++ b/src/components/DocsCategoryMobileNav/Hamburger.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from '../DocsCategoryMobileNav/styles.module.css'
+
+const Hamburger = ({onClick}) =>
+{
+  return(
+      <svg className={styles.docsNavBurger}
+           width="30"
+           height="30"
+           viewBox="0 0 30 30"
+           aria-hidden="true"
+           onClick={onClick}
+      >
+        <path stroke="currentColor" stroke-linecap="round"
+              stroke-miterlimit="10"
+              stroke-width="2" d="M4 7h22M4 15h22M4 23h22"></path>
+      </svg>
+  );
+}
+
+export default Hamburger;

--- a/src/components/DocsCategoryMobileNav/Hamburger.jsx
+++ b/src/components/DocsCategoryMobileNav/Hamburger.jsx
@@ -11,9 +11,9 @@ const Hamburger = ({onClick}) =>
            aria-hidden="true"
            onClick={onClick}
       >
-        <path stroke="currentColor" stroke-linecap="round"
-              stroke-miterlimit="10"
-              stroke-width="2" d="M4 7h22M4 15h22M4 23h22"></path>
+        <path stroke="currentColor" strokeLinecap="round"
+              strokeMiterlimit="10"
+              strokeWidth="2" d="M4 7h22M4 15h22M4 23h22"></path>
       </svg>
   );
 }

--- a/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
@@ -1,0 +1,31 @@
+import React, {useState} from 'react';
+
+import Hamburger from "./Hamburger";
+import MobileMenu from './MobileMenu'
+import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
+import NavbarBackdrop from '../../theme/Navbar/Layout/index'
+import styles from '../DocsCategoryMobileNav/styles.module.css'
+
+function HamburgerMenu({menuItems})
+{
+
+  const [currentMenuState, setMenuState] = useState(false);
+
+  return(
+    <>
+      <Hamburger
+        onClick={() => setMenuState(!currentMenuState)}
+      />
+      <div className={currentMenuState ? styles.docsMobileMenuBackdropActive : styles.docsMobileMenuBackdropInactive}/>
+      <MobileMenu
+        showMobileMenu={currentMenuState}
+        onClick={() => setMenuState(!currentMenuState)}
+        className={currentMenuState
+          ? styles.docsMobileMenuActive
+          : styles.docsMobileMenuHidden}
+      />
+    </>
+  );
+}
+
+export default HamburgerMenu;

--- a/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
@@ -6,7 +6,7 @@ import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
 import NavbarBackdrop from '../../theme/Navbar/Layout/index'
 import styles from '../DocsCategoryMobileNav/styles.module.css'
 
-function HamburgerMenu({menuItems})
+function HamburgerMenu()
 {
 
   const [currentMenuState, setMenuState] = useState(false);
@@ -18,7 +18,6 @@ function HamburgerMenu({menuItems})
       />
       <div className={currentMenuState ? styles.docsMobileMenuBackdropActive : styles.docsMobileMenuBackdropInactive}/>
       <MobileMenu
-        showMobileMenu={currentMenuState}
         onClick={() => setMenuState(!currentMenuState)}
         className={currentMenuState
           ? styles.docsMobileMenuActive

--- a/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/HamburgerMenu.jsx
@@ -5,6 +5,7 @@ import MobileMenu from './MobileMenu'
 import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
 import NavbarBackdrop from '../../theme/Navbar/Layout/index'
 import styles from '../DocsCategoryMobileNav/styles.module.css'
+import clsx from 'clsx'
 
 function HamburgerMenu()
 {

--- a/src/components/DocsCategoryMobileNav/MobileMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/MobileMenu.jsx
@@ -14,7 +14,7 @@ import ClickHouseLogo from '../../icons/ClickHouseLogo'
 const MobileMenu = ({className, onClick, path}) => {
 
   return(
-    <div className={className}>
+    <div className={clsx(styles.docsMobileMenu,className)}>
       <div
         className={clsx("navbar-sidebar__brand", styles.docsMobileMenu_header)}>
         <ClickHouseLogo width={150}/>
@@ -26,7 +26,7 @@ const MobileMenu = ({className, onClick, path}) => {
         <SearchBar/>
       </div>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list', styles.docsMobileMenuItems)}>
-        <DocSidebarItems items={sidebars.dropdownCategories} activePath={path} level={1}/>
+        <DocSidebarItems items={sidebars.dropdownCategories} activePath={path} level={1} onItemClick={onClick}/>
       </ul>
     </div>
   );

--- a/src/components/DocsCategoryMobileNav/MobileMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/MobileMenu.jsx
@@ -1,0 +1,33 @@
+import React, {useState} from 'react';
+import styles from '../DocsCategoryMobileNav/styles.module.css'
+import NavbarMobileSidebar from '../../theme/Navbar/MobileSidebar'
+import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
+import IconClose from '@theme/Icon/Close';
+import NavbarLogo from '@theme/Navbar/Logo';
+import SearchBar from "@theme/SearchBar";
+import clsx from 'clsx'
+import DocSidebarItems from '@theme/DocSidebarItems'
+import sidebars from '../../../sidebars'
+import { ThemeClassNames } from '@docusaurus/theme-common'
+import ClickHouseLogo from '../../icons/ClickHouseLogo'
+
+const MobileMenu = ({className, showMobileMenu, onClick, path}) => {
+
+  return(
+    <div className={className}>
+      <div
+        className={clsx("navbar-sidebar__brand", styles.docsMobileMenu_header)}>
+        <ClickHouseLogo width={150}/>
+        <IconClose
+          onClick={onClick}
+        />
+      </div>
+      <SearchBar className={styles.searchBar}/>
+      <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list', styles.docsMobileMenuItems)}>
+        <DocSidebarItems items={sidebars.docsDropDownCategories} activePath={path} level={1}/>
+      </ul>
+    </div>
+  );
+}
+
+export default MobileMenu;

--- a/src/components/DocsCategoryMobileNav/MobileMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/MobileMenu.jsx
@@ -22,7 +22,9 @@ const MobileMenu = ({className, onClick, path}) => {
           onClick={onClick}
         />
       </div>
-      <SearchBar className={styles.searchBar}/>
+      <div className={styles.searchBar}>
+        <SearchBar/>
+      </div>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list', styles.docsMobileMenuItems)}>
         <DocSidebarItems items={sidebars.dropdownCategories} activePath={path} level={1}/>
       </ul>

--- a/src/components/DocsCategoryMobileNav/MobileMenu.jsx
+++ b/src/components/DocsCategoryMobileNav/MobileMenu.jsx
@@ -11,7 +11,7 @@ import sidebars from '../../../sidebars'
 import { ThemeClassNames } from '@docusaurus/theme-common'
 import ClickHouseLogo from '../../icons/ClickHouseLogo'
 
-const MobileMenu = ({className, showMobileMenu, onClick, path}) => {
+const MobileMenu = ({className, onClick, path}) => {
 
   return(
     <div className={className}>
@@ -24,7 +24,7 @@ const MobileMenu = ({className, showMobileMenu, onClick, path}) => {
       </div>
       <SearchBar className={styles.searchBar}/>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list', styles.docsMobileMenuItems)}>
-        <DocSidebarItems items={sidebars.docsDropDownCategories} activePath={path} level={1}/>
+        <DocSidebarItems items={sidebars.dropdownCategories} activePath={path} level={1}/>
       </ul>
     </div>
   );

--- a/src/components/DocsCategoryMobileNav/styles.module.css
+++ b/src/components/DocsCategoryMobileNav/styles.module.css
@@ -1,0 +1,86 @@
+.docsNavBurger {
+    display: none;
+}
+
+.docsMobileMenuActive {
+    position:fixed;
+    z-index: 15;
+    left: 0;
+    top: 0;
+    height: 100vh;
+    width: 100%;
+    padding: 1em;
+    transform: translate3d(0, 0, 0);
+    margin: 0;
+    padding: 0 1rem;
+    overflow-x:hidden;
+    transition-property: opacity, visibility, transform;
+    transition-duration: 250ms;
+    transition-timing-function: ease-in-out;
+}
+
+.docsMobileMenuBackdropInactive{
+    display:none;
+}
+
+[data-theme="dark"] .docsMobileMenuBackdropActive{
+    background-color: #282828;
+    display: flex;
+    position:fixed;
+    width:100%;
+    height: 100vh;
+    left:0;
+    top:0;
+    z-index:14;
+    transition-property: opacity, visibility, transform;
+    transition-duration: 250ms;
+    transition-timing-function: ease-in-out;
+}
+
+[data-theme="light"] .docsMobileMenuBackdropActive {
+    background-color: white;
+    display: flex;
+    position:fixed;
+    width:100%;
+    height: 100vh;
+    left:0;
+    top:0;
+    z-index:14;
+    transition-property: opacity, visibility, transform;
+    transition-duration: 250ms;
+    transition-timing-function: ease-in-out;
+}
+
+[data-theme="dark"] .searchBar {
+    button.DocSearch{
+        background: #414040;
+    }
+}
+
+.docsMobileMenuHidden {
+    position:absolute;
+    display: none;
+}
+
+.docsMobileMenuItems{
+    margin-top: 1em;
+    margin-bottom: 2em;
+}
+.docsMobileMenu_header{
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    height: 3.5rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+@media (max-width: 1400px) {
+
+}
+
+@media (max-width: 996px) {
+    .docsNavBurger {
+        display: flex;
+    }
+}

--- a/src/components/DocsCategoryMobileNav/styles.module.css
+++ b/src/components/DocsCategoryMobileNav/styles.module.css
@@ -52,8 +52,8 @@
 }
 
 [data-theme="dark"] .searchBar {
-    button.DocSearch{
-        background: #414040;
+    button{
+        background: #303030;
     }
 }
 

--- a/src/components/DocsCategoryMobileNav/styles.module.css
+++ b/src/components/DocsCategoryMobileNav/styles.module.css
@@ -2,6 +2,12 @@
     display: none;
 }
 
+.docsMobileMenu {
+    transition-property: transform, opacity;
+    transition-duration: 250ms;
+    transition-timing-function: ease-in-out;
+}
+
 .docsMobileMenuActive {
     position:fixed;
     z-index: 15;
@@ -14,13 +20,17 @@
     margin: 0;
     padding: 0 1rem;
     overflow-x:hidden;
-    transition-property: opacity, visibility, transform;
-    transition-duration: 250ms;
-    transition-timing-function: ease-in-out;
+    opacity: 1;
+}
+
+.docsMobileMenuHidden {
+    position:absolute;
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
 }
 
 .docsMobileMenuBackdropInactive{
-    display:none;
+
 }
 
 [data-theme="dark"] .docsMobileMenuBackdropActive{
@@ -32,9 +42,7 @@
     left:0;
     top:0;
     z-index:14;
-    transition-property: opacity, visibility, transform;
-    transition-duration: 250ms;
-    transition-timing-function: ease-in-out;
+    transform: translate3d(0, 0, 0);
 }
 
 [data-theme="light"] .docsMobileMenuBackdropActive {
@@ -46,20 +54,13 @@
     left:0;
     top:0;
     z-index:14;
-    transition-property: opacity, visibility, transform;
-    transition-duration: 250ms;
-    transition-timing-function: ease-in-out;
+    transform: translate3d(0, 0, 0);
 }
 
 [data-theme="dark"] .searchBar {
     button{
         background: #303030;
     }
-}
-
-.docsMobileMenuHidden {
-    position:absolute;
-    display: none;
 }
 
 .docsMobileMenuItems{

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -15,6 +15,7 @@ import ColorModeToggle from "../../../components/ColorModeToggler";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import GlobalMenu from "./GlobalMenu";
 import DocsCategoryDropdown, { DocsCategoryDropdownLinkOnly } from "../../../components/DocsCategoryDropdown";
+import HamburgerMenu from "../../../components/DocsCategoryMobileNav/HamburgerMenu";
 import Navigation from "../../../components/Navigation";
 function useNavbarItems() {
   // TODO temporary casting until ThemeConfig type is improved
@@ -351,6 +352,9 @@ export default function NavbarContent() {
           <NavbarItems items={secRightItems} />
           <ColorModeToggle className="navbar-color-toggle" />
         </div>
+        <HamburgerMenu
+          menuItems={dropdownCategories}
+        />
       </div>
     </div>
   );

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -353,7 +353,6 @@ export default function NavbarContent() {
           <ColorModeToggle className="navbar-color-toggle" />
         </div>
         <HamburgerMenu
-          menuItems={dropdownCategories}
         />
       </div>
     </div>

--- a/src/theme/Navbar/Content/styles.module.css
+++ b/src/theme/Navbar/Content/styles.module.css
@@ -104,8 +104,19 @@
   left: 2rem;
 }
 
+.dropdownCategoriesContainer {
+  overflow-x: auto;
+  width: 100%;
+  max-width: 100%;
+  white-space: wrap;
+}
+
 @media (max-width: 997px) {
   .navbarItemsList {
+    display: none !important;
+  }
+
+  .dropdownCategoriesContainer {
     display: none !important;
   }
 }
@@ -121,11 +132,4 @@
   .githubStars {
     display: none;
   }
-}
-
-.dropdownCategoriesContainer {
-  overflow-x: auto;
-  width: 100%;
-  max-width: 100%;
-  white-space: wrap;
 }

--- a/src/theme/badges/CloudAvailableBadge/index.js
+++ b/src/theme/badges/CloudAvailableBadge/index.js
@@ -5,8 +5,8 @@ const Icon = () => {
     return (
         <div className={styles.cloudIcon} style={{marginRight: '8px', marginTop: '4px'}}>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M5.33395 12.6667H12.3739C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00004 12.3739 8.00004H12.0839V7.33337C12.0839 5.12671 10.2906 3.33337 8.08395 3.33337C6.09928 3.33337 4.45395 4.78537 4.14195 6.68204C2.55728 6.76271 1.29395 8.06204 1.29395 9.66671C1.29395 11.3234 2.63728 12.6667 4.29395 12.6667H5.33395Z"
-             stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path fillRule="evenodd" clipRule="evenodd" d="M5.33395 12.6667H12.3739C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00004 12.3739 8.00004H12.0839V7.33337C12.0839 5.12671 10.2906 3.33337 8.08395 3.33337C6.09928 3.33337 4.45395 4.78537 4.14195 6.68204C2.55728 6.76271 1.29395 8.06204 1.29395 9.66671C1.29395 11.3234 2.63728 12.6667 4.29395 12.6667H5.33395Z"
+             strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
     )


### PR DESCRIPTION
## Summary
I'm sure there are very few people looking at ClickHouse docs on mobile... never the less, the secondary (docs) navigation bar looks horrible on mobile:

![image](https://github.com/user-attachments/assets/fb8906f1-e4df-4dc6-a180-5446eb886320)

This PR adds custom React components `Hamburger`, `HamburgerMenu` and `MobileMenu` (grouped under `DocsCategoryMobileNav`) such that the secondary menu acts in a similar way to the primary menu (displays a burger menu and navigation overlay for smaller screen sizes).

**Result**

![demo](https://github.com/user-attachments/assets/fda8bf5e-48bf-42ec-b56d-de9c33ba4882)

Still to do:

- [x] Fix search bar styling for dark theme.
- [x] Hide navbar when link is clicked.
- [x] Move `dropdownCategories` in `src/theme/NavBar/Content/index.js` to it's own config file, accessible by this new component.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
