### PR TITLE
Fix jp imports in zh docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/avoid_mutations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/avoid_mutations.md
@@ -8,6 +8,6 @@
 - 'mutations'
 ---
 
-import Content from '@site/i18n/jp/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_mutations.md';
+import Content from '@site/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_mutations.md';
 
 <Content />

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/avoid_optimize_final.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/avoid_optimize_final.md
@@ -9,6 +9,6 @@
 - 'background merges'
 ---
 
-import Content from '@site/i18n/jp/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_optimize_final.md';
+import Content from '@site/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_optimize_final.md';
 
 <Content />

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/select_data_type.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/select_data_type.md
@@ -8,7 +8,7 @@
 - 'data types'
 ---
 
-import NullableColumns from '@site/i18n/jp/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_nullable_columns.md';
+import NullableColumns from '@site/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/_snippets/_avoid_nullable_columns.md';
 
 ClickHouse 查询性能的核心原因之一是其高效的数据压缩。磁盘上的数据减少通过最小化 I/O 开销，从而导致更快的查询和插入。ClickHouse 的列式架构自然地将相似数据相邻排列，使压缩算法和编解码器能够显著减小数据大小。为了最大化这些压缩收益，精心选择适当的数据类型至关重要。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/selecting_an_insert_strategy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/selecting_an_insert_strategy.md
@@ -15,8 +15,8 @@
 import Image from '@theme/IdealImage';
 import insert_process from '@site/static/images/bestpractices/insert_process.png';
 import async_inserts from '@site/static/images/bestpractices/async_inserts.png';
-import AsyncInserts from '@site/i18n/jp/docusaurus-plugin-content-docs/current/best-practices/_snippets/_async_inserts.md';
-import BulkInserts from '@site/i18n/jp/docusaurus-plugin-content-docs/current/best-practices/_snippets/_bulk_inserts.md';
+import AsyncInserts from '@site/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/_snippets/_async_inserts.md';
+import BulkInserts from '@site/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/_snippets/_bulk_inserts.md';
 
 高效的数据摄取构成了高性能 ClickHouse 部署的基础。选择正确的插入策略可以显著影响吞吐量、成本和可靠性。本节概述了最佳实践、权衡和配置选项，以帮助您为工作负载做出正确的决策。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/cloud/get-started/cloud-quick-start.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/cloud/get-started/cloud-quick-start.mdx
@@ -24,7 +24,7 @@ import data_sources from '@site/static/images/_snippets/data_sources.png';
 import select_data_source from '@site/static/images/_snippets/select_data_source.png';
 import client_details from '@site/static/images/_snippets/client_details.png';
 import new_rows_from_csv from '@site/static/images/_snippets/new_rows_from_csv.png';
-import SQLConsoleDetail from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_launch_sql_console.md';
+import SQLConsoleDetail from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_launch_sql_console.md';
 
 
 # ClickHouse Cloud 快速入门

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/horizontal-scaling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/horizontal-scaling.md
@@ -7,8 +7,8 @@
 ---
 
 import Image from '@theme/IdealImage';
-import ReplicationShardingTerminology from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
-import ConfigFileNote from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_config-files.md';
+import ReplicationShardingTerminology from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
+import ConfigFileNote from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_config-files.md';
 import scalingOut1 from '@site/static/images/deployment-guides/scaling-out-1.png';
 
 ## 描述 {#description}

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/replicated.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/replicated.md
@@ -7,9 +7,9 @@
 ---
 
 import Image from '@theme/IdealImage';
-import ReplicationShardingTerminology from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
-import ConfigFileNote from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_config-files.md';
-import KeeperConfigFileNote from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_keeper-config-files.md';
+import ReplicationShardingTerminology from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
+import ConfigFileNote from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_config-files.md';
+import KeeperConfigFileNote from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_keeper-config-files.md';
 import ReplicationArchitecture from '@site/static/images/deployment-guides/architecture_1s_2r_3_nodes.png';
 
 ## 描述 {#description}

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/terminology.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment-guides/terminology.md
@@ -6,7 +6,7 @@
 'description': '此页面包含基于 ClickHouse Support and Services 组织向 ClickHouse 用户提供的建议的部署示例'
 ---
 
