### PR TITLE
fix postgresql linking

### DIFF
--- a/docs/en/faq/integration/index.md
+++ b/docs/en/faq/integration/index.md
@@ -12,7 +12,7 @@ keywords: [clickhouse, faq, questions, integrations]
 - [How do I connect Kafka to ClickHouse?](/docs/en/integrations/data-ingestion/kafka/index.md)
 - [Can I connect my Java application to ClickHouse?](/docs/en/integrations/data-ingestion/dbms/jdbc-with-clickhouse.md)
 - [Can ClickHouse read tables from MySQL?](/docs/en/integrations/data-ingestion/dbms/mysql/index.md)
-- [Can ClickHouse read tables from PostgreSQL](/docs/en/integrations/data-ingestion/dbms/postgresql/index.md)
+- [Can ClickHouse read tables from PostgreSQL](/docs/en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md)
 - [What if I have a problem with encodings when connecting to Oracle via ODBC?](/docs/en/faq/integration/oracle-odbc.md)
 
 :::info Don’t see what you're looking for?

--- a/docs/en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
+++ b/docs/en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
@@ -1,5 +1,5 @@
 ---
-slug: /en/integrations/postgresql
+slug: /en/integrations/postgresql/connecting-to-postgresql
 title: Connecting to PostgreSQL
 keywords: [clickhouse, postgres, postgresql, connect, integrate, table, engine]
 ---
@@ -10,7 +10,6 @@ import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 # Connecting ClickHouse to PostgreSQL
 
 This page covers following options for integrating PostgreSQL with ClickHouse:
-
 
 - using [ClickPipes](/en/integrations/clickpipes/postgres), the managed integration service for ClickHouse Cloud - now in Private Preview. Please [sign up here](https://clickpipes.peerdb.io/)
 - using `PeerDB by ClickHouse`, a CDC tool specifically designed for PostgreSQL database replication to both self-hosted ClickHouse and ClickHouse Cloud

--- a/docs/en/integrations/data-sources/postgres.md
+++ b/docs/en/integrations/data-sources/postgres.md
@@ -1,0 +1,10 @@
+---
+slug: /en/integrations/postgresql
+sidebar_label: PostgreSQL
+title: PostgreSQL
+hide_title: false
+---
+
+import PostgreSQL from '@site/docs/en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md';
+
+<PostgreSQL/>

--- a/docs/en/integrations/data-sources/postgres.md
+++ b/docs/en/integrations/data-sources/postgres.md
@@ -7,4 +7,6 @@ hide_title: false
 
 import PostgreSQL from '@site/docs/en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md';
 
+A full migration guide for PostgreSQL to ClickHouse, including advice on data modeling and equivalent concepts, can be found [here](/docs/en/migrations/postgresql/overview). The following describes how to connect ClickHouse and PostgreSQL.
+
 <PostgreSQL/>

--- a/sidebars.js
+++ b/sidebars.js
@@ -121,7 +121,7 @@ const sidebars = {
               id: "en/migrations/postgres/overview",
               label: "Introduction",
             },
-            "en/integrations/data-ingestion/dbms/postgresql/index",
+            "en/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql",
             "en/integrations/data-ingestion/dbms/postgresql/postgres-vs-clickhouse",
             "en/migrations/postgres/dataset",
             "en/migrations/postgres/designing-schemas",
@@ -664,11 +664,7 @@ const sidebars = {
            "en/integrations/data-ingestion/s3/performance"
           ],
         },
-        {
-          type: "doc",
-          id: "en/integrations/data-ingestion/dbms/postgresql/index",
-          label: "PostgreSQL",
-        },
+        "en/integrations/data-sources/postgres",
         {
           type: "category",
           label: "Kafka",


### PR DESCRIPTION
## Summary

Avoids switching between menus when reading postgres guide. File org on disk is still a mess.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
