### PR TITLE
add missing replication permission for MySQL

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/source/aurora.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/source/aurora.md
@@ -62,6 +62,7 @@ Connect to your Aurora MySQL instance as an admin user and execute the following
 
     ```sql
     GRANT REPLICATION CLIENT ON *.* TO 'clickpipes_user'@'%';
+    GRANT REPLICATION SLAVE ON *.* TO 'clickpipes_user'@'%';
     ```
 
 ## Configure network access {#configure-network-access}

--- a/docs/integrations/data-ingestion/clickpipes/mysql/source/rds.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/source/rds.md
@@ -63,6 +63,7 @@ Connect to your RDS MySQL instance as an admin user and execute the following co
 
     ```sql
     GRANT REPLICATION CLIENT ON *.* TO 'clickpipes_user'@'%';
+    GRANT REPLICATION SLAVE ON *.* TO 'clickpipes_user'@'%';
     ```
 
 ## Configure network access {#configure-network-access}


### PR DESCRIPTION
## Summary
missed one permission

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
