### PR TITLE
fix html in search

### DIFF
--- a/scripts/search/index_pages.py
+++ b/scripts/search/index_pages.py
@@ -131,6 +131,8 @@ def split_large_document(doc, max_size=10000):
 def clean_content(content):
     content = re.sub(r'\\(\S)', r'\\\\\1', content)  # Replace `\` followed by a non-whitespace character
     content = re.sub(r'```.*?```', '', content, flags=re.DOTALL)  # replace code blocks
+    content = re.sub(r'<iframe.*?</iframe>', '', content, flags=re.DOTALL) # remove iframe
+    content = re.sub(r'<div.*?</div>', '', content, flags=re.DOTALL)
     return content
 
 


### PR DESCRIPTION
## Summary

iframes and divs show in search drop down. We should probably remove all html from the markdown - ill follow up.


## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
