### PR TITLE
Revert "Add FixedString to PostgreSQL mapping"

### DIFF
--- a/docs/migrations/postgres/appendix.md
+++ b/docs/migrations/postgres/appendix.md
@@ -166,8 +166,7 @@ The following table shows the equivalent ClickHouse data types for Postgres.
 | `BIGINT` | [Int64](/sql-reference/data-types/int-uint) |
 | `SERIAL` | [UInt32](/sql-reference/data-types/int-uint) |
 | `BIGSERIAL` | [UInt64](/sql-reference/data-types/int-uint) |
-| `TEXT` | [String](/sql-reference/data-types/string) |
-| `CHAR, BPCHAR` | [FixedString](/sql-reference/data-types/fixedstring) |
+| `TEXT, CHAR, BPCHAR` | [String](/sql-reference/data-types/string) |
 | `INTEGER` | Nullable([Int32](/sql-reference/data-types/int-uint)) |
 | `ARRAY` | [Array](/sql-reference/data-types/array) |
 | `FLOAT4` | [Float32](/sql-reference/data-types/float) |

--- a/i18n/ru/docusaurus-plugin-content-docs/current/integrations/data-ingestion/dbms/postgresql/data-type-mappings.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/integrations/data-ingestion/dbms/postgresql/data-type-mappings.md
@@ -19,8 +19,7 @@ description: 'Страница с таблицей, показывающей э�
 | `BIGINT` | [Int64](/sql-reference/data-types/int-uint) |
 | `SERIAL` | [UInt32](/sql-reference/data-types/int-uint) |
 | `BIGSERIAL` | [UInt64](/sql-reference/data-types/int-uint) |
-| `TEXT` | [String](/sql-reference/data-types/string) |
-| `CHAR, BPCHAR` | [FixedString](/sql-reference/data-types/fixedstring) |
+| `TEXT, CHAR, BPCHAR` | [String](/sql-reference/data-types/string) |
 | `INTEGER` | Nullable([Int32](/sql-reference/data-types/int-uint)) |
 | `ARRAY` | [Array](/sql-reference/data-types/array) |
 | `FLOAT4` | [Float32](/sql-reference/data-types/float) |


### PR DESCRIPTION
## Summary
Revert https://github.com/ClickHouse/clickhouse-docs/pull/3489 due to https://github.com/ClickHouse/ClickHouse/pull/79108

PostgreSQL's CHARACTER type stores number of characters, while ClickHouse's FixedString stores number of bytes. Thus, that 1:1 mapping doesn't work for all encodings. That's the reason it wasn't done for MySQL. Since those types mean different things, I think it's rather misleading to map one to the other. The safest option is to map CHARACTER types that mean characters to String instead.

e.g. there might be a Japanese word of 4 characters but that uses 18 bytes

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
