### PR TITLE
fix rendering for light mode on details table

### DIFF
--- a/src/theme/Details/styles.module.css
+++ b/src/theme/Details/styles.module.css
@@ -6,3 +6,41 @@
   margin: 0 0 var(--ifm-spacing-vertical);
   border: 1px solid var(--prism-background-color);
 }
+
+.details table {
+  width: 100%;
+  display: inline;
+  border-collapse: collapse;
+  border: 1px solid var(--click-color-table-cell-stroke);
+  background-color: var(--click-color-table-row-background);
+  color: var(--click-color-table-row-text);
+  table-layout: auto; /* Automatically adjusts column widths to fit content */
+}
+
+.details th, .details td {
+  border: 1px solid var(--click-color-table-cell-stroke);
+  padding: 8px; /* Adjust padding for consistent spacing */
+}
+
+.details th {
+  background-color: var(--click-color-table-header-background);
+  color: var(--click-color-table-header-text);
+  text-align: left;
+}
+
+.details td {
+  background-color: var(--click-color-table-row-background);
+}
+
+.details {
+  overflow-x: auto; /* Enable horizontal scrolling if content exceeds container width */
+}
+
+.details a {
+  color: var(--click-color-link);
+  text-decoration: underline;
+}
+
+.details a:hover {
+  color: var(--click-color-accent);
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/ClickHouse/clickhouse-docs/issues/2861

## Before

<img width="2721" alt="image" src="https://github.com/user-attachments/assets/7a237da6-54ad-4312-a874-71eb99c7e1a3">

<img width="2721" alt="image" src="https://github.com/user-attachments/assets/3786eaf7-a028-44c9-8d09-248f6cd9d1f3">

## After

<img width="2721" alt="image" src="https://github.com/user-attachments/assets/0fd39b35-cf79-4404-b88b-b8aa064a6c06">
<img width="2721" alt="image" src="https://github.com/user-attachments/assets/64fd626a-ee01-4a69-9275-4a6fd70838b6">


## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
