### PR TITLE
Build scripts: don't pull repo if CI environment variable is true

### DIFF
--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -109,12 +109,12 @@ main() {
 
     if [[ -n "$CI" ]]; then
       echo "CI environment detected, expecting /ClickHouse without having to pull the repo"
+      copy_docs_locally "/ClickHouse"
     else
       git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse
+      # Copy docs from cloned repository
+      copy_docs_locally "$(pwd)/ClickHouse"
     fi
-
-    # Copy docs from cloned repository
-    copy_docs_locally "$(pwd)/ClickHouse"
 
     # Remove cloned repository
     rm -rf ClickHouse

--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -107,7 +107,7 @@ main() {
 
   if [[ -z "$local_path" ]]; then
 
-    if [[ -n "$CI" ]]; then
+    if [[ "$CI" == "true" ]]; then
       echo "CI environment detected, expecting /ClickHouse without having to pull the repo"
       copy_docs_locally "/ClickHouse"
     else

--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -26,18 +26,6 @@ function parse_args() {
   echo "$local_path"
 }
 
-# Validate local path exists and ends in ClickHouse
-function validate_local() {
-  echo "Validating path provided"
-  echo "local_path: $local_path"
-  if [[ -d "$local_path" && "$local_path" == *"/ClickHouse" ]]; then
-    return 0
-  else
-    echo "Please provide a valid path to your local ClickHouse repository."
-    exit 1
-  fi
-}
-
 # Copy files/folders using rsync (or fallback to cp)
 copy_item() {
   local source="$1"
@@ -57,11 +45,6 @@ copy_item() {
 # Define function to copy docs locally
 function copy_docs_locally() {
   local local_path=$1
-
-  # Validate local path only if it's provided
-  if [[ -n "$local_path" ]]; then
-    validate_local "$local_path"
-  fi
 
   # Read package.json to get list of docs folders and files
   package_json=$(cat "$(pwd)/package.json")

--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -28,7 +28,8 @@ function parse_args() {
 
 # Validate local path exists and ends in ClickHouse
 function validate_local() {
-
+  echo "Validating path provided"
+  echo "local_path: $local_path"
   if [[ -d "$local_path" && "$local_path" == *"ClickHouse" ]]; then
     return 0
   else

--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -123,7 +123,11 @@ main() {
 
   if [[ -z "$local_path" ]]; then
 
-    git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse
+    if [[ -n "$CI" ]]; then
+      echo "CI environment detected, expecting /ClickHouse without having to pull the repo"
+    else
+      git clone --depth 1 --branch master https://github.com/ClickHouse/ClickHouse
+    fi
 
     # Copy docs from cloned repository
     copy_docs_locally "$(pwd)/ClickHouse"

--- a/scripts/copy-clickhouse-repo-docs.sh
+++ b/scripts/copy-clickhouse-repo-docs.sh
@@ -30,7 +30,7 @@ function parse_args() {
 function validate_local() {
   echo "Validating path provided"
   echo "local_path: $local_path"
-  if [[ -d "$local_path" && "$local_path" == *"ClickHouse" ]]; then
+  if [[ -d "$local_path" && "$local_path" == *"/ClickHouse" ]]; then
     return 0
   else
     echo "Please provide a valid path to your local ClickHouse repository."


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

- Needed for edge case where you make a change on main repo but the docs check fails because the copy-script is pulling from master instead of using the changes from the current branch.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
