### PR TITLE
Roadmap update

### DIFF
--- a/docs/en/whats-new/roadmap.md
+++ b/docs/en/whats-new/roadmap.md
@@ -8,10 +8,11 @@ sidebar_position: 50
 
 The current roadmap is published for open discussion:
 
-- [2024](https://github.com/ClickHouse/ClickHouse/issues/58392)
+- [2025](https://github.com/ClickHouse/ClickHouse/issues/74046)
 
 ## Previous Roadmaps
 
+- [2024](https://github.com/ClickHouse/ClickHouse/issues/58392)
 - [2023](https://github.com/ClickHouse/ClickHouse/issues/44767)
 - [2022](https://github.com/ClickHouse/ClickHouse/issues/44767)
 - [2021](https://github.com/ClickHouse/ClickHouse/issues/17623)


### PR DESCRIPTION
Adding the link to the 2025 roadmap.

## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adding the link to the [2025](https://github.com/ClickHouse/ClickHouse/issues/74046) roadmap.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
