### PR TITLE
Fix top menu change log link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -2006,7 +2006,7 @@ const sidebars = {
           type: "link",
           label: "Changelogs",
           description: "View the latest changes in ClickHouse",
-          href: "/whats-new/security-changelog"
+          href: "/category/changelog"
         },
         {
           type: "link",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Top menu change log link goes to security change logs and not change logs
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