-import ReplicationShardingTerminology from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
+import ReplicationShardingTerminology from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_replication-sharding-terminology.md';
 
 这些部署示例基于 ClickHouse 支持和服务组织向 ClickHouse 用户提供的建议。 这些都是有效的示例，我们建议您尝试它们，然后根据您的需求进行调整。 您可能会在这里找到完全符合您要求的示例。 或者，如果您有一个需求是数据复制三次而不是两次，您应该能够按照这里呈现的模式添加另一个副本。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/example-datasets/cell-towers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/example-datasets/cell-towers.md
@@ -6,14 +6,14 @@
 'title': '使用基站数据集的地理数据'
 ---
 
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import ActionsMenu from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_service_actions_menu.md';
-import SQLConsoleDetail from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_launch_sql_console.md';
-import SupersetDocker from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_add_superset_detail.md';
+import ActionsMenu from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_service_actions_menu.md';
+import SQLConsoleDetail from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_launch_sql_console.md';
+import SupersetDocker from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_add_superset_detail.md';
 import cloud_load_data_sample from '@site/static/images/_snippets/cloud-load-data-sample.png';
 import cell_towers_1 from '@site/static/images/getting-started/example-datasets/superset-cell-tower-dashboard.png'
 import add_a_database from '@site/static/images/getting-started/example-datasets/superset-add.png'

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/astrato-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/astrato-and-clickhouse.md
@@ -28,7 +28,7 @@ import astrato_4c_clickhouse_completed_data_view from '@site/static/images/integ
 import astrato_5a_clickhouse_build_chart from '@site/static/images/integrations/data-visualization/astrato_5a_clickhouse_build_chart.png';
 import astrato_5b_clickhouse_view_sql from '@site/static/images/integrations/data-visualization/astrato_5b_clickhouse_view_sql.png';
 import astrato_5c_clickhouse_complete_dashboard from '@site/static/images/integrations/data-visualization/astrato_5c_clickhouse_complete_dashboard.png';
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import Image from '@theme/IdealImage';
 import CommunityMaintainedBadge from '@theme/badges/CommunityMaintained';
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/chartbrew-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/chartbrew-and-clickhouse.md
@@ -21,7 +21,7 @@ import chartbrew_06 from '@site/static/images/integrations/data-visualization/ch
 import chartbrew_07 from '@site/static/images/integrations/data-visualization/chartbrew_07.png';
 import chartbrew_08 from '@site/static/images/integrations/data-visualization/chartbrew_08.png';
 import chartbrew_09 from '@site/static/images/integrations/data-visualization/chartbrew_09.png';
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import CommunityMaintainedBadge from '@theme/badges/CommunityMaintained';
 import Image from '@theme/IdealImage';
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/embeddable-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/embeddable-and-clickhouse.md
@@ -11,7 +11,7 @@
 'title': '将 Embeddable 连接到 ClickHouse'
 ---
 
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import CommunityMaintainedBadge from '@theme/badges/CommunityMaintained';
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/grafana/config.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/grafana/config.md
@@ -7,7 +7,7 @@
 ---
 
 import Image from '@theme/IdealImage';
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_native.md';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_native.md';
 import config_common from '@site/static/images/integrations/data-visualization/grafana/config_common.png';
 import config_http from '@site/static/images/integrations/data-visualization/grafana/config_http.png';
 import config_additional from '@site/static/images/integrations/data-visualization/grafana/config_additional.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/grafana/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/grafana/index.md
@@ -7,7 +7,7 @@
 'show_related_blogs': true
 ---
 
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_native.md';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_native.md';
 import search from '@site/static/images/integrations/data-visualization/grafana/search.png';
 import install from '@site/static/images/integrations/data-visualization/grafana/install.png';
 import add_new_ds from '@site/static/images/integrations/data-visualization/grafana/add_new_ds.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/looker-studio-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/looker-studio-and-clickhouse.md
@@ -15,8 +15,8 @@
 ---
 
 import Image from '@theme/IdealImage';
-import MySQLCloudSetup from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_cloud_setup.mdx';
-import MySQLOnPremiseSetup from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_on_premise_setup.mdx';
+import MySQLCloudSetup from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_cloud_setup.mdx';
+import MySQLOnPremiseSetup from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_on_premise_setup.mdx';
 import looker_studio_01 from '@site/static/images/integrations/data-visualization/looker_studio_01.png';
 import looker_studio_02 from '@site/static/images/integrations/data-visualization/looker_studio_02.png';
 import looker_studio_03 from '@site/static/images/integrations/data-visualization/looker_studio_03.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/powerbi-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/powerbi-and-clickhouse.md
