### PR TITLE
KB navigation: fix routing bug

### DIFF
--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -51,7 +51,7 @@ function BlogListPageContent(props) {
       <ButtonGroup
         onClick={function Nav(value) {
           if (typeof window !== 'undefined') {
-            value === 'recent' ? history.push(`/docs/${currentLocale}/knowledgebase`) : history.push(`/docs/${currentLocale}/knowledgebase/tags`)
+            value === 'recent' ? history.push(`/docs/knowledgebase`) : history.push(`/docs/knowledgebase/tags`)
           }
         }}
         options={[

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -17,7 +17,7 @@ export default function BlogPostItem({children, className}) {
   const containerClassName = useContainerClassName();
   return (
     <BlogPostItemContainer className={clsx(containerClassName, className)}>
-      {location.pathname === '/docs/knowledgebase' || location.pathname.includes('/docs/knowledgebase/tags/') ? <div></div> : <BlogBreadcrumbs/>}
+      {location.pathname.includes('/knowledgebase') || location.pathname.includes('/knowledgebase/tags/') ? <div></div> : <BlogBreadcrumbs/>}
       <BlogPostItemHeader />
       <BlogPostItemContent>{children}</BlogPostItemContent>
       <BlogPostItemFooter />

--- a/src/theme/BlogTagsListPage/index.js
+++ b/src/theme/BlogTagsListPage/index.js
@@ -37,7 +37,7 @@ export default function BlogTagsListPage({ tags, sidebar }) {
         <BlogBreadcrumbs />
         <Heading as="h1" className={styles.kbTitle}><Translate id={`theme.blog.title`} description={`Translation for Knowledge Base`}>Knowledge Base</Translate></Heading>
         <ButtonGroup
-          onClick={function Nav(value) { if (typeof window !== 'undefined') { value === 'recent' ? history.push(`/docs/${currentLocale}/knowledgebase`) : history.push(`/docs/${currentLocale}/knowledgebase/tags`) } }}
+          onClick={function Nav(value) { if (typeof window !== 'undefined') { value === 'recent' ? history.push(`/docs/knowledgebase`) : history.push(`/docs/knowledgebase/tags`) } }}
           options={[
             {
               label: 'Recent',

--- a/src/theme/BlogTagsPostsPage/index.js
+++ b/src/theme/BlogTagsPostsPage/index.js
@@ -43,7 +43,7 @@ function BlogTagsPostsPageContent({ tag, items, sidebar, listMetadata }) {
         <BlogBreadcrumbs />
         <h1 className={styles.kbTitle}>Knowledge Base</h1>
         <ButtonGroup
-          onClick={function Nav(value) { value === 'recent' ? history.push(`/docs/${currentLocale}/knowledgebase`) : history.push(`/docs/${currentLocale}/knowledgebase/tags`) }}
+          onClick={function Nav(value) { value === 'recent' ? history.push(`/docs/knowledgebase`) : history.push(`/docs/knowledgebase/tags`) }}
           options={[
             {
               label: 'Recent',


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes a bug where the "Recent"/"Grouped by tags" navigation breaks after our i18n changes.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
