### PR TITLE
add redirect for quick start from pricing page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2856,6 +2856,11 @@
       "source": "/docs/manage/billing",
       "destination": "/docs/cloud/manage/billing/overview",
       "permanent": true
+    },
+    {
+      "source": "/docs/quick-start",
+      "destination": "/docs/getting-started/quick-start",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/en/integrations/index.mdx
