### PR TITLE
update developer on-demand training broken link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2179,6 +2179,10 @@ const config = {
 						to: '/en/sql-reference/table-functions/generate',
 					},
 					{
+						from: '/en/sql_reference/sql-reference/ansi',
+						to: '/en/sql-reference',
+					},
+					{
 						from: '/en/sql_reference/table_functions/generate',
 						to: '/en/sql-reference/table-functions/generate',
 					},


### PR DESCRIPTION
## Summary
Closes #2980. Adds a redirect to a broken link which is linked from developer on-demand training slides.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
