### PR TITLE
Make images 100% width on mobile

### DIFF
--- a/docs/en/managing-data/core-concepts/merges.md
+++ b/docs/en/managing-data/core-concepts/merges.md
@@ -21,7 +21,7 @@ To control the number of parts per table and implement ② above, ClickHouse con
 
 The following diagram sketches this background merge process:
 
-<img src={require('./images/merges_01.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_01.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The `merge level` of a part is incremented by one with each additional merge. A level of `0` means the part is new and has not been merged yet. Parts that were merged into larger parts are marked as [inactive](/docs/en/operations/system-tables/parts) and finally deleted after a [configurable](/docs/en/operations/settings/merge-tree-settings#old-parts-lifetime) time (8 minutes by default). Over time, this creates a **tree** of merged parts. Hence the name [merge tree](/docs/en/engines/table-engines/mergetree-family) table.
@@ -59,7 +59,7 @@ The [previously documented](/docs/en/parts#monitoring-table-parts) query result 
 
 In ClickHouse 24.10, a new [merges dashboard](https://presentations.clickhouse.com/2024-release-24.10/index.html#17) was added to the built-in [monitoring dashboards](https://clickhouse.com/blog/common-issues-you-can-solve-using-advanced-monitoring-dashboards). Available in both OSS and Cloud via the `/merges` HTTP handler, we can use it to visualize all part merges for our example table:
 
-<img src={require('./images/merges-dashboard.gif').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges-dashboard.gif').default} alt='PART MERGES' class='image' />
 <br/>
 
 The recorded dashboard above captures the entire process, from the initial data inserts to the final merge into a single part:
@@ -74,7 +74,7 @@ The recorded dashboard above captures the entire process, from the initial data 
 
 A single ClickHouse server uses several background [merge threads](/docs/en/operations/server-configuration-parameters/settings#background_pool_size) to execute concurrent part merges:
 
-<img src={require('./images/merges_02.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_02.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 Each merge thread executes a loop: 
@@ -97,7 +97,7 @@ ClickHouse does not necessarily load all parts to be merged into memory at once,
 
 The diagram below illustrates how a single background [merge thread](/docs/en/merges#concurrent-merges) in ClickHouse merges parts (by default, without [vertical merging](/docs/en/merges#memory-optimized-merges)):
 
-<img src={require('./images/merges_03.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_03.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The part merging is performed in several steps:
@@ -121,7 +121,7 @@ Next, we will briefly outline the merge mechanics of specific engines in the Mer
 
 The diagram below illustrates how parts in a standard [MergeTree](/docs/en/engines/table-engines/mergetree-family/mergetree) table are merged:
 
-<img src={require('./images/merges_04.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_04.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The DDL statement in the diagram above creates a `MergeTree` table with a sorting key `(town, street)`, [meaning](/docs/en/parts#what-are-table-parts-in-clickhouse) data on disk is sorted by these columns, and a sparse primary index is generated accordingly.
@@ -132,7 +132,7 @@ The ① decompressed, pre-sorted table columns are ② merged while preserving t
 
 Part merges in a [ReplacingMergeTree](/docs/en/engines/table-engines/mergetree-family/replacingmergetree) table work similarly to [standard merges](/docs/en/merges#standard-merges), but only the most recent version of each row is retained, with older versions being discarded:
 
-<img src={require('./images/merges_05.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_05.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The DDL statement in the diagram above creates a `ReplacingMergeTree` table with a sorting key `(town, street, id)`, meaning data on disk is sorted by these columns, with a sparse primary index generated accordingly.
@@ -147,7 +147,7 @@ However, the `ReplacingMergeTree` removes duplicate rows with the same sorting k
 
 Numeric data is automatically summarized during merges of parts from a [SummingMergeTree](/docs/en/engines/table-engines/mergetree-family/summingmergetree) table:
 
-<img src={require('./images/merges_06.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_06.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The DDL statement in the diagram above defines a `SummingMergeTree` table with `town` as the sorting key, meaning that data on disk is sorted by this column and a sparse primary index is created accordingly.
@@ -158,7 +158,7 @@ In the ② merging step, ClickHouse replaces all rows with the same sorting key 
 
 The `SummingMergeTree` table example from above is a specialized variant of the [AggregatingMergeTree](/docs/en/engines/table-engines/mergetree-family/aggregatingmergetree) table, allowing [automatic incremental data transformation](https://www.youtube.com/watch?v=QDAJTKZT8y4) by applying any of [90+](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference) aggregation functions during part merges:
 
-<img src={require('./images/merges_07.png').default} alt='PART MERGES' class='image' style={{width: '60%'}} />
+<img src={require('./images/merges_07.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 The DDL statement in the diagram above creates an `AggregatingMergeTree` table with `town` as the sorting key, ensuring data is ordered by this column on disk and a corresponding sparse primary index is generated.

--- a/docs/en/managing-data/core-concepts/partitions.md
+++ b/docs/en/managing-data/core-concepts/partitions.md
@@ -38,7 +38,7 @@ You can [query this table](https://sql.clickhouse.com/?query=U0VMRUNUICogRlJPTSB
 
 Whenever a set of rows is inserted into the table, instead of creating (at [least](/docs/en/operations/settings/settings#max_insert_block_size)) one single data part containing all the inserted rows (as described [here](/docs/en/parts)), ClickHouse creates one new data part for each unique partition key value among the inserted rows:
 
-<img src={require('./images/partitions.png').default} alt='INSERT PROCESSING' class='image' style={{width: '100%'}} />
+<img src={require('./images/partitions.png').default} alt='INSERT PROCESSING' class='image' />
 <br/>
 
 The ClickHouse server first splits the rows from the example insert with 4 rows sketched in the diagram above by their partition key value `toStartOfMonth(date)`. 
@@ -50,7 +50,7 @@ Note that with partitioning enabled, ClickHouse automatically creates [MinMax in
 
 With partitioning enabled, ClickHouse only [merges](/docs/en/merges) data parts within, but not across partitions. We sketch that for our example table from above:
 
-<img src={require('./images/merges_with_partitions.png').default} alt='PART MERGES' class='image' style={{width: '100%'}} />
+<img src={require('./images/merges_with_partitions.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 As sketched in the diagram above, parts belonging to different partitions are never merged. If a partition key with high cardinality is chosen, then parts spread across thousands of partitions will never be merge candidates - exceeding preconfigured limits and causing the dreaded `Too many parts` error. Addressing this problem is simple: choose a sensible partition key with [cardinality under 1000..10000](https://github.com/ClickHouse/ClickHouse/blob/ffc5b2c56160b53cf9e5b16cfb73ba1d956f7ce4/src/Storages/MergeTree/MergeTreeDataWriter.cpp#L121).
@@ -160,7 +160,7 @@ The query runs over our example table from above and [calculates](https://sql.cl
 
 ClickHouse processes that query by applying a sequence of pruning techniques to avoid evaluating irrelevant data:
 
-<img src={require('./images/partition-pruning.png').default} alt='PART MERGES' class='image' style={{width: '100%'}} />
+<img src={require('./images/partition-pruning.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 ① **Partition pruning**: [MinMax indexes](/docs/en/partitions#what-are-table-partitions-in-clickhouse) are used to ignore whole partitions (sets of parts) that logically can't match the query's filter on columns used in the table's partition key.

--- a/docs/en/managing-data/core-concepts/parts.md
+++ b/docs/en/managing-data/core-concepts/parts.md
@@ -30,7 +30,7 @@ You can [query this table](https://sql.clickhouse.com/?query=U0VMRUNUICogRlJPTSB
 
 A data part is created whenever a set of rows is inserted into the table. The following diagram sketches this:
 
-<img src={require('./images/part.png').default} alt='INSERT PROCESSING' class='image' style={{width: '100%'}} />
+<img src={require('./images/part.png').default} alt='INSERT PROCESSING' class='image' />
 <br/>
 
 When a ClickHouse server processes the example insert with 4 rows (e.g., via an [INSERT INTO statement](/docs/en/sql-reference/statements/insert-into)) sketched in the diagram above, it performs several steps:
@@ -51,7 +51,7 @@ Data parts are self-contained, including all metadata needed to interpret their 
 
 To manage the number of parts per table, a [background merge](/docs/en/merges) job periodically combines smaller parts into larger ones until they reach a [configurable](/docs/en/operations/settings/merge-tree-settings#max-bytes-to-merge-at-max-space-in-pool) compressed size (typically ~150 GB). Merged parts are marked as inactive and deleted after a [configurable](/docs/en/operations/settings/merge-tree-settings#old-parts-lifetime) time interval. Over time, this process creates a hierarchical structure of merged parts, which is why it’s called a MergeTree table:
 
-<img src={require('./images/merges.png').default} alt='PART MERGES' class='image' style={{width: '100%'}} />
+<img src={require('./images/merges.png').default} alt='PART MERGES' class='image' />
 <br/>
 
 To minimize the number of initial parts and the overhead of merges, database clients are [encouraged](https://clickhouse.com/blog/asynchronous-data-inserts-in-clickhouse#data-needs-to-be-batched-for-optimal-performance) to either insert tuples in bulk, e.g. 20,000 rows at once, or to use the [asynchronous insert mode](https://clickhouse.com/blog/asynchronous-data-inserts-in-clickhouse), in which ClickHouse buffers rows from multiple incoming INSERTs into the same table and creates a new part only after the buffer size exceeds a configurable threshold, or a timeout expires.

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -471,7 +471,8 @@ prism-code {
 
 /* Add a drop shadow to images in the user guides and docs */
 img {
-  width: fit-content;
+  width: 100%;
+  max-width: 1000px;
   /* padding looks bad in dark mode as it adds white space around images that have dark backgrounds */
   /*padding-bottom: 0.2rem;
   padding-top: 0.5rem;*/
@@ -480,14 +481,6 @@ img {
   margin-right: auto;
   background: var(--clickhouse-img-background-color);
   box-shadow: 0px 1px 8px -1px rgba(21, 21, 21, 0.20);
-}
-
-@media (max-width: 996px) {
-  img {
-    width: 100% !important;
-    margin-left: auto;
-    margin-right: auto;
-  }
 }
 
 .eighty-percent {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -482,6 +482,14 @@ img {
   box-shadow: 0px 1px 8px -1px rgba(21, 21, 21, 0.20);
 }
 
+@media (max-width: 996px) {
+  img {
+    width: 100% !important;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 .eighty-percent {
   max-width: 80%;
   display: block;


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

As discussed with Tom, we make images 60% width on desktop however this displays them too small on mobile. See [Example](https://clickhouse.com/docs/en/merges)

- Added a media query to force images on mobile to 100% width.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
