### PR TITLE
Fix broken link in `alternative-query-languages.md`

### DIFF
--- a/docs/guides/developer/alternative-query-languages.md
+++ b/docs/guides/developer/alternative-query-languages.md
@@ -10,7 +10,7 @@ import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 Besides standard SQL, ClickHouse supports various alternative query languages for querying data.
 
 The currently supported dialects are:
-- `clickhouse`: The default [SQL dialect](../../sql-reference/syntax.md) of ClickHouse
+- `clickhouse`: The default [SQL dialect](../../chdb/reference/sql-reference.md) of ClickHouse
 - `prql`: [Pipelined Relational Query Language (PRQL)](https://prql-lang.org/)
 - `kusto`: [Kusto Query Language (KQL)](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query)
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
