### PR TITLE
Fix search action

### DIFF
--- a/.github/workflows/build-search.yml
+++ b/.github/workflows/build-search.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '20' 
 
       - name: Run Prep from Master
-        run: yarn copy-clickhouse-repo-docs
+        run: yarn copy-clickhouse-repo-docs -f
 
       - name: Run Auto Generate Settings
         run: yarn autogenerate-settings


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
We added something to `copy-clickhouse-repo-docs` a little while back such that the repo doesn't get pulled if `CI=true` in environment variables. In this case `CI=true` but we *do* want to pull the repo because this is not the docs-check image which does that already.

Could probably also set `CI=false` but i don't want to test how that affects github so have added a `-f` argument to `copy-clickhouse-repo-docs` which will do a "force pull", even if `CI=true`.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
