### PR TITLE
Redirect for observability pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3108,8 +3108,8 @@
       "permanent": true
     },
     {
-      "source": "/docs/observability/schema-design(.*)",
-      "destination": "/docs/use-cases/observability/schema-design$1",
+      "source": "/docs/observability/(.*)",
+      "destination": "/docs/use-cases/observability/$1",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2883,11 +2883,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/use-cases/observability/schema-design",
-      "destination": "/docs/observability/schema-design",
-      "permanent": true
-    },
-    {
       "source": "/docs/integrations/sql-clients/clickhouse-client-local",
       "destination": "/docs/operations/utilities/clickhouse-local",
       "permanent": true
@@ -3003,11 +2998,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/observability/schema-design",
-      "destination": "/docs/use-cases/observability/schema-design",
-      "permanent": true
-    },
-    {
       "source": "/docs/cloud-quick-start",
       "destination": "/docs/cloud/get-started/cloud-quick-start",
       "permanent": true
@@ -3115,6 +3105,11 @@
     {
       "source": "/docs/operations",
       "destination": "/docs/guides/manage-and-deploy-index",
+      "permanent": true
+    },
+    {
+      "source": "/docs/observability/schema-design(.*)",
+      "destination": "/docs/use-cases/observability/schema-design$1",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- removes duplicate redirect
- adds a global redirect for observability guide pages so that `#anchor-links` work as well
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
