### PR TITLE
Add new HIPAA and PCI regions

### DIFF
--- a/docs/cloud/reference/supported-regions.md
+++ b/docs/cloud/reference/supported-regions.md
@@ -80,15 +80,21 @@ Additional requirements may apply for HIPAA compliance (including signing a BAA)
 <EnterprisePlanFeatureBadge feature="HIPAA" support="true"/>
 
 Customers must sign a Business Associate Agreement (BAA) and request onboarding through Sales or Support to set up services in HIPAA compliant regions. The following regions support HIPAA compliance:
-- AWS us-east-1
-- AWS us-west-2
-- GCP us-central1
-- GCP us-east1
+- AWS eu-central-1 (Frankfurt)
+- AWS eu-west-2 (London)
+- AWS us-east-1 (N. Virginia)
+- AWS us-east-2 (Ohio)
+- AWS us-west-2 (Oregon)
+- GCP us-central1 (Iowa)
+- GCP us-east1 (South Carolina)
 
 ## PCI Compliant Regions {#pci-compliant-regions}
 
-<EnterprisePlanFeatureBadge feature="HIPAA" support="true"/>
+<EnterprisePlanFeatureBadge feature="PCI" support="true"/>
 
 Customers must request onboarding through Sales or Support to set up services in PCI compliant regions. The following regions support PCI compliance:
-- AWS us-east-1
-- AWS us-west-2
+- AWS eu-central-1 (Frankfurt)
+- AWS eu-west-2 (London)
+- AWS us-east-1 (N. Virginia)
+- AWS us-east-2 (Ohio)
+- AWS us-west-2 (Oregon)


### PR DESCRIPTION
## Summary
Add new HIPAA/ PCI regions in AWS:
- eu-west-2
- eu-central-1
- us-east-2

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
