### PR TITLE
Revert "Bump actions/github-script from 6 to 7"

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set check status
         if: steps.check_step.outcome != 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('${{ matrix.check_type }} check failed.');


### PR DESCRIPTION
Reverts ClickHouse/clickhouse-docs#3318

Yarn.lock conflict causing issue in https://github.com/ClickHouse/ClickHouse/pull/76639