### PR TITLE
Use new search link APi

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -3,8 +3,7 @@ import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import {useHistory} from '@docusaurus/router';
-import {isRegexpStringMatch} from '@docusaurus/theme-common';
-import {useSearchPage} from '@docusaurus/theme-common/internal';
+import {isRegexpStringMatch, useSearchLinkCreator} from '@docusaurus/theme-common';
 import {
   useAlgoliaContextualFacetFilters,
   useSearchResultUrlProcessor,
@@ -18,7 +17,7 @@ function Hit({hit, children}) {
   return <Link to={hit.url}>{children}</Link>;
 }
 function ResultsFooter({state, onClose}) {
-  const {generateSearchPageLink} = useSearchPage();
+  const generateSearchPageLink = useSearchLinkCreator();
   return (
     <Link to={generateSearchPageLink(state.query)} onClick={onClose}>
       <Translate


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
It seems like we are importing an API that is no longer exported from the docusaurus package. I believe I've found a new hook that serves the same purpose.

Fixes https://github.com/mwoenker/clickhouse-docs/pull/new/mw-fix-search-crash

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
