### PR TITLE
Serialise dates to strings for table of contents generator JSON dump

### DIFF
--- a/scripts/table-of-contents-generator/toc_gen.py
+++ b/scripts/table-of-contents-generator/toc_gen.py
@@ -84,7 +84,7 @@ def write_to_file(json_items, directory, output=None):
     try:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)  # Create directories if they don't exist
         with open(output_path, "w") as f:
-            json.dump(json_items, f, indent=4)
+            json.dump(json_items, f, indent=4, default=str)
             f.write('\n')
             print(f"Wrote {output_path}")
     except OSError as e:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

If you try to generate a table of contents file containing dates, the script throws error:

```
TypeError: Object of type date is not JSON serializable
```

Adds `default=str` to `json.dumps` method such that dates will be written as strings. For our purposes this is probably sufficient for now.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
