### PR TITLE
refactor Postgres source slightly, link MySQL ClickPipe

### DIFF
--- a/docs/integrations/data-ingestion/dbms/mysql/index.md
+++ b/docs/integrations/data-ingestion/dbms/mysql/index.md
@@ -12,7 +12,11 @@ import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 
 # Integrating MySQL with ClickHouse
 
-This page covers using the `MySQL` table engine, for reading from a MySQL table
+This page covers using the `MySQL` table engine, for reading from a MySQL table.
+
+:::note
+For ClickHouse Cloud, you can also use the [MySQL ClickPipe](/integrations/clickpipes/mysql) (currently in Private Preview) to easily move data from your MySQL tables to ClickHouse.
+:::
 
 ## Connecting ClickHouse to MySQL using the MySQL Table Engine {#connecting-clickhouse-to-mysql-using-the-mysql-table-engine}
 

--- a/docs/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
+++ b/docs/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
@@ -12,15 +12,10 @@ import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 
 This page covers following options for integrating PostgreSQL with ClickHouse:
 
-- using [ClickPipes](/integrations/clickpipes/postgres), the managed integration service for ClickHouse Cloud - now in public beta. Please [sign up here](https://clickpipes.peerdb.io/)
-- using `PeerDB by ClickHouse`, a CDC tool specifically designed for PostgreSQL database replication to both self-hosted ClickHouse and ClickHouse Cloud
-  - PeerDB is now available natively in ClickHouse Cloud - Blazing-fast Postgres to ClickHouse CDC with our [new ClickPipe connector](/integrations/clickpipes/postgres) - now in public beta. Please [sign up here](https://clickpipes.peerdb.io/)
+- using [ClickPipes](/integrations/clickpipes/postgres), the managed integration service for ClickHouse Cloud powered by PeerDB - now in public beta!
+- using [PeerDB](https://github.com/PeerDB-io/peerdb), an open-source CDC tool specifically designed for PostgreSQL database replication to both self-hosted ClickHouse and ClickHouse Cloud.
 - using the `PostgreSQL` table engine, for reading from a PostgreSQL table
 - using the experimental `MaterializedPostgreSQL` database engine, for syncing a database in PostgreSQL with a database in ClickHouse
-
-## Using ClickPipes (powered by PeerDB) {#using-clickpipes-powered-by-peerdb}
-
-PeerDB is now available natively in ClickHouse Cloud - Blazing-fast Postgres to ClickHouse CDC with our [new ClickPipe connector](/integrations/clickpipes/postgres) - now in public beta. Please [sign up here](https://clickpipes.peerdb.io/)
 
 ## Using the PostgreSQL Table Engine {#using-the-postgresql-table-engine}
 


### PR DESCRIPTION
## Summary
clean up Postgres data source a bit
add a call to action to MySQL data source linking to MySQL ClickPipe

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
