### PR TITLE
MySQL Overview Doc: change links to point to mysql rds/aurora

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/index.md
@@ -30,9 +30,9 @@ You can use ClickPipes to ingest data from your source MySQL database into Click
 
 To get started, you first need to make sure that your MySQL database is set up correctly. Depending on your source MySQL instance, you may follow any of the following guides:
 
-1. [Amazon RDS MySQL](./postgres/source/rds)
+1. [Amazon RDS MySQL](./mysql/source/rds)
 
-2. [Amazon Aurora MySQL](./postgres/source/aurora)
+2. [Amazon Aurora MySQL](./mysql/source/aurora)
 
 Once your source MySQL database is set up, you can continue creating your ClickPipe.
 


### PR DESCRIPTION
## Summary
This PR fixes two links in the overview page of MySQL ClickPipe - ones which point to MySQL RDS and MySQL Aurora guides. Currently they point to Postgres

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
