### PR TITLE
Make content more readable

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -419,6 +419,12 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   background: #f8f8f8;
 }
 
+/* override content width */
+:root {
+  --ifm-container-width: 1280px;
+  --ifm-container-width-xl: 1600px;
+}
+
 /* the h1 style on the category pages overrides the font-size */
 .title_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCategoryGeneratedIndexPage-styles-module {
   --ifm-h1-font-size: 2.5rem !important;
@@ -545,19 +551,6 @@ img {
   display: block !important;
   flex: 1 1 auto;
   min-height: auto;
-}
-
-@media (min-width: 1440px) {
-  .container {
-    max-width: 95%;
-    margin-left: 1rem;
-  }
-}
-
-@media (max-width: 1439px) {
-  .container {
-    margin-left: 1rem;
-  }
 }
 
 #__docusaurus {


### PR DESCRIPTION
## Summary

Introduces a small styling change to content width to improve readability. Closes [#2940](https://github.com/ClickHouse/clickhouse-docs/issues/2940). Currently docs have the Docusaurus content area defaults overridden to make content full page width. This results in a high character count per line compared to other documentation sites (see eg. React Native, Jest, MongoDB) and general guidelines for readability (see #2940 for justification).

Before: 
![image](https://github.com/user-attachments/assets/71726533-87d1-46f8-aef6-01b2f679cf97)

After: 
![image](https://github.com/user-attachments/assets/da411520-a579-48e0-aad0-ec313003513b)

Small change but makes a huge difference to readability in my opinion. We can always increase padding between content and the table of contents on the right if the white space on the right feels uncomfortable.

Of course subjective, interested to know what others think.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
