### PR TITLE
fix run_indexer.sh

### DIFF
--- a/scripts/search/run_indexer.sh
+++ b/scripts/search/run_indexer.sh
@@ -38,7 +38,7 @@ else
 fi
 
 BASE_DIRECTORY_ARG="$BASE_DIRECTORY"
-SUB_DIRECTORIES="docs/en,knowledgebase"
+SUB_DIRECTORIES="docs,knowledgebase"
 DRY_RUN=false
 
 # allows us to override params if needed


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Nightly reindexing of search is running but not working properly
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
