### PR TITLE
Postgres ClickPipe: Add section for rds proxy

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/postgres/source/rds.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/postgres/source/rds.md
@@ -85,6 +85,13 @@ If you want to restrict traffic to your RDS instance, please add the [documented
 
 To connect to your RDS instance through a private network, you can use AWS PrivateLink. Follow our [AWS PrivateLink setup guide for ClickPipes](/knowledgebase/aws-privatelink-setup-for-clickpipes) to set up the connection.
 
+### Workarounds for RDS Proxy
+RDS Proxy does not support logical replication connections. If you have dynamic IP addresses in RDS and cannot use DNS name or a lambda, here are some alternatives:
+
+1. Using a cron job, resolve the RDS endpoint’s IP periodically and update the NLB if it has changed.
+2. Using RDS Event Notifications with EventBridge/SNS: Trigger updates automatically using AWS RDS event notifications
+3. Stable EC2: Deploy an EC2 instance to act as a polling service or IP-based proxy
+4. Automate IP address management using tools like Terraform or CloudFormation.
 
 ## What's next?
 


### PR DESCRIPTION
## Summary
Some users have their RDS behind an [RDS proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) pooler. RDS Proxy does not support streaming replication protocols and thereby the Postgres ClickPipe.

This PR adds some information on workarounds for this in RDS doc

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
