### PR TITLE
Fix docs check

### DIFF
--- a/docs/cloud/reference/architecture.md
+++ b/docs/cloud/reference/architecture.md
@@ -7,7 +7,7 @@ import architecture from '@site/static/images/cloud/reference/architecture.svg';
 
 # ClickHouse Cloud Architecture
 
-<img src={architecture} alt='ClickHouse Cloud architecture' class='image' />
+<architecture alt='ClickHouse Cloud architecture' class='image' />
 
 ## Storage backed by object store {#storage-backed-by-object-store}
 - Virtually unlimited storage


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Image is an svg, not a png so usage of `src` is invalid.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
