### PR TITLE
fix: Duplicate materialized view definition in `Use Cases and Caveats`

### DIFF
--- a/docs/materialized-view/incremental-materialized-view.md
+++ b/docs/materialized-view/incremental-materialized-view.md
@@ -651,8 +651,8 @@ In this example, the set built from the `IN (SELECT id FROM t0)` subquery has on
 Consider our [earlier Materialized View example](/materialized-view/incremental-materialized-view#example) to compute **daily badges per user**, including the user's display name from the `users` table.
 
 ```sql
-CREATE MATERIALIZED VIEW daily_badges_by_user_mv TO daily_badges_by_user AS
-SELECT
+CREATE MATERIALIZED VIEW daily_badges_by_user_mv TO daily_badges_by_user
+AS SELECT
     toDate(Date) AS Day,
     b.UserId,
     u.DisplayName,
@@ -660,7 +660,7 @@ SELECT
     countIf(Class = 'Silver') AS Silver,
     countIf(Class = 'Bronze') AS Bronze
 FROM badges AS b
-LEFT JOIN (SELECT Id, DisplayName FROM users WHERE Id IN (SELECT UserId FROM badges)) AS u ON b.UserId = u.Id
+LEFT JOIN users AS u ON b.UserId = u.Id
 GROUP BY Day, b.UserId, u.DisplayName;
 ```
 


### PR DESCRIPTION
## Summary
[Related issue](https://github.com/ClickHouse/clickhouse-docs/issues/3778)

There are 2 example under `Use Cases and Caveats` with the first showing a non-optimum materialized view join and the second showing a join which filters on the changed rows. The 2 code blocks are identical, just slightly differently formatted in their white space.

This changes the initial query to what should be the non-optimum version.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
