### PR TITLE
Refreshable views are no longer experimental

### DIFF
--- a/docs/en/materialized-view/refreshable-materialized-view.md
+++ b/docs/en/materialized-view/refreshable-materialized-view.md
@@ -148,8 +148,6 @@ ORDER BY uuid;
 We could then create a refreshable materialized view to populate this table:
 
 ```sql
-SET allow_experimental_refreshable_materialized_view=1;
-
 CREATE MATERIALIZED VIEW events_snapshot_mv
 REFRESH EVERY 10 SECOND APPEND TO events_snapshot
 AS SELECT


### PR DESCRIPTION
## Summary
I believe refreshable views are not experimental any more based on: https://github.com/ClickHouse/ClickHouse/pull/70550

Thus there shouldn't be any need to set this before creating them.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
