### PR TITLE
improve grammar in csv header tip

### DIFF
--- a/docs/integrations/data-ingestion/data-formats/csv-tsv.md
+++ b/docs/integrations/data-ingestion/data-formats/csv-tsv.md
@@ -71,7 +71,7 @@ clickhouse-client -q "INSERT INTO sometable FORMAT CSVWithNames" < data_small_he
 In this case, ClickHouse skips the first row while importing data from the file.
 
 :::tip
-Starting from 23.1 [version](https://github.com/ClickHouse/ClickHouse/releases) ClickHouse will automatically detect headers in CSV files when `CSV` type is used, so no need to use `CSVWithNames` or `CSVWithNamesAndTypes`.
+Starting from [version](https://github.com/ClickHouse/ClickHouse/releases) 23.1, ClickHouse will automatically detect headers in CSV files when using the `CSV` format, so it is not necessary to use `CSVWithNames` or `CSVWithNamesAndTypes`.
 :::
 
 


### PR DESCRIPTION
## Summary
Simple PR improves the grammar in one of the tips on the CSV format page.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
