### PR TITLE
Fix double title

### DIFF
--- a/docs/cloud/support.md
+++ b/docs/cloud/support.md
@@ -3,6 +3,7 @@ sidebar_label: 'Cloud Support'
 title: 'Cloud Support'
 slug: /cloud/support
 description: 'Learn about Cloud Support'
+hide_title: true
 ---
 
 # Cloud Support


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Two titles show on this page due to snippet import. Fix.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
