### PR TITLE
Remove nested danger tags

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
@@ -57,12 +57,11 @@ Also, remember to use the same publication name when creating the mirror in Clic
 
 This step will restart your Supabase database and may cause a brief downtime.
 
-:::warning
-
 You can increase the `max_slot_wal_keep_size` parameter for your Supabase database to a higher value (at least 100GB or `102400`) by following the [Supabase Docs](https://supabase.com/docs/guides/database/custom-postgres-config#cli-supported-parameters)
 
 For better recommendation of this value you can contact the ClickPipes team.
 
+:::
 
 ## Connection details to use for Supabase {#connection-details-to-use-for-supabase}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes nested danger tags:

![Screenshot 2025-02-28 at 17 05 58](https://github.com/user-attachments/assets/ea13c6e0-40e7-4081-8b7b-d25e15517125)

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
