### PR TITLE
Fix link which breaks docs translations

### DIFF
--- a/docs/integrations/data-visualization/quicksight-and-clickhouse.md
+++ b/docs/integrations/data-visualization/quicksight-and-clickhouse.md
@@ -117,7 +117,7 @@ Read 4 rows, 603.00 B in 0.00156 sec., 2564 rows/sec., 377.48 KiB/sec.
 
 ## Connecting QuickSight to ClickHouse {#connecting-quicksight-to-clickhouse}
 
-First of all, go to https://quicksight.aws.amazon.com, navigate to Datasets and click "New dataset":
+First of all, go to [https://quicksight.aws.amazon.com](https://quicksight.aws.amazon.com), navigate to Datasets and click "New dataset":
 
 <Image size="md" img={quicksight_01} alt="Amazon QuickSight dashboard showing the New dataset button in Datasets section" border />
 <br/>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
