### PR TITLE
add named tuple to js mapping table

### DIFF
--- a/docs/integrations/language-clients/js.md
+++ b/docs/integrations/language-clients/js.md
@@ -816,7 +816,8 @@ The related JS type is relevant for any `JSON*` formats except the ones that rep
 | Variant(T1, T2...) | ✔️              | T (depends on the variant) |
 | Dynamic            | ✔️              | T (depends on the variant) |
 | Nested             | ✔️              | T[]                        |
-| Tuple              | ✔️              | Tuple                      |
+| Tuple(T1, T2, ...) | ✔️              | [T1, T2, ...]              |
+| Tuple(n1 T1, n2 T2...)  | ✔️         | \{ n1: T1; n2: T2; ...}     |
 | Nullable(T)        | ✔️              | JS type for T or null      |
 | IPv4               | ✔️              | string                     |
 | IPv6               | ✔️              | string                     |


### PR DESCRIPTION
## Summary
Add an entry to the table of JS types for named tuples

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
