### PR TITLE
Modify htmltest config

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,6 +1,5 @@
 DirectoryPath: build/
 IgnoreDirectoryMissingTrailingSlash: true
-CheckAnchors: false
 CheckExternal: true
 CheckInternal: true
 CheckInternalHash: false
@@ -30,5 +29,8 @@ IgnoreURLs:
   - https://www.yandex.com/company/*
   - https://clickhouse-public-datasets.s3.amazonaws.com/my-bucket/some_folder/*
   - https://clickhouse-public-datasets.s3.amazonaws.com/my-test-bucket-768/*
+  IgnoreDirs:
+    - zh
+    - ru
 
 

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,12 +1,13 @@
 DirectoryPath: build/
 IgnoreDirectoryMissingTrailingSlash: true
+CheckAnchors: false
 CheckExternal: true
 CheckInternal: true
 CheckInternalHash: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
 IgnoreInternalEmptyHash: true
-CacheExpires: 144h
+CacheExpires: 16h
 IgnoreURLs:
   - https://62VCH2MD74-dsn.algolia.net
   - https://www.googletagmanager.com


### PR DESCRIPTION
See https://github.com/ClickHouse/clickhouse-docs/issues/3095

## Summary
- changes `CacheExpiry` to 16h given that we change docs content often.
- also turns off checking off anchor tags as they are generated automatically by docusaurus for heading elements but seem to have issues. 

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
