### PR TITLE
Markdown-lint: modify `custom-anchor-headings` rule to also check for uniqueness

### DIFF
--- a/scripts/.markdownlint-cli2.yaml
+++ b/scripts/.markdownlint-cli2.yaml
@@ -7,7 +7,7 @@ config:
   default:                false
   MD040:                  false  # Fenced code blocks should have a language specified
   links-url-type:         false  # Disallow relative links to a .md or .mdx file
-  custom-anchor-headings: false  # Headings must have a custom anchor eg. # A Heading {#a-heading}
+  custom-anchor-headings: false  # Headings must have a custom anchor which is unique per page eg. # A Heading {#a-heading}
 
   # Keep this item last due to length
   proper-names:                     # MD044

--- a/scripts/markdownlint/rules/headings_have_custom_anchors.js
+++ b/scripts/markdownlint/rules/headings_have_custom_anchors.js
@@ -1,11 +1,17 @@
 const {filterTokens} = require('./utility_functions.js');
 
 /*
-A custom rule that requires headings to have an explicit heading id.
+A custom rule that requires headings to have an explicit heading id which is unique per page.
 
 E.g. ### Hello World {#my-explicit-id}
 
-This is required as LLM translations break anchors by translating the heading
+This is required as LLM translations break anchors by translating the heading.
+
+The explicit ids (anchors) should be unique. E.g the following is invalid:
+
+### First Heading {#my-explicit-id}
+
+### Second Heading {#my-explicit-id} <--- should be unique
 */
 
 module.exports = {
@@ -13,13 +19,26 @@ module.exports = {
     tags: ["headings"],
     description: 'Headings should have an explicit heading id',
     function: (params, onError) => {
+        const headingIds = {};
         filterTokens(params, "heading_open", (token) => {
             const headingLine = params.lines[token.map[0]];
-            const hasCustomId = /\{#./.test(headingLine);
-            if (!hasCustomId) {
+            const match = /\{#([a-zA-Z0-9_-]+)\}/.exec(headingLine);
+
+            if (match) {
+                const id = match[1];
+                if (headingIds[id]) {
+                    onError({
+                        lineNumber: token.map[0] + 1,
+                        detail: `Duplicate heading id: '${id}'.`,
+                        context: headingLine,
+                    });
+                } else {
+                    headingIds[id] = true;
+                }
+            } else {
                 onError({
                     lineNumber: token.map[0] + 1, // Line number is 1-based
-                    details: `${headingLine.trim()} is missing an explicit ID (e.g., {#my-custom-id}).`,
+                    detail: `${headingLine.trim()} is missing an explicit ID (e.g., {#my-custom-id}).`,
                     context: headingLine,
                 });
             };


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- Modifies the custom rule which enforces unique anchor headings to also check that anchors are unique per page
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
