### PR TITLE
Remove cloud badge from lightweight updates

### DIFF
--- a/docs/en/guides/developer/lightweight-update.md
+++ b/docs/en/guides/developer/lightweight-update.md
@@ -5,11 +5,7 @@ title: Lightweight Update
 keywords: [lightweight update]
 ---
 
-import CloudAvailableBadge from '@theme/badges/CloudAvailableBadge';
-
 ## Lightweight Update
-
-<CloudAvailableBadge/>
 
 When lightweight updates are enabled, updated rows are marked as updated immediately and subsequent `SELECT` queries will automatically return with the changed values. When lightweight updates are not enabled, you may have to wait for your mutations to be applied via a background process to see the changed values.
 
@@ -23,7 +19,7 @@ SET apply_mutations_on_fly = 1;
 
 Let's create a table and run some mutations:
 ```sql
-CREATE TABLE test_on_fly_mutations (id UInt64, v String) 
+CREATE TABLE test_on_fly_mutations (id UInt64, v String)
 ENGINE = MergeTree ORDER BY id;
 
 -- Disable background materialization of mutations to showcase
@@ -93,4 +89,4 @@ These behaviours are controlled by the following settings:
 - `mutations_execute_nondeterministic_on_initiator` - if true, non-deterministic functions are executed on the initiator replica and are replaced as literals in `UPDATE` and `DELETE` queries. Default value: `false`.
 - `mutations_execute_subqueries_on_initiator` - if true, scalar subqueries are executed on the initiator replica and are replaced as literals in `UPDATE` and `DELETE` queries. Default value: `false`.
  - `mutations_max_literal_size_to_replace` - The maximum size of serialized literals in bytes to replace in `UPDATE` and `DELETE` queries. Default value: `16384` (16 KiB).
- 
+


### PR DESCRIPTION
## Summary
This feature was moved to open source recently: https://github.com/ClickHouse/ClickHouse/pull/74877.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
