### PR TITLE
Fix link to swagger

### DIFF
--- a/docs/cloud/manage/api/api-overview.md
+++ b/docs/cloud/manage/api/api-overview.md
@@ -25,7 +25,7 @@ If you'd like to contribute to the ClickHouse Terraform Provider, you can view t
 
 ## Swagger (OpenAPI) Endpoint and UI {#swagger-openapi-endpoint-and-ui}
 
-The ClickHouse Cloud API is built on the open-source [OpenAPI specification](https://www.openapis.org/) to allow for predictable client-side consumption. If you need to programmatically consume the ClickHouse Cloud API docs, we offer a JSON-based Swagger endpoint via https://api.clickhouse.cloud/v1. Our API Reference docs are automatically generated from that same endpoint. If you prefer to consume the API docs via the Swagger UI, please click [here](/docs/cloud/manage/api/swagger).
+The ClickHouse Cloud API is built on the open-source [OpenAPI specification](https://www.openapis.org/) to allow for predictable client-side consumption. If you need to programmatically consume the ClickHouse Cloud API docs, we offer a JSON-based Swagger endpoint via https://api.clickhouse.cloud/v1. Our API Reference docs are automatically generated from that same endpoint. If you prefer to consume the API docs via the Swagger UI, please click [here](https://clickhouse.com/docs/cloud/manage/api/swagger).
 
 ## Support {#support}
 

--- a/docs/cloud/manage/api/api-overview.md
+++ b/docs/cloud/manage/api/api-overview.md
@@ -25,7 +25,7 @@ If you'd like to contribute to the ClickHouse Terraform Provider, you can view t
 
 ## Swagger (OpenAPI) Endpoint and UI {#swagger-openapi-endpoint-and-ui}
 
-The ClickHouse Cloud API is built on the open-source [OpenAPI specification](https://www.openapis.org/) to allow for predictable client-side consumption. If you need to programmatically consume the ClickHouse Cloud API docs, we offer a JSON-based Swagger endpoint via https://api.clickhouse.cloud/v1. Our API Reference docs are automatically generated from that same endpoint. If you prefer to consume the API docs via the Swagger UI, please click [here](/cloud/manage/api/swagger).
+The ClickHouse Cloud API is built on the open-source [OpenAPI specification](https://www.openapis.org/) to allow for predictable client-side consumption. If you need to programmatically consume the ClickHouse Cloud API docs, we offer a JSON-based Swagger endpoint via https://api.clickhouse.cloud/v1. Our API Reference docs are automatically generated from that same endpoint. If you prefer to consume the API docs via the Swagger UI, please click [here](/docs/cloud/manage/api/swagger).
 
 ## Support {#support}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes issue reported in #3360

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
