### PR TITLE
Redirect to swagger from old API usage cost page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3294,6 +3294,10 @@
     {
       "source": "/docs/en/:path*",
       "destination": "/docs/:path*"
+    },
+    {
+      "source": "/docs/cloud/manage/api/swagger",
+      "destination": "/docs/cloud/manage/api/swagger#/paths/~1v1~1organizations~1%7BorganizationId%7D~1usageCost/get"
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
