### PR TITLE
Replace sed with cat

### DIFF
--- a/copyClickhouseRepoDocs.sh
+++ b/copyClickhouseRepoDocs.sh
@@ -28,9 +28,7 @@ echo "[$SCRIPT_NAME] Copying completed"
 
 echo "[$SCRIPT_NAME] Generate changelog"
 cp docs/en/_placeholders/changelog/_index.md docs/en/whats-new/changelog/index.md
-sed "0,/^# $(date +%Y) Changelog/d" \
-    < ClickHouse/CHANGELOG.md \
-    >> docs/en/whats-new/changelog/index.md
+cat ClickHouse/CHANGELOG.md >> docs/en/whats-new/changelog/index.md
 
 # Delete ClickHouse repo
 echo "[$SCRIPT_NAME] Start deleting ClickHouse repo"


### PR DESCRIPTION
The `sed` command doesn't do what it's probably supposed to do. To match lines from the beginning of the file until the pattern it needs to start with `1,/` not `0,/`. But also, I don't think we want this since it would remove the table of contents which is useful to have. This is probably some artefact from before something changed in the formatting of the changelog. 

As it is, it just appends the contents, which we can do easily with `cat`.