### PR TITLE
Update the recommended beam version

### DIFF
--- a/docs/en/integrations/data-ingestion/etl-tools/apache-beam.md
+++ b/docs/en/integrations/data-ingestion/etl-tools/apache-beam.md
@@ -27,6 +27,12 @@ Add the following dependency to your package management framework:
 </dependency>
 ```
 
+:::important Recommended Beam version
+The `ClickHouseIO` connector is recommended for use starting from Apache Beam version `2.59.0`.
+Earlier versions may not fully support the connector's functionality.
+:::
+
+
 The artifacts could be found in the [official maven repository](https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-clickhouse).
 
 ### Code Example


### PR DESCRIPTION
## Summary

Due to multiple fixes in our `ClickHouseIO` connector ( apache/beam#32229 and apache/beam#32100), we recommend using Apache Beam version `2.59.0` (earlier versions may not fully support the connector's functionality).