### PR TITLE
Fix Typo in the Postgres Query (Limit)

### DIFF
--- a/docs/en/integrations/data-ingestion/dbms/postgresql/rewriting-postgres-queries.md
+++ b/docs/en/integrations/data-ingestion/dbms/postgresql/rewriting-postgres-queries.md
@@ -44,7 +44,7 @@ WHERE (PostTypeId = 1) AND (OwnerDisplayName != '')
 GROUP BY OwnerDisplayName
 HAVING COUNT(*) > 10
 ORDER BY total_views DESC
-LIMIT 10;
+LIMIT 5;
 
 	ownerdisplayname 	| total_views
 -------------------------+-------------


### PR DESCRIPTION
## Summary

The Postgres query had 10 even if the results only shows 5 results, which corresponds to the re-written Clickhouse query.
Quick typo fix.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
