### PR TITLE
Fixes to docs check failing on explicit anchors

### DIFF
--- a/docs/cloud/changelogs/changelog-24-12.md
+++ b/docs/cloud/changelogs/changelog-24-12.md
@@ -75,7 +75,7 @@ Relevant changes for ClickHouse Cloud services based on the v24.12 release.
 - Default values for settings `max_size_to_preallocate_for_aggregation`, `max_size_to_preallocate_for_joins` were further increased to `10^12`, so the optimisation will be applied in more cases. [#72555](https://github.com/ClickHouse/ClickHouse/pull/72555) ([Nikita Taranov](https://github.com/nickitat)).
 - Improved performance of deserialization of states of aggregate functions (in data type `AggregateFunction` and in distributed queries). Slightly improved performance of parsing of format `RowBinary`. [#72818](https://github.com/ClickHouse/ClickHouse/pull/72818) ([Anton Popov](https://github.com/CurtizJ)).
 
-## Improvement
+## Improvement {#improvement}
 
 - Higher-order functions with constant arrays and constant captured arguments will return constants. [#58400](https://github.com/ClickHouse/ClickHouse/pull/58400) ([Alexey Milovidov](https://github.com/alexey-milovidov)).
 - Read-in-order optimization via generating virtual rows, so less data would be read during merge sort especially useful when multiple parts exist. [#62125](https://github.com/ClickHouse/ClickHouse/pull/62125) ([Shichao Jin](https://github.com/jsc0218)).

--- a/docs/managing-data/core-concepts/shards.md
+++ b/docs/managing-data/core-concepts/shards.md
@@ -61,7 +61,7 @@ The diagram below illustrates how INSERTs into a distributed table are processed
 
 The next section explains how SELECT forwarding works.
 
-## SELECT forwarding {#insert-routing}
+## SELECT forwarding {#select-forwarding}
 
 This diagram shows how SELECT queries are processed with a distributed table in ClickHouse:
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
We merged the PR which enables checking for issues with explicit anchor tags only after merging PRs which fail this check, so they got through without being picked up.
Fixes docs check.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
