### PR TITLE
Docs: formatting and language edit to Avoid Optimize Final page

### DIFF
--- a/docs/en/cloud/bestpractices/avoidoptimizefinal.md
+++ b/docs/en/cloud/bestpractices/avoidoptimizefinal.md
@@ -2,10 +2,32 @@
 slug: /en/cloud/bestpractices/avoid-optimize-final
 sidebar_label: Avoid Optimize Final
 title: Avoid Optimize Final
+keywords: ['OPTIMIZE TABLE', 'FINAL', 'unscheduled merge']
 ---
 
-Using the [`OPTIMIZE TABLE ... FINAL`](/docs/en/sql-reference/statements/optimize/) query will initiate an unscheduled merge of data parts for the specific table into one data part. During this process, ClickHouse reads all the data parts, uncompresses, merges, compresses them into a single part, and then rewrites back into object store, causing huge CPU and IO consumption.
+Using the [`OPTIMIZE TABLE ... FINAL`](/docs/en/sql-reference/statements/optimize/) query initiates an unscheduled merge of data parts for a specific table into one single data part. 
+During this process, ClickHouse performs the following steps:
 
-Note that this optimization rewrites the one part even if they are already merged into a single part. Also, it is important to note the scope of a "single part" - this indicates that the value of the setting [`max_bytes_to_merge_at_max_space_in_pool`](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#max-bytes-to-merge-at-max-space-in-pool) will be ignored. For example, [`max_bytes_to_merge_at_max_space_in_pool`](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#max-bytes-to-merge-at-max-space-in-pool) is by default set to 150 GB. When running OPTIMIZE TABLE ... FINAL, the remaining single part could exceed even this size. This is another important consideration and reason not to generally use this command, since merging a large number of 150 GB parts into a single part could require a significant amount of time and/or memory.
+- Data parts are read.
+- The parts get uncompressed.
+- The parts get merged.
+- They are compressed into a single part.
+- The part is then written back into the object store.
+
+The operations described above are resource intensive, consuming significant CPU and disk I/O.
+It is important to note that using this optimization will force a rewrite of a part, 
+even if merging to a single part has already occurred.
+
+Additionally, use of the `OPTIMIZE TABLE ... FINAL` query may disregard 
+setting [`max_bytes_to_merge_at_max_space_in_pool`](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#max-bytes-to-merge-at-max-space-in-pool) which controls the maximum size of parts
+that ClickHouse will typically merge by itself in the background.
+
+The [`max_bytes_to_merge_at_max_space_in_pool`](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#max-bytes-to-merge-at-max-space-in-pool) setting is by default set to 150 GB. 
+When running `OPTIMIZE TABLE ... FINAL`, 
+the steps outlined above will be performed resulting in a single part after merge. 
+This remaining single part could exceed the 150 GB specified by the default of this setting. 
+This is another important consideration and reason why you should avoid use of this statement, 
+since merging a large number of 150 GB parts into a single part could require a significant amount of time and/or memory.
+
 
 


### PR DESCRIPTION
## Summary
Small formatting and language edits to Avoid Optimize Final page.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
