### PR TITLE
Fixed incorrect links to headers of Settings Profiles management queries

### DIFF
--- a/docs/en/guides/sre/user-management/index.md
+++ b/docs/en/guides/sre/user-management/index.md
@@ -128,9 +128,9 @@ Management queries:
 
 - [CREATE SETTINGS PROFILE](/docs/en/sql-reference/statements/create/settings-profile.md#create-settings-profile-statement)
 - [ALTER SETTINGS PROFILE](/docs/en/sql-reference/statements/alter/settings-profile.md#alter-settings-profile-statement)
-- [DROP SETTINGS PROFILE](/docs/en/sql-reference/statements/drop.md#drop-settings-profile-statement)
-- [SHOW CREATE SETTINGS PROFILE](/docs/en/sql-reference/statements/show.md#show-create-settings-profile-statement)
-- [SHOW PROFILES](/docs/en/sql-reference/statements/show.md#show-profiles-statement)
+- [DROP SETTINGS PROFILE](/docs/en/sql-reference/statements/drop.md#drop-settings-profile)
+- [SHOW CREATE SETTINGS PROFILE](/docs/en/sql-reference/statements/show.md#show-create-settings-profile)
+- [SHOW PROFILES](/docs/en/sql-reference/statements/show.md#show-profiles)
 
 ### Quota {#quotas-management}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
