### PR TITLE
KB article checker: Improve error messages on KB checker

### DIFF
--- a/scripts/knowledgebase-checker/knowledgebase_article_checker.py
+++ b/scripts/knowledgebase-checker/knowledgebase_article_checker.py
@@ -65,6 +65,12 @@ def check_yaml_tags(directory, allowed_tags):
                         if tagged_correct and has_description and has_precontent_tags:
                             correctly_tagged_files.append(filename)
                         else:
+                            if not tagged_correct:
+                                print(f"KB article {filename} is incorrectly tagged")
+                            if not has_description:
+                                print(f"KB article {filename} is lacking a description")
+                            if not has_precontent_tags:
+                                print(f"KB article {filename} is missing \u007bfrontMatter.description/\u007d\u007b/* truncate */\u007d between YAML frontmatter and content.")
                             incorrectly_tagged_files.append(filename)
 
                     except yaml.YAMLError as e:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Error messages when the KB article fails are rather vague.

Makes a change to specifically output what the issue is and which KB article it is complaining about.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
