### PR TITLE
fix mobile language picker bug on `/docs`

### DIFF
--- a/src/components/MobileSideBarMenu/MobileLanguagePicker.jsx
+++ b/src/components/MobileSideBarMenu/MobileLanguagePicker.jsx
@@ -144,9 +144,9 @@ const MobileLanguagePicker = ({ onLanguageChange }) => {
                             // Handle docs root paths specifically
                             if (currentPath === '/docs' || currentPath === '/docs/') {
                                 if (locale === i18n.defaultLocale || locale === 'en') {
-                                    href = '/docs/';
+                                    href = '/docs';
                                 } else {
-                                    href = `/docs/${locale}/`;
+                                    href = `/docs/${locale}`;
                                 }
                             } else {
                                 // Remove existing locale from docs path if present


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
When on /docs selecting a different language takes you to /docs/jp/ when it should be /docs/jp. Same for other languages.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
