### PR TITLE
Added new FAQ for MP Committed Spend Billing

### DIFF
--- a/docs/cloud/manage/billing/marketplace/overview.md
+++ b/docs/cloud/manage/billing/marketplace/overview.md
@@ -87,6 +87,6 @@ There is no difference in pricing between marketplace billing and signing up dir
 
 A single ClickHouse organization can only be configured to bill to a single Cloud marketplace billing account or sub account.
 
-### If my ClickHouse Organization is billed through a cloud marketplace committed spend agreement will I automatically move to PAYG billing when I run out of credits?
+### If my ClickHouse Organization is billed through a cloud marketplace committed spend agreement will I automatically move to PAYG billing when I run out of credits? {#automatically-move-to-PAYG-when-running-out-of-credit}
 
 If your marketplace committed spend contract is active and you run out of credits we will automatically move your organization to PAYG billing. However, when your existing contract expires, you will need to link a new marketplace contract to your organization or move your organization to direct billing via credit card. 

--- a/docs/cloud/manage/billing/marketplace/overview.md
+++ b/docs/cloud/manage/billing/marketplace/overview.md
@@ -86,3 +86,7 @@ There is no difference in pricing between marketplace billing and signing up dir
 ### Can I set up multiple ClickHouse Organizations to bill to a single cloud marketplace billing account or sub account (AWS, GCP, or Azure)? {#multiple-organizations-to-bill-to-single-cloud-marketplace-account}
 
 A single ClickHouse organization can only be configured to bill to a single Cloud marketplace billing account or sub account.
+
+### If my ClickHouse Organization is billed through a cloud marketplace committed spend agreement will I automatically move to PAYG billing when I run out of credits?
+
+If your marketplace committed spend contract is active and you run out of credits we will automatically move your organization to PAYG billing. However, when your existing contract expires, you will need to link a new marketplace contract to your organization or move your organization to direct billing via credit card. 


### PR DESCRIPTION
## Summary
Added new  FAQ:

If my ClickHouse Organization is billed through a cloud marketplace committed spend agreement will I automatically move to PAYG billing when I run out of credits?

If your marketplace committed spend contract is active and you run out of credits we will automatically move your organization to PAYG billing. However, when your existing contract expires, you will need to link a new marketplace contract to your organization or move your organization to direct billing via credit card. 

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
