### PR TITLE
Update scaling.md

### DIFF
--- a/docs/en/cloud/manage/scaling.md
+++ b/docs/en/cloud/manage/scaling.md
@@ -73,7 +73,7 @@ However, these services can be scaled vertically by contacting support.
 
 You can use ClickHouse Cloud [public APIs](https://clickhouse.com/docs/en/cloud/manage/api/swagger#/paths/~1v1~1organizations~1:organizationId~1services~1:serviceId~1scaling/patch) to scale your service by updating the scaling settings for the service or adjust the number of replicas from the cloud console.
 
-A **Scale** or **Enterprise** ClickHouse service must have a minimum of `2` replicas.
+**Scale** and **Enterprise** tiers do support single-replcia services. However, a service in these tiers that starts with multiple replicas, or scales out to multiples replicas can only be scaled back in to a minimum of `2` replicas.
 
 :::note
 Services can scale horizontally to a maximum of 20 replicas. If you need additional replicas, please contact our support team.

--- a/docs/en/cloud/manage/scaling.md
+++ b/docs/en/cloud/manage/scaling.md
@@ -73,7 +73,7 @@ However, these services can be scaled vertically by contacting support.
 
 You can use ClickHouse Cloud [public APIs](https://clickhouse.com/docs/en/cloud/manage/api/swagger#/paths/~1v1~1organizations~1:organizationId~1services~1:serviceId~1scaling/patch) to scale your service by updating the scaling settings for the service or adjust the number of replicas from the cloud console.
 
-**Scale** and **Enterprise** tiers do support single-replcia services. However, a service in these tiers that starts with multiple replicas, or scales out to multiples replicas can only be scaled back in to a minimum of `2` replicas.
+**Scale** and **Enterprise** tiers do support single-replica services. However, a service in these tiers that starts with multiple replicas, or scales out to multiples replicas can only be scaled back in to a minimum of `2` replicas.
 
 :::note
 Services can scale horizontally to a maximum of 20 replicas. If you need additional replicas, please contact our support team.


### PR DESCRIPTION
Added clarification that scale and enterprise support single replica services, but can only be scaled down back to 2 replicas once scaled past single replica.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
