### PR TITLE
update changelog to reference previous year if blank

### DIFF
--- a/copyClickhouseRepoDocs.sh
+++ b/copyClickhouseRepoDocs.sh
@@ -6,7 +6,9 @@ echo "[$SCRIPT_NAME] Start tasks for copying docs from ClickHouse repo"
 
 # Clone ClickHouse repo
 echo "[$SCRIPT_NAME] Start cloning ClickHouse repo"
-git clone --depth 1 https://github.com/ClickHouse/ClickHouse.git
+git clone --depth 1 https://github.com/ClickHouse/ClickHouse.git temp
+cp -r temp/ ClickHouse/
+rm -rf temp
 echo "[$SCRIPT_NAME] Cloning completed"
 
 # Copy docs folders from ClickHouse repo to docs folder
@@ -34,12 +36,15 @@ if grep -q '^# $(date +%Y) Changelog' ClickHouse/CHANGELOG.md; then
   rm temp.txt
   echo "$(date +%Y) Changelog was updated."
 else
-  echo "No Changelog found for present year."
+  current_year="$(date +%Y)"
+  previous_year="$(($current_year - 1))"
+  echo "No Changelog found for $current_year."
+  echo -e ":::note\nThere have been no new releases yet for $current_year.  \n View changelog for the year [$previous_year](/docs/en/whats-new/changelog/$previous_year).\n:::" >> docs/en/whats-new/changelog/index.md
 fi
 
 # Delete ClickHouse repo
 echo "[$SCRIPT_NAME] Start deleting ClickHouse repo"
-rm -r ClickHouse
+rm -rf ClickHouse
 echo "[$SCRIPT_NAME] Deleting ClickHouse repo completed"
 
 echo "[$SCRIPT_NAME] Finish tasks for copying docs from ClickHouse repo"


### PR DESCRIPTION
Closes #3047. 

## Summary
There are currently no new releases for 2025 so the changelog shows as blank.
I have updated the script to reference the previous years change log if this happens.

![Screenshot 2025-01-10 at 11 17 23](https://github.com/user-attachments/assets/95374285-8326-4d17-8df8-ea114d8838ff)

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
