### PR TITLE
[ClickPipes] Add GCS FAQ for public buckets

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/object-storage.md
@@ -145,6 +145,11 @@ Service Accounts for GCS aren't directly supported. HMAC (IAM) Credentials must 
 The Service Account permissions attached to the HMAC credentials should be `storage.objects.list` and `storage.objects.get`.
 
 ## F.A.Q.
+
 - **Does ClickPipes support GCS buckets prefixed with `gs://`?**
 
 No. For interoprability reasons we ask you to replace your `gs://` bucket prefix with `https://storage.googleapis.com/`.
+
+- **What permissions does a GCS public bucket require?**
+
+`allUsers` requires appropriate role assignment. The `roles/storage.objectViewer` role must be granted at the bucket level. This role provides the `storage.objects.list` permission, which allows ClickPipes to list all objects in the bucket which is required for onboarding and ingestion. This role also includes the `storage.objects.get` permission, which is required to read or download individual objects in the bucket. See: [Google Cloud Access Control](https://cloud.google.com/storage/docs/access-control/iam-roles) for further information.


### PR DESCRIPTION
## Summary

A cloud user was having issues with the GCS pipe - although the bucket was public and we could read objects, we couldn't list bucket pattern contents which is a critical part of how the pipe functions. 

