### PR TITLE
Add redirects for recent 404s

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3282,6 +3282,16 @@
       "permanent": true
     },
     {
+      "source": "/docs/category/engines",
+      "destination": "/docs/engines",
+      "permanent": true
+    },
+    {
+      "source": "/docs/integrations/postgresql/data-type-mappings",
+      "destination": "/migrations/postgresql/appendix/#data-type-mappings",
+      "permanent": true
+    },
+    {
       "source": "/docs/en/:path*",
       "destination": "/docs/:path*"
     }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds redirects for two pages giving 404
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
