### PR TITLE
Fix scroll position of main content when left sidebar requires scrolling to show active item

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -63,8 +63,7 @@ body {
 }
 /* Rich's attempt to add scrollbar to nav */
 .sidebar_mhZE {
-  position: absolute !important;
-  padding-bottom: 33px;
+  padding-bottom: 4rem;
   height: 100% !important;
 }
 /* Make the navbar move with the page */
@@ -1068,10 +1067,6 @@ button.DocSearch {
   margin-top: var(--ifm-navbar-height) !important;
 }
 
-.theme-doc-sidebar-container {
-  margin-top: calc(1 * var(--ifm-navbar-height)) !important;
-}
-
 .footer__link-item{
   line-height: inherit;
   color: var(--docsearch-muted-color);
@@ -1101,10 +1096,6 @@ iframe {
 
 [data-theme='dark'] .logo-color {
   fill: white;
-}
-
-nav[aria-label='Docs sidebar'] {
-  overflow: hidden !important;
 }
 
 nav[aria-label='Docs sidebar']:hover {

--- a/src/theme/DocSidebar/Desktop/Content/index.js
+++ b/src/theme/DocSidebar/Desktop/Content/index.js
@@ -36,7 +36,7 @@ export default function DocSidebarDesktopContent({path, sidebar, className}) {
         showAnnouncementBar && styles.menuWithAnnouncementBar,
         className,
       )}
-      style={{paddingTop: '1.75rem', paddingBottom: '250px', overflowY: 'auto'}}
+      style={{paddingTop: '1.75rem', overflowY: 'auto'}}
     >
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
         <DocSidebarItems items={sidebar} activePath={path} level={1} />

--- a/src/theme/DocSidebar/Desktop/index.js
+++ b/src/theme/DocSidebar/Desktop/index.js
@@ -32,7 +32,7 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden, ...props}) {
       if (!isVisible) {
         activeLink.scrollIntoView({
           behavior: 'auto',
-          block: 'center', // 'start' or 'end' depending on where you want the link
+          block: 'end',
         });
       }
     }
@@ -45,8 +45,8 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden, ...props}) {
         styles.sidebar,
         hideOnScroll && styles.sidebarWithHideableNavbar,
         isHidden && styles.sidebarHidden,
+        'padding-top--md',
       )}
-        style={{position: 'fixed'}}
       >
       {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
       <div className={styles.sidebarSearchContainer}>


### PR DESCRIPTION
## Summary

Try to fix scroll position of main content when left sidebar requires scrolling to show active item

Also now the search bar is always visible, previously search bar and the first item from the sidebar was hidden after scrolling the main content.

You can see both issues on https://clickhouse.com/docs/en/optimize/skipping-indexes

I made minimum amount of changes which fixed described issues.

I tested:
1. Scrolling the left sidebar menu to active item works correctly - https://clickhouse.com/docs/en/optimize/skipping-indexes
1. Scrolling to headings works correctly - https://clickhouse.com/docs/en/sql-reference/functions/string-functions#trim

## Before

https://github.com/user-attachments/assets/84cad7d3-0754-4845-bfc6-e1a7fc165470




## After
https://github.com/user-attachments/assets/38acca53-9207-494a-8b84-c8b675aa5a84


