### PR TITLE
Fix links to primary key guide

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -442,6 +442,10 @@ const config = {
 					{ from: '/en/analyze', to: '/en/sql-reference' },
 					{ from: '/en/guides', to: '/en/guides/creating-tables' },
 					{
+						from: '/en/optimize/sparse-primary-indexes',
+						to: '/en/guides/best-practices/sparse-primary-indexes',
+					},
+					{
 						from: '/en/guides/improving-query-performance/sparse-primary-indexes',
 						to: '/en/guides/best-practices/sparse-primary-indexes',
 					},


### PR DESCRIPTION
## Summary
The links to `Primary Key Indexes` is missing a redirect now that it's in the guides section.

For example: https://clickhouse.com/docs/en/concepts/why-clickhouse-is-so-fast#storage-layer-data-pruning

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
