### PR TITLE
Correct Core Concepts link redirecting to wrong place in the docs

### DIFF
--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -130,7 +130,7 @@ const dropdownCategories = [{
       {
         title: 'Core Data Concepts',
         description: 'Understand internal concepts in ClickHouse',
-        link: '/docs/en/concepts'
+        link: '/docs/en/managing-data/core-concepts'
       },
       {
         title: 'Updating Data',


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
