### PR TITLE
Fix link which breaks translations

### DIFF
--- a/docs/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/guides/best-practices/sparse-primary-indexes.md
@@ -1494,7 +1494,7 @@ A compromise between fastest retrieval and optimal data compression is to use a 
 
 ### A concrete example {#a-concrete-example}
 
-One concrete example is a the plaintext paste service https://pastila.nl that Alexey Milovidov developed and [blogged about](https://clickhouse.com/blog/building-a-paste-service-with-clickhouse/).
+One concrete example is a the plaintext paste service [https://pastila.nl](https://pastila.nl) that Alexey Milovidov developed and [blogged about](https://clickhouse.com/blog/building-a-paste-service-with-clickhouse/).
 
 On every change to the text-area, the data is saved automatically into a ClickHouse table row (one row per change).
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

```
× Module build failed:
  ╰─▶   × Error: MDX compilation failed for file "/Users/sstruw/Desktop/clickhouse-docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/best-practices/sparse-primary-indexes.md"
        │ Cause: Can't parse URL https://pastila.nl，并在[博客中介绍了 with base unspecified://
        │ Details:
        │ Error: Can't parse URL https://pastila.nl，并在[博客中介绍了 with base unspecified://
        │     at parseURLOrPath (/Users/sstruw/Desktop/clickhouse-docs/node_modules/@docusaurus/utils/lib/urlUtils.js:162:15)
        │     at parseLocalURLPath (/Users/sstruw/Desktop/clickhouse-docs/node_modules/@docusaurus/utils/lib/urlUtils.js:210:17)
        │     at parseMarkdownLinkURLPath (/Users/sstruw/Desktop/clickhouse-docs/node_modules/@docusaurus/mdx-loader/lib/remark/resolveMarkdownLinks/index.js:12:51)

```
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
