### PR TITLE
Use a light mode theme for light mode

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -285,9 +285,9 @@ const config = {
         copyright: `© 2016&ndash;${new Date().getFullYear()} ClickHouse, Inc.`,
       },
       prism: {
-        theme: themes.darkTheme,
-        darkTheme: themes.darkTheme,
-        additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
+        theme: require('prism-react-renderer').themes.github,
+        darkTheme: require('prism-react-renderer').themes.dracula,
+        additionalLanguages: ["java", "cpp", "rust", "python", "javascript", "yaml"],
         magicComments: [
           // Remember to extend the default highlight class name as well!
           {

--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -286,7 +286,7 @@ const config = {
       },
       prism: {
         theme: require('prism-react-renderer').themes.github,
-        darkTheme: require('prism-react-renderer').themes.dracula,
+        darkTheme: themes.darkTheme,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript", "yaml"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -250,8 +250,8 @@ const config = {
         copyright: `© 2016&ndash;${new Date().getFullYear()} ClickHouse, Inc.`,
       },
       prism: {
-        theme: themes.darkTheme,
-        darkTheme: themes.darkTheme,
+        theme: require('prism-react-renderer').themes.github,
+        darkTheme: require('prism-react-renderer').themes.dracula,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -251,7 +251,7 @@ const config = {
       },
       prism: {
         theme: require('prism-react-renderer').themes.github,
-        darkTheme: require('prism-react-renderer').themes.dracula,
+        darkTheme: themes.darkTheme,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -257,8 +257,8 @@ const config = {
         copyright: `© 2016&ndash;${new Date().getFullYear()} ClickHouse, Inc.`,
       },
       prism: {
-        theme: themes.darkTheme,
-        darkTheme: themes.darkTheme,
+        theme: require('prism-react-renderer').themes.github,
+        darkTheme: require('prism-react-renderer').themes.dracula,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -258,7 +258,7 @@ const config = {
       },
       prism: {
         theme: require('prism-react-renderer').themes.github,
-        darkTheme: require('prism-react-renderer').themes.dracula,
+        darkTheme: themes.darkTheme,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -250,8 +250,8 @@ const config = {
         copyright: `© 2016&ndash;${new Date().getFullYear()} ClickHouse, Inc.`,
       },
       prism: {
-        theme: themes.darkTheme,
-        darkTheme: themes.darkTheme,
+        theme: require('prism-react-renderer').themes.github,
+        darkTheme: require('prism-react-renderer').themes.dracula,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -251,7 +251,7 @@ const config = {
       },
       prism: {
         theme: require('prism-react-renderer').themes.github,
-        darkTheme: require('prism-react-renderer').themes.dracula,
+        darkTheme: themes.darkTheme,
         additionalLanguages: ["java", "cpp", "rust", "python", "javascript"],
         magicComments: [
           // Remember to extend the default highlight class name as well!


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
We were using a dark mode theme for light mode prism highlighting for some sad reason.

YAML syntax highlighting was looking pretty sad:

BEFORE:

![Screenshot 2025-05-22 at 15 01 15](https://github.com/user-attachments/assets/65d4bb4e-a8c4-4a2b-81af-d7bb3b531211)

AFTER:

![Screenshot 2025-05-22 at 15 02 31](https://github.com/user-attachments/assets/c737cbaf-b8e0-440a-aaef-33f6a84bf501)


## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
