### PR TITLE
Fixed scarf pixel displaying at 1x1 full width

### DIFF
--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -9,6 +9,12 @@ export default function CustomLayout(props) {
                 referrerPolicy='no-referrer-when-downgrade'
                 src="https://static.scarf.sh/a.png?x-pxid=e6377503-591b-4886-9398-e69c7fee0b91"
                 alt=""
+                height={0}
+                width={0}
+                style={{
+                    height: 0,
+                    width: 0
+                }}
             />
         </>
     );


### PR DESCRIPTION
## Summary
This PR applies 0x0 dimensions to the scarf tracking pixel ensuring it doesn't add unwanted white space to the bottom of the page