### PR TITLE
Add description of how automatical idling works with RMV and S3 Queue

### DIFF
--- a/docs/en/cloud/manage/scaling.md
+++ b/docs/en/cloud/manage/scaling.md
@@ -86,6 +86,8 @@ In the **Settings** page, you can also choose whether or not to allow automatic 
 
 :::note
 In certain special cases, for instance when a service has a high number of parts, the service will not be idled automatically.
+
+The service may enter an idle state where it suspends refreshes of [refreshable materialized views](/docs/en/materialized-view/refreshable-materialized-view), consumption from [S3Queue](/docs/en/engines/table-engines/integrations/s3queue), and scheduling of new merges. Existing merge operations will complete before the service transitions to the idle state. To ensure continuous operation of refreshable materialized views and S3Queue consumption, disable the idle state functionality.
 :::
 
 :::danger When not to use automatic idling


### PR DESCRIPTION
Adds comment regarding automatic idling behaviour with refreshable materialised views and S3 queue. Closes https://github.com/ClickHouse/clickhouse-docs/issues/3041

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
