### PR TITLE
Script improvements

### DIFF
--- a/scripts/settings/autogenerate-settings.sh
+++ b/scripts/settings/autogenerate-settings.sh
@@ -9,8 +9,6 @@ fi
 # otherwise it will fail not being able to find the files it needs which
 # are copied to scripts/tmp and configured in package.json -> "autogen_settings_needed_files"
 
-set -x
-
 if command -v curl >/dev/null 2>&1; then
   echo "curl is installed"
 else
@@ -33,7 +31,7 @@ script_path="$tmp_dir/$script_filename"
 # Install ClickHouse
 if [ ! -f "$script_path" ]; then
   echo -e "[$SCRIPT_NAME] Installing ClickHouse binary\n"
-  curl https://clickhouse.com/ | sh
+  curl -s https://clickhouse.com/ | sh &> /dev/null
 fi
 
 if [[ ! -f "$script_path" ]]; then
@@ -106,7 +104,7 @@ title: Session Settings
 sidebar_label: Session Settings
 slug: /operations/settings/settings
 toc_max_heading_level: 2
-description: Settings which are found in the `system.settings` table. 
+description: Settings which are found in the ``system.settings`` table.
 ---
 
 import ExperimentalBadge from \'@theme/badges/ExperimentalBadge\';
@@ -130,4 +128,3 @@ echo "[$SCRIPT_NAME] Auto-generation of settings markdown pages completed succes
 rm -rf "$tmp_dir"/{settings-formats.md,settings.md,FormatFactorySettings.h,Settings.cpp,clickhouse}
 
 echo "[$SCRIPT_NAME] Autogenerating settings completed"
-

--- a/scripts/table-of-contents-generator/toc_gen.py
+++ b/scripts/table-of-contents-generator/toc_gen.py
@@ -97,7 +97,7 @@ def write_md_to_file(json_items, path_to_md_file):
                 title = item.get('title', '')
                 slug = item.get('slug', '')
                 description = item.get('description','')
-                link = f"[{title}](/docs{slug})" if slug else title
+                link = f"[{title}]({slug})" if slug else title
                 f.write(f"| {link} | {description} |\n")
 
         print(f"Markdown table appended to {path_to_md_file}")


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- Hides the curl download progress and query output when autogenerate script runs for cleaner build logging
- removes `/docs` from autogenerated table of contents tables (needed for translations)
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
