### PR TITLE
Fix Changelog generation script

### DIFF
--- a/copyClickhouseRepoDocs.sh
+++ b/copyClickhouseRepoDocs.sh
@@ -31,10 +31,13 @@ echo "[$SCRIPT_NAME] Copying completed"
 
 echo "[$SCRIPT_NAME] Generate changelog"
 cp docs/en/_placeholders/changelog/_index.md docs/en/whats-new/changelog/index.md
-if grep -q '^# $(date +%Y) Changelog' ClickHouse/CHANGELOG.md; then
-  sed '/^# $(date +%Y) Changelog/d' ClickHouse/CHANGELOG.md > temp.txt
-  cat >> docs/en/whats-new/changelog/index.md
-  rm temp.txt
+if grep -q "^# $(date +%Y) Changelog" ClickHouse/CHANGELOG.md; then
+  echo "Generating $(date +%Y) Changelog..."
+  sed "/^# $(date +%Y) Changelog/d" ClickHouse/CHANGELOG.md > temp.txt
+  echo "Changelog copied to temp.txt"
+  cat temp.txt >> docs/en/whats-new/changelog/index.md
+  echo "Changelog written to docs/en/whats-new/changelog/index.md"
+  rm -f temp.txt
   echo "$(date +%Y) Changelog was updated."
 else
   current_year="$(date +%Y)"


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes Changelog generation script which was not functioning correctly after it was changed to display a note if no changelog is present yet at the start of a new year.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
