### PR TITLE
KB: custom DNS alias for instance

### DIFF
--- a/knowledgebase/connection_timeout_remote_remoteSecure.mdx
+++ b/knowledgebase/connection_timeout_remote_remoteSecure.mdx
@@ -8,7 +8,7 @@ keywords: ['Connection tries failed']
 
 {frontMatter.description}
 {/* truncate */}
----
+
 
 ## Code: 279. DB::NetException: All connection tries failed. {#code-279-dbnetexception-all-connection-tries-failed}
 

--- a/knowledgebase/custom-dns-alias-for-instance.mdx
+++ b/knowledgebase/custom-dns-alias-for-instance.mdx
@@ -1,31 +1,35 @@
 ---
 title: Create a custom DNS alias by setting up a reverse proxy
-description: Learn how to setup a custom DNS alias for your instance
+description: Learn how to set up a custom DNS alias for your instance using a reverse proxy
 date: 2025-05-16
 tags: ['Server Admin', 'Security and Authentication']
 keywords: ['custom DNS alias', 'DNS']
+hide_title: true
 ---
 
 {frontMatter.description}
 {/* truncate */}
 
+<br/>
+<br/>
 # Custom DNS alias by setting up reverse proxy {#custom-dns-alias}
 
-In this knowledgebase article we will walk you through how you can set up a
-custom DNS alias for your ClickHouse Cloud instance by setting up a reverse
+> In this knowledgebase article, we will walk you through how you can set up a
+custom DNS alias for your ClickHouse Cloud instance through the use of a reverse
 proxy such as Nginx for ClickHouse native client.
 
 ## Create a self-signed certificate {#create-certificate}
 
 :::note
-This step is not needed if you are using signed certificates
+This step is not needed if you are using signed certificates.
 :::
 
 Create a self-signed certificate with the domain name of your choice.
 In this example we will use a domain name `xyz-customdomain.com` and
