### PR TITLE
Fix Markdown syntax in docs/en/integrations/data-ingestion/data-formats/json/other.md

### DIFF
--- a/docs/en/integrations/data-ingestion/data-formats/json/other.md
+++ b/docs/en/integrations/data-ingestion/data-formats/json/other.md
@@ -27,7 +27,7 @@ Below, we provide an example of using the Nested type to model a static object. 
   "status": 200,
   "size": 3305
 }
-``
+```
 
 We can declare the `request` key as `Nested`. Similar to `Tuple`, we are required to specify the sub columns.
 


### PR DESCRIPTION
## Summary
Resolves issue with Markdown syntax.

## Checklist
- [X] Delete items not relevant to your PR
- [X] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
