### PR TITLE
MySQL ClickPipe Aurora Doc: Fix screenshot for parameter group

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/source/aurora.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/source/aurora.md
@@ -9,7 +9,7 @@ import rds_backups from '@site/static/images/integrations/data-ingestion/clickpi
 import parameter_group_in_blade from '@site/static/images/integrations/data-ingestion/clickpipes/postgres/source/rds/parameter_group_in_blade.png';
 import security_group_in_rds_mysql from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/source/rds/security-group-in-rds-mysql.png';
 import edit_inbound_rules from '@site/static/images/integrations/data-ingestion/clickpipes/postgres/source/rds/edit_inbound_rules.png';
-import aurora_config from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/parameter_group/rds_config.png';
+import aurora_config from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/parameter_group/aurora_config.png';
 import binlog_format from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/parameter_group/binlog_format.png';
 import binlog_row_image from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/parameter_group/binlog_row_image.png';
 import binlog_row_metadata from '@site/static/images/integrations/data-ingestion/clickpipes/mysql/parameter_group/binlog_row_metadata.png';
@@ -47,7 +47,7 @@ If this configuration isn't set, Amazon RDS purges the binary logs as soon as po
 
 The parameter group can be found when you click on your MySQL instance in the RDS Console, and then heading over to the `Configurations` tab.
 
-<Image img={aurora_config} alt="Where to find parameter group in RDS" size="lg" border/>
+<Image img={aurora_config} alt="Where to find parameter group in Aurora" size="lg" border/>
 
 Upon clicking on the parameter group link, you will be taken to the page for it. You will see an Edit button in the top-right.
 


### PR DESCRIPTION
## Summary
Currently in the mysql aurora clickpipe doc we are using the screenshot from RDS for the parameter group. This PR fixes this
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
