### PR TITLE
docs: Update refreshable-materialized-view.md to cross reference DEPENDS ON

### DIFF
--- a/docs/en/materialized-view/refreshable-materialized-view.md
+++ b/docs/en/materialized-view/refreshable-materialized-view.md
@@ -25,7 +25,7 @@ ClickHouse incremental materialized views are enormously powerful and typically 
 
 However, there are use cases where this incremental process is not required or is not applicable. Some problems are either incompatible with an incremental approach or don't require real-time updates, with a periodic rebuild being more appropriate. For example, you may want to regularly perform a complete recomputation of a view over the full dataset because it uses a complex join, which is incompatible with an incremental approach.
 
->  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job. To find out more about how to set dependancies between refreshable materialized views go to [CREATE VIEW](https://clickhouse.com/docs/en/sql-reference/statements/create/view#refresh-dependencies), `Dependancies` section.
+>  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job. To find out more about how to set dependencies between refreshable materialized views go to [CREATE VIEW](https://clickhouse.com/docs/en/sql-reference/statements/create/view#refresh-dependencies), `Dependencies` section.
 
 ## How do you refresh a refreshable materialized view?
 

--- a/docs/en/materialized-view/refreshable-materialized-view.md
+++ b/docs/en/materialized-view/refreshable-materialized-view.md
@@ -25,7 +25,7 @@ ClickHouse incremental materialized views are enormously powerful and typically 
 
 However, there are use cases where this incremental process is not required or is not applicable. Some problems are either incompatible with an incremental approach or don't require real-time updates, with a periodic rebuild being more appropriate. For example, you may want to regularly perform a complete recomputation of a view over the full dataset because it uses a complex join, which is incompatible with an incremental approach.
 
->  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job. To find out more about how to set dependencies between refreshable materialized views go to [CREATE VIEW](https://clickhouse.com/docs/en/sql-reference/statements/create/view#refresh-dependencies), `Dependencies` section.
+>  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job. To find out more about how to set dependencies between refreshable materialized views go to [CREATE VIEW](/docs/en/sql-reference/statements/create/view#refresh-dependencies), `Dependencies` section.
 
 ## How do you refresh a refreshable materialized view?
 

--- a/docs/en/materialized-view/refreshable-materialized-view.md
+++ b/docs/en/materialized-view/refreshable-materialized-view.md
@@ -25,7 +25,7 @@ ClickHouse incremental materialized views are enormously powerful and typically 
 
 However, there are use cases where this incremental process is not required or is not applicable. Some problems are either incompatible with an incremental approach or don't require real-time updates, with a periodic rebuild being more appropriate. For example, you may want to regularly perform a complete recomputation of a view over the full dataset because it uses a complex join, which is incompatible with an incremental approach.
 
->  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job.
+>  Refreshable materialized views can run batch processes performing tasks such as denormalization. Dependencies can be created between refreshable materialized views such that one view depends on the results of another and only executes once it is complete. This can replace scheduled workflows or simple DAGs such as a [dbt](https://www.getdbt.com/) job. To find out more about how to set dependancies between refreshable materialized views go to [CREATE VIEW](https://clickhouse.com/docs/en/sql-reference/statements/create/view#refresh-dependencies), `Dependancies` section.
 
 ## How do you refresh a refreshable materialized view?
 


### PR DESCRIPTION
This adds a cross reference on how to manage DEPENDS on for refreshable-materialized-view

The page [refreshable-materialized-view](https://clickhouse.com/docs/en/materialized-view/refreshable-materialized-view) where materialized views are explained, mentions Dependancies but it does not link you to the docs in terms of how these are set. 

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
