### PR TITLE
Documenting limit (soft) on number of services per warehouse

### DIFF
--- a/docs/cloud/bestpractices/usagelimits.md
+++ b/docs/cloud/bestpractices/usagelimits.md
@@ -17,11 +17,11 @@ If you've run up against one of these guardrails, it's possible that you are imp
 - **Partitions**: 50k
 - **Parts**: 100k across the entire instance
 - **Part size**: 150gb
-- **Services per Organization**: 20 (soft)
-- **Services per Warehouse**: 5 (soft)
+- **Services per organization**: 20 (soft)
+- **Services per warehouse**: 5 (soft)
 - **Low cardinality**: 10k or less
 - **Primary keys in a table**: 4-5 that sufficiently filter down the data
-- **Query Concurrency**: 1000
+- **Query concurrency**: 1000
 - **Batch ingest**: anything > 1M will be split by the system in 1M row blocks
 
 :::note

--- a/docs/cloud/bestpractices/usagelimits.md
+++ b/docs/cloud/bestpractices/usagelimits.md
@@ -17,7 +17,8 @@ If you've run up against one of these guardrails, it's possible that you are imp
 - **Partitions**: 50k
 - **Parts**: 100k across the entire instance
 - **Part size**: 150gb
-- **Services**: 20 (soft)
+- **Services per Organization**: 20 (soft)
+- **Services per Warehouse**: 5 (soft)
 - **Low cardinality**: 10k or less
 - **Primary keys in a table**: 4-5 that sufficiently filter down the data
 - **Query Concurrency**: 1000


### PR DESCRIPTION
A warehouse is a set of services that share the same data.  Today, the number of services in a warehouse is limited to 5.  This is a soft limit.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