@@ -11,7 +11,7 @@
 'title': 'Power BI'
 ---
 
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import Image from '@theme/IdealImage';
 import powerbi_odbc_install from '@site/static/images/integrations/data-visualization/powerbi_odbc_install.png';
 import powerbi_odbc_search from '@site/static/images/integrations/data-visualization/powerbi_odbc_search.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/tableau/tableau-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/tableau/tableau-and-clickhouse.md
@@ -13,7 +13,7 @@
 ---
 
 import TOCInline from '@theme/TOCInline';
-import ConnectionDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
+import ConnectionDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_gather_your_details_http.mdx';
 import Image from '@theme/IdealImage';
 import tableau_connecttoserver from '@site/static/images/integrations/data-visualization/tableau_connecttoserver.png';
 import tableau_connector_details from '@site/static/images/integrations/data-visualization/tableau_connector_details.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/tableau/tableau-online-and-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-visualization/tableau/tableau-online-and-clickhouse.md
@@ -14,8 +14,8 @@
 'title': 'Tableau Online'
 ---
 
-import MySQLCloudSetup from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_cloud_setup.mdx';
-import MySQLOnPremiseSetup from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_on_premise_setup.mdx';
+import MySQLCloudSetup from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_cloud_setup.mdx';
+import MySQLOnPremiseSetup from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_clickhouse_mysql_on_premise_setup.mdx';
 import Image from '@theme/IdealImage';
 import tableau_online_01 from '@site/static/images/integrations/data-visualization/tableau_online_01.png';
 import tableau_online_02 from '@site/static/images/integrations/data-visualization/tableau_online_02.png';

--- a/i18n/zh/docusaurus-plugin-content-docs/current/managing-data/deleting-data/delete_mutations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/managing-data/deleting-data/delete_mutations.md
@@ -6,7 +6,7 @@
 'description': '页面描述删除突变 - ALTER 查询通过删除操作来操控表数据'
 ---
 
-import DeleteMutations from '@site/i18n/jp/docusaurus-plugin-content-docs/current/sql-reference/statements/alter/delete.md';
+import DeleteMutations from '@site/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/statements/alter/delete.md';
 
 Delete mutations refers to `ALTER` 查询，通过删除操作来操纵表数据。最显著的查询是 `ALTER TABLE DELETE` 等。执行此类查询会生成数据片段的新变异版本。这意味着这些语句会触发对所有在变异之前插入的数据的整个数据片段的重写，这将导致大量的写请求。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/query_condition_cache.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/query_condition_cache.md
@@ -7,7 +7,7 @@
 'title': 'system.query_condition_cache'
 ---
 
-import SystemTableCloud from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_system_table_cloud.md';
+import SystemTableCloud from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_system_table_cloud.md';
 
 
 # system.query_condition_cache

--- a/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/system_warnings.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/system_warnings.md
@@ -7,7 +7,7 @@
 'title': 'system.warnings'
 ---
 
-import SystemTableCloud from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_system_table_cloud.md';
+import SystemTableCloud from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_system_table_cloud.md';
 
 
 # system.warnings

--- a/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/dictionaries/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/dictionaries/index.md
@@ -6,8 +6,8 @@
 'title': '字典'
 ---
 
-import SelfManaged from '@site/i18n/jp/docusaurus-plugin-content-docs/current/_snippets/_self_managed_only_no_roadmap.md';
-import CloudDetails from '@site/i18n/jp/docusaurus-plugin-content-docs/current/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md';
+import SelfManaged from '@site/i18n/zh/docusaurus-plugin-content-docs/current/_snippets/_self_managed_only_no_roadmap.md';
+import CloudDetails from '@site/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/operators/distributed-ddl.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/operators/distributed-ddl.md
@@ -5,6 +5,6 @@
 'title': '分布式 DDL 页面'
 ---
 
-import Content from '@site/i18n/jp/docusaurus-plugin-content-docs/current/sql-reference/distributed-ddl.md';
+import Content from '@site/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/distributed-ddl.md';
 
 <Content/>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes a bug where Zh files had Jp imports for snippets (had fixed the code already but seems I missed a few pages)
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
