### PR TITLE
Rewording migration guidance from dedicated to new plan

### DIFF
--- a/docs/cloud/manage/jan2025_faq/plan_migrations.md
+++ b/docs/cloud/manage/jan2025_faq/plan_migrations.md
@@ -70,7 +70,7 @@ Your service has to be on version 24.8 or later and already migrated to SharedMe
 
 ### What is the migration experience for users of the current Development and Production services? Do users need to plan for a maintenance window where the service is unavailable? {#what-is-the-migration-experience-for-users-of-the-current-development-and-production-services-do-users-need-to-plan-for-a-maintenance-window-where-the-service-is-unavailable}
 
-Migrations of Development and Production services to the new pricing tiers may trigger a server restart. To migrate to Dedicated services, please contact [support](https://clickhouse.com/support/program).
+Migrations of Development and Production services to the new pricing tiers may trigger a server restart. To migrate a Dedicated service, please contact [support](https://clickhouse.com/support/program).
 
 ### What other actions should a user take after the migration? {#what-other-actions-should-a-user-take-after-the-migration}
 


### PR DESCRIPTION
It seems that we no longer offer Dedicated services, and I believe the intention was to support users who need to migrate from Dedicated to a new plan.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
