### PR TITLE
Translations: language drop downs in the language

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -66,17 +66,17 @@ const config = {
         path: "en",
       },
       ru: {
-        label: "Russian",
+        label: "Русский",
         htmlLang: "ru",
         path: "ru",
       },
       jp: {
-        label: "Japanese",
+        label: "日本語",
         htmlLang: "jp",
         path: "jp",
       },
       zh: {
-        label: "Chinese",
+        label: "中文",
         htmlLang: "zh",
         path: "zh",
       },

--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -66,17 +66,17 @@ const config = {
         path: "en",
       },
       ru: {
-        label: "Russian",
+        label: "Русский",
         htmlLang: "ru",
         path: "ru",
       },
       jp: {
-        label: "Japanese",
+        label: "日本語",
         htmlLang: "jp",
         path: "jp",
       },
       zh: {
-        label: "Chinese",
+        label: "中文",
         htmlLang: "zh",
         path: "zh",
       },

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -60,23 +60,23 @@ const config = {
     locales: ["ru", "en", "jp", "zh"],
     path: "i18n",
     localeConfigs: {
-     en: {
+      en: {
         label: "English",
         htmlLang: "en",
         path: "en",
       },
       ru: {
-        label: "Russian",
+        label: "Русский",
         htmlLang: "ru",
         path: "ru",
       },
       jp: {
-        label: "Japanese",
+        label: "日本語",
         htmlLang: "jp",
         path: "jp",
       },
       zh: {
-        label: "Chinese",
+        label: "中文",
         htmlLang: "zh",
         path: "zh",
       },

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -60,23 +60,23 @@ const config = {
     locales: ["zh", "en", "jp", "ru"],
     path: "i18n",
     localeConfigs: {
-     en: {
+      en: {
         label: "English",
         htmlLang: "en",
         path: "en",
       },
       ru: {
-        label: "Russian",
+        label: "Русский",
         htmlLang: "ru",
         path: "ru",
       },
       jp: {
-        label: "Japanese",
+        label: "日本語",
         htmlLang: "jp",
         path: "jp",
       },
       zh: {
-        label: "Chinese",
+        label: "中文",
         htmlLang: "zh",
         path: "zh",
       },


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Languages in the dropdown should display in the language
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
