### PR TITLE
Fix typo in topics2TableMap to topic2TableMap in Kafka connect guide

### DIFF
--- a/docs/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
+++ b/docs/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
@@ -348,7 +348,7 @@ or in the [Kafka documentation](https://kafka.apache.org/documentation/#consumer
 
 #### Multiple high throughput topics {#multiple-high-throughput-topics}
 
-If your connector is configured to subscribe to multiple topics, you're using `topics2TableMap` to map topics to tables, and you're experiencing a bottleneck at insertion resulting in consumer lag, consider creating one connector per topic instead. The main reason why this happens is that currently batches are inserted into every table [serially](https://github.com/ClickHouse/clickhouse-kafka-connect/blob/578ac07e8be1a920aaa3b26e49183595c3edd04b/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java#L95-L100).
+If your connector is configured to subscribe to multiple topics, you're using `topic2TableMap` to map topics to tables, and you're experiencing a bottleneck at insertion resulting in consumer lag, consider creating one connector per topic instead. The main reason why this happens is that currently batches are inserted into every table [serially](https://github.com/ClickHouse/clickhouse-kafka-connect/blob/578ac07e8be1a920aaa3b26e49183595c3edd04b/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java#L95-L100).
 
 Creating one connector per topic is a workaround that ensures that you get the fastest possible insert rate.
 


### PR DESCRIPTION
## Summary
The configuration property was incorrectly mentioned as `topics2TableMap`. The correct property name is `topic2TableMap`. It wasn't very clear while setting up Kafka connectors that subscribed to multiple topics.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
