### PR TITLE
remove /en

### DIFF
--- a/scripts/settings/autogenerate-settings.sh
+++ b/scripts/settings/autogenerate-settings.sh
@@ -103,7 +103,7 @@ main_content AS
 '---
 title: Session Settings
 sidebar_label: Session Settings
-slug: /en/operations/settings/settings
+slug: /operations/settings/settings
 toc_max_heading_level: 2
 ---
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes /en from autogenerated slug
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