-create a certificate `MyCertificate.crt`.
+create a certificate called `MyCertificate.crt`. Refer to ["Create SSL certificates"](/guides/sre/configuring-ssl#2-create-ssl-certificates)
+for further details.
 
-Add the following into `/etc/clickhouse-client/config.xml`:
+Add the certificate to `/etc/clickhouse-client/config.xml`:
 
 ```yaml
 <clickhouse>
@@ -54,7 +58,7 @@ proxy_ssl_name xyz.us-west-2.aws.clickhouse.cloud;
 proxy_ssl_server_name on;
 ```
 
-```
+```text
 stream {
     upstream stream_backend {
          server xyz.us-west-2.aws.clickhouse.cloud:9440;
@@ -75,7 +79,9 @@ stream {
 	proxy_ssl_trusted_certificate /etc/ssl/certs/isrgrootx1.pem;
 	proxy_ssl_session_reuse on;
         proxy_ssl_verify on;
+    #highlight-next-line
 	proxy_ssl_name xyz.us-west-2.aws.clickhouse.cloud;
+    #highlight-next-line
 	proxy_ssl_server_name on;
     }
 }
@@ -101,6 +107,8 @@ Add the following to your `/etc/hosts` file on the Nginx server:
 Where `10.X.Y.Z` is the IP address of your specific Nginx box.
 
 ## Connect to Cloud using alias {#connect-to-cloud-using-alias}
+
+You are now ready to connect using your custom alias:
 
 ```bash
 clickhouse-client --host xyz.customdomain.com --secure --password 'xxxxxxx'

--- a/knowledgebase/custom-dns-alias-for-instance.mdx
+++ b/knowledgebase/custom-dns-alias-for-instance.mdx
@@ -1,0 +1,112 @@
+---
+title: Create a custom DNS alias by setting up a reverse proxy
+description: Learn how to setup a custom DNS alias for your instance
+date: 2025-05-16
+tags: ['Server Admin', 'Security and Authentication']
+keywords: ['custom DNS alias', 'DNS']
+---
+
+{frontMatter.description}
+{/* truncate */}
+
+# Custom DNS alias by setting up reverse proxy {#custom-dns-alias}
+
+In this knowledgebase article we will walk you through how you can set up a
+custom DNS alias for your ClickHouse Cloud instance by setting up a reverse
+proxy such as Nginx for ClickHouse native client.
+
+## Create a self-signed certificate {#create-certificate}
+
+:::note
+This step is not needed if you are using signed certificates
+:::
+
+Create a self-signed certificate with the domain name of your choice.
+In this example we will use a domain name `xyz-customdomain.com` and
+create a certificate `MyCertificate.crt`.
+
+Add the following into `/etc/clickhouse-client/config.xml`:
+
+```yaml
+<clickhouse>
+    <openSSL>
+        <client>
+            <loadDefaultCAFile>false</loadDefaultCAFile>
+            # highlight-next-line
+            <caConfig>/etc/ssl/certs/MyCertificate.crt</caConfig>
+            <cacheSessions>true</cacheSessions>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+            <invalidCertificateHandler>
+                <name>RejectCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+</clickhouse>
+```
+
+## Update Nginx configuration {#update-nginx-config}
+
+Add the following in your `nginx.conf` file:
+
+```text
+proxy_ssl_name xyz.us-west-2.aws.clickhouse.cloud;
+proxy_ssl_server_name on;
+```
+
+```
+stream {
+    upstream stream_backend {
+         server xyz.us-west-2.aws.clickhouse.cloud:9440;
+    }
+
+    server {
+        listen                9440 ssl;
+        proxy_pass            stream_backend;
+
+        ssl_certificate       /etc/ssl/certs/MyCertificate.crt;
+        ssl_certificate_key   /etc/ssl/certs/MyKey.key;
+        ssl_protocols         SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers           HIGH:!aNULL:!MD5;
+        ssl_session_cache     shared:SSL:20m;
+        ssl_session_timeout   4h;
+        ssl_handshake_timeout 30s;
+	proxy_ssl on;
+	proxy_ssl_trusted_certificate /etc/ssl/certs/isrgrootx1.pem;
+	proxy_ssl_session_reuse on;
+        proxy_ssl_verify on;
+	proxy_ssl_name xyz.us-west-2.aws.clickhouse.cloud;
+	proxy_ssl_server_name on;
+    }
+}
+```
+
+Where `isrgrootx1.pem` is the root certificate for ClickHouse Cloud which you
+can download [here](https://letsencrypt.org/certs/isrgrootx1.pem).
+
+## Update hosts file {#update-hosts-file}
+
+:::note
+The following step is not needed if you are using your own domain controllers
+:::
+
+Add the following to your `/etc/hosts` file on the Nginx server:
+
+```text title='/etc/hosts'
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost6 localhost6.localdomain6
+10.X.Y.Z  xyz-customdomain.com
+```
+
+Where `10.X.Y.Z` is the IP address of your specific Nginx box.
+
+## Connect to Cloud using alias {#connect-to-cloud-using-alias}
+
+```bash
+clickhouse-client --host xyz.customdomain.com --secure --password 'xxxxxxx'
+ClickHouse client version 23.12.1.428 (official build).
+Connecting to xyz.customdomain.com:9440 as user default.
+Connected to ClickHouse server version 23.9.2.
+
+clickhouse-cloud :)
+```

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -9,8 +9,7 @@ import BlogBreadcrumbs from "../../components/BlogBreadcrumbs/BlogBreadcrumbs";
 import {useLocation} from '@docusaurus/router';
 // apply a bottom margin in list view
 function useContainerClassName() {
-  const {isBlogPostPage} = useBlogPost();
-  return !isBlogPostPage ? 'margin-bottom--xl' : undefined;
+  return 'margin-bottom--xl';
 }
 export default function BlogPostItem({children, className}) {
   const location = useLocation()


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
New KB article on how to set up a custom DNS alias using a reverse proxy
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
