### PR TITLE
[clickpipes] add FAQ entries for data type mapping, JSON handling, an…

### DIFF
--- a/docs/en/integrations/data-ingestion/clickpipes/postgres/faq.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/postgres/faq.md
@@ -117,7 +117,7 @@ Currently, we don't support defining custom data type mappings as part of the pi
 
 JSON and JSONB columns are replicated as String type in ClickHouse. Since ClickHouse supports a native [JSON type](https://clickhouse.com/docs/en/sql-reference/data-types/newjson), you can create a materialized view over the ClickPipes tables to perform the translation if needed. Alternatively, you can use [JSON functions](https://clickhouse.com/docs/en/sql-reference/functions/json-functions) directly on the String column(s). We are actively working on a feature that replicates JSON and JSONB columns directly to the JSON type in ClickHouse. This feature is expected to be available in a few months.
 
-### What happens to inserts when a mirror is paused during the post-resync process?
+### What happens to inserts when a mirror is paused?
 
 When you pause the mirror, the messages are queued up in the replication slot on the source Postgres, ensuring they are buffered and not lost. However, pausing and resuming the mirror will re-establish the connection, which could take some time depending on the source.
 

--- a/docs/en/integrations/data-ingestion/clickpipes/postgres/faq.md
+++ b/docs/en/integrations/data-ingestion/clickpipes/postgres/faq.md
@@ -127,3 +127,19 @@ During this process, both the sync (pulling data from Postgres and streaming it 
 - For normalize, the ReplacingMergeTree insert order handles deduplication.
 
 In summary, while sync and normalize processes are terminated during a pause, it is safe to do so as they can resume without data loss or inconsistency.
+
+### Can ClickPipe creation be automated or done via API or CLI?
+
+As of now, you can create a ClickPipe only via the UI. However, we are actively working on exposing OpenAPI and Terraform endpoints. We expect this to be released in the near future (within a month). If you are interested in becoming a design partner for this feature, please reach out to db-integrations-support@clickhouse.com.
+
+### How do I speed up my initial load?
+
+You cannot speed up an already running initial load. However, you can optimize future initial loads by adjusting certain settings. By default, the settings are configured with 4 parallel threads and a snapshot number of rows per partition set to 100,000. These are advanced settings and are generally sufficient for most use cases.
+
+For Postgres versions 13 or lower, ctid range scans are slower, and these settings become more critical. In such cases, consider the following process to improve performance:
+
+1. **Drop the existing pipe**: This is necessary to apply new settings.
+2. **Delete destination tables on ClickHouse**: Ensure that the tables created by the previous pipe are removed.
+3. **Create a new pipe with optimized settings**: Typically, increase the snapshot number of rows per partition to between 1 million and 10 million, depending on your specific requirements and the load your Postgres instance can handle.
+
+These adjustments should significantly enhance the performance of the initial load, especially for older Postgres versions. If you are using Postgres 14 or later, these settings are less impactful due to improved support for ctid range scans.


### PR DESCRIPTION
…d mirror pausing

Added three new FAQ entries to the Postgres ClickPipes documentation:
- Custom data type mapping support
- JSON/JSONB column handling and future improvements
- Behavior of inserts during mirror pause/resume

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
