### PR TITLE
update restrictions to contact support for table drops greater than 1TB

### DIFF
--- a/docs/en/cloud/manage/backups.md
+++ b/docs/en/cloud/manage/backups.md
@@ -192,4 +192,11 @@ The `UNDROP` command is not supported in ClickHouse Cloud. If you accidentally `
 
 To prevent users from accidentally dropping tables, you can use [`GRANT` statements](/docs/en/sql-reference/statements/grant) to revoke permissions for the [`DROP TABLE` command](/docs/en/sql-reference/statements/drop#drop-table) for a specific user or role.
 
-Additionally, to prevent accidental deletion of data, please note that it is not possible to drop tables >`1TB` in size in ClickHouse Cloud. Please contact support@clickhouse.com if you wish to drop tables greater than this threshold.
+:::note
+To prevent accidental deletion of data, please note that by default it is not possible to drop tables >`1TB` in size in ClickHouse Cloud. 
+Should you wish to drop tables greater than this threshold you can use setting [`max_table_size_to_drop`]() to do so:
+
+```sql
+DROP TABLE IF EXISTS table_to_drop SYNC SETTINGS max_table_size_to_drop=2097152 -- increases the limit to 2TB
+```
+:::

--- a/docs/en/cloud/manage/backups.md
+++ b/docs/en/cloud/manage/backups.md
@@ -194,7 +194,7 @@ To prevent users from accidentally dropping tables, you can use [`GRANT` stateme
 
 :::note
 To prevent accidental deletion of data, please note that by default it is not possible to drop tables >`1TB` in size in ClickHouse Cloud. 
-Should you wish to drop tables greater than this threshold you can use setting [`max_table_size_to_drop`]() to do so:
+Should you wish to drop tables greater than this threshold you can use setting `max_table_size_to_drop` to do so:
 
 ```sql
 DROP TABLE IF EXISTS table_to_drop SYNC SETTINGS max_table_size_to_drop=2097152 -- increases the limit to 2TB


### PR DESCRIPTION
## Summary
Updates [this section](https://clickhouse.com/docs/en/cloud/manage/backups#undeleting-or-undropping-tables) with the correct information. We no longer need support for dropping large tables.

Closes https://github.com/ClickHouse/clickhouse-docs/issues/3051

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
