### PR TITLE
Defining stars value up front and adding fallback

### DIFF
--- a/plugins/header.js
+++ b/plugins/header.js
@@ -8,13 +8,16 @@ async function chHeader(context, opts) {
     name: 'ch-header-plugin',
     
     async loadContent() {
-      // The loadContent hook is executed after siteConfig and env has been loaded.
-      // You can return a JavaScript object that will be passed to contentLoaded hook.
-      const githubData = await fetch(
-        'https://api.github.com/repos/ClickHouse/ClickHouse'
-      )
-      const data = await githubData.json()
-      const stars = data?.stargazers_count ?? 36500
+      let stars = 38000;
+      try {
+        const githubData = await fetch(
+          'https://api.github.com/repos/ClickHouse/ClickHouse'
+        )
+        const data = await githubData.json()
+        stars = data?.stargazers_count ?? stars
+      } catch (error) {
+        console.warn('Failed to fetch GitHub stars:', error)
+      }
       return {
         github: {
           stars


### PR DESCRIPTION
## Summary
There's a production level issue that needs fixing asap. When going from ClickHouse.com to docs, we're getting the following error `TypeError: Cannot read properties of undefined (reading 'stars')`.

I cannot reproduce in any other environment, but in theory this PR should protect against this error by first defining a value for stars before everything else loads.

![CleanShot 2024-12-19 at 13 57 40@2x](https://github.com/user-attachments/assets/955907ae-382e-43a2-b46d-116a75b35288)

