### PR TITLE
Redirects for 404s

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,15 +101,15 @@ const config = {
 						if (docPath === 'index.md') return false
 
 						if (
-							docPath.includes('/development') ||
-							docPath.includes('/engines') ||
-							docPath.includes('/getting-started') ||
-							docPath.includes('/interfaces') ||
-							docPath.includes('/operations') ||
-							docPath.includes('/sql-reference')
+							docPath.includes('development') ||
+							docPath.includes('engines') ||
+							docPath.includes('getting-started') ||
+							docPath.includes('interfaces') ||
+							docPath.includes('operations') ||
+							docPath.includes('sql-reference')
 						) {
 							return (
-								'https://github.com/ClickHouse/ClickHouse/tree/master/docs/' +
+								'https://github.com/ClickHouse/ClickHouse/tree/master/docs/en/' +
 								docPath
 							)
 						} else {

--- a/vercel.json
+++ b/vercel.json
@@ -3046,6 +3046,21 @@
       "source": "/docs/img/favicon.ico",
       "destination": "/docs/img/docs_favicon.ico",
       "permanent": true
+    },
+    {
+      "source": "/docs/en/changelog/",
+      "destination": "/docs/category/changelog",
+      "permanent": true
+    },
+    {
+      "source": "/docs/en/query_language/functions/string_functions/",
+      "destination": "/docs/sql-reference/functions/string-functions",
+      "permanent": true
+    },
+    {
+      "source": "/docs/manage",
+      "destination": "/docs/guides/manage-and-deploy-index",
+      "permanent": true
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3041,6 +3041,11 @@
       "source": "/robots.txt",
       "destination": "/docs/robots.txt",
       "permanent": true
+    },
+    {
+      "source": "/docs/img/favicon.ico",
+      "destination": "/docs/img/docs_favicon.ico",
+      "permanent": true
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3036,6 +3036,11 @@
       "source": "/docs/intron",
       "destination": "/docs/intro",
       "permanent": true
+    },
+    {
+      "source": "/robots.txt",
+      "destination": "/docs/robots.txt",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- Fixes redirects for 404s 
- Fixes the "edit this page" redirect which broke
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
