### PR TITLE
Fix a typo in code snippet

### DIFF
--- a/knowledgebase/mysql-to-parquet-csv-json.md
+++ b/knowledgebase/mysql-to-parquet-csv-json.md
@@ -71,7 +71,7 @@ To go from MySQL to JSON, just change the extension on the filename to `jsonl` o
 
 ```bash
 ./clickhouse local -q "SELECT * FROM
-   mysqlql(
+   mysql(
     'localhost:3306',
     'my_sql_database',
     'my_sql_table',


### PR DESCRIPTION
## Summary

The code snippet in `mysql-to-parquet-csv-json.md` seems to contain a typo. This PR fixes it.