### PR TITLE
add userspace page cache to sidebar

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -10,3 +10,4 @@
 integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 operations/query-condition-cache
+operations/userspace-page-cache

--- a/sidebars.js
+++ b/sidebars.js
@@ -1109,6 +1109,7 @@ const sidebars = {
         "operations/analyzer",
         "operations/optimizing-performance/sampling-query-profiler",
         "operations/query-cache",
+        //"operations/userspace-page-cache",
         "operations/performance-test",
       ]
     }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds page added in https://github.com/ClickHouse/ClickHouse/pull/78039 to sidebar
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
