### PR TITLE
Fix for part of doc which translations break on

### DIFF
--- a/docs/cloud/manage/jan2025_faq/summary.md
+++ b/docs/cloud/manage/jan2025_faq/summary.md
@@ -39,7 +39,7 @@ Below we provide an overview of the new tiers, describe how they relate to use c
 
 **Basic: A taste of ClickHouse**
 
-* Basic tier is designed to offer a budget-friendly option for organizations with smaller data volumes and less demanding workloads. It allows you to run single-replica deployments with up to 12GB of memory and \< 1TB of storage and is ideal for small-scale use cases that do not require reliability guarantees.
+* Basic tier is designed to offer a budget-friendly option for organizations with smaller data volumes and less demanding workloads. It allows you to run single-replica deployments with up to 12GB of memory and less than 1TB of storage and is ideal for small-scale use cases that do not require reliability guarantees.
 
 **Scale: Enhanced SLAs and scalability**
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
LLM ignores the escaped `<`
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
