### PR TITLE
give usageCost page a sidebar

### DIFF
--- a/docs/cloud/manage/api/api-reference-index.md
+++ b/docs/cloud/manage/api/api-reference-index.md
@@ -3,10 +3,11 @@ title: Cloud API
 slug: /cloud/manage/api/
 ---
 
-| Page               | Description                      |
-|--------------------|----------------------------------|
-| [Invitations](/cloud/manage/api/invitations-api-reference) | API reference for invitations.   |
-| [Keys](/cloud/manage/api/keys-api-reference)        | API reference for keys.          |
-| [Members](/cloud/manage/api/members-api-reference)      | API reference for requests.      |
+| Page                                                           | Description                      |
+|----------------------------------------------------------------|----------------------------------|
+| [Invitations](/cloud/manage/api/invitations-api-reference)     | API reference for invitations.   |
+| [Keys](/cloud/manage/api/keys-api-reference)                   | API reference for keys.          |
+| [Members](/cloud/manage/api/members-api-reference)             | API reference for requests.      |
 | [Organizations](/cloud/manage/api/organizations-api-reference) | API reference for organizations. |
-| [Services](/cloud/manage/api/services-api-reference)   | API reference for services.      |
+| [Services](/cloud/manage/api/services-api-reference)           | API reference for services.      |
+| [Usage cost](/cloud/manage/api/usageCost-api-reference)        | API reference for services.      |

--- a/docs/cloud/manage/api/usageCost-api-reference.md
+++ b/docs/cloud/manage/api/usageCost-api-reference.md
@@ -1,6 +1,6 @@
----
+--- 
 sidebar_label: UsageCost
-title: UsageCost
+title: Usage cost
 ---
 
 ## Get organization usage costs {#get-organization-usage-costs}

--- a/sidebars.js
+++ b/sidebars.js
@@ -309,6 +309,7 @@ const sidebars = {
             "cloud/manage/api/members-api-reference",
             "cloud/manage/api/organizations-api-reference",
             "cloud/manage/api/services-api-reference",
+            "cloud/manage/api/usageCost-api-reference",
           ],
         },
       ],


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
usageCost page was floating. Adds it to the sidebar and index page.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
