### PR TITLE
Update uk-price-paid.md

### DIFF
--- a/docs/getting-started/example-datasets/uk-price-paid.md
+++ b/docs/getting-started/example-datasets/uk-price-paid.md
@@ -70,7 +70,7 @@ SELECT
     district,
     county
 FROM url(
-    'http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-complete.csv',
+    'http://prod1.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-complete.csv',
     'CSV',
     'uuid_string String,
     price_string String,


### PR DESCRIPTION
clickhouse % curl -I http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-complete.csv  returns: 
HTTP/1.1 301 Moved Permanently
x-amz-id-2: /X17etbRIujTo0RD+3VP9iQc4oy4YTyccAVDCFfmouQ6bsAVOyGpQJqCWugUDeIdW3ZciZxGewJnzjrGy9IZcu2/Ch2Mi6qFB3CxMoq6ZII= x-amz-request-id: WDMQ48SHNJY9JEQ2
Date: Tue, 22 Apr 2025 20:42:16 GMT
Location: http://prod1.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-complete.csv Content-Length: 0
Server: AmazonS3

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
