### PR TITLE
Fix: Enterprise badge for PCI says HIPAA

### DIFF
--- a/docs/cloud/security/compliance-overview.md
+++ b/docs/cloud/security/compliance-overview.md
@@ -33,7 +33,7 @@ The Health Insurance Portability and Accountability Act (HIPAA) of 1996 is a Uni
 
 ### PCI Service Provider (Since 2025) {#pci-service-provider-since-2025}
 
-<EnterprisePlanFeatureBadge feature="HIPAA" support="true"/>
+<EnterprisePlanFeatureBadge feature="PCI compliance" support="true"/>
 
 Customers must contact sales or support to onboard services to PCI compliant regions to load cardholder data. Additionally, customers should review our PCI responsibility overview available in our [Trust Center](https://trust.clickhouse.com), select and implement appropriate controls for their use case.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes typo in the enterprise badge for PCI which currently reads "HIPAA is an enterprise tier feature..."
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
