### PR TITLE
Update autogenerate-settings.sh with descriptions

### DIFF
--- a/scripts/settings/autogenerate-settings.sh
+++ b/scripts/settings/autogenerate-settings.sh
@@ -70,6 +70,7 @@ title: Format Settings
 sidebar_label: Format Settings
 slug: /operations/settings/formats
 toc_max_heading_level: 2
+description: Settings which control input and output formats.
 ---
 
 import ExperimentalBadge from \'@theme/badges/ExperimentalBadge\';
@@ -105,6 +106,7 @@ title: Session Settings
 sidebar_label: Session Settings
 slug: /operations/settings/settings
 toc_max_heading_level: 2
+description: Settings which are found in the `system.settings` table. 
 ---
 
 import ExperimentalBadge from \'@theme/badges/ExperimentalBadge\';


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
![Screenshot 2025-02-25 at 16 02 32](https://github.com/user-attachments/assets/0d6b0eb5-c424-4d31-aafd-6490f37bb82c)

Autogenerated table for settings is missing a description for settings pages which are autogenerated. (Missing in the autogen script)
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
