### PR TITLE
Settings: add logic to handle `auto(N)` default type

### DIFF
--- a/scripts/settings/session-settings.sql
+++ b/scripts/settings/session-settings.sql
@@ -59,7 +59,15 @@ WITH
         ' {#'||name||'} \n\n',
         multiIf(tier == 'Experimental', '<ExperimentalBadge/>\n\n', tier == 'Beta', '<BetaBadge/>\n\n', ''),
         if(description LIKE '%Only has an effect in ClickHouse Cloud%', '<CloudAvailableBadge/>\n\n', ''),
-        if(type != '' AND default != '', format('\n\n<SettingsInfoBlock type="{}" default_value="{}" />\n\n', type, default), ''),
+        if(
+            type != '' AND default != '',
+            format(
+                '\n\n<SettingsInfoBlock type="{}" default_value="{}" />\n\n',
+                type,
+                replaceRegexpOne(default, 'auto\(\d+\)','auto(N)')
+            ),
+            ''
+        ),
         if(rows != '', printf('\n\n<VersionHistory rows={%s}/>\n\n', rows), ''),
         replaceOne(trim(BOTH '\\n' FROM description), ' and [MaterializedMySQL](../../engines/database-engines/materialized-mysql.md)',''))
     FROM settings_with_change_history


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Closes #3724. Adds logic to replace `auto(N)` which shows as `auto(4)` due to the number of threads used in the deploy machine. Default values with `auto()` will now be replaced with string `auto(N)`.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
