### PR TITLE
dlt: Move dataset_table_separator out of destination.clickhouse.creds

### DIFF
--- a/docs/integrations/data-ingestion/etl-tools/dlt-and-clickhouse.md
+++ b/docs/integrations/data-ingestion/etl-tools/dlt-and-clickhouse.md
@@ -74,6 +74,8 @@ host = "localhost"                       # ClickHouse server host
 port = 9000                              # ClickHouse HTTP port, default is 9000
 http_port = 8443                         # HTTP Port to connect to ClickHouse server's HTTP interface. Defaults to 8443.
 secure = 1                               # Set to 1 if using HTTPS, else 0.
+
+[destination.clickhouse]
 dataset_table_separator = "___"          # Separator for dataset table names from dataset.
 ```
 


### PR DESCRIPTION
`dataset_table_separator` belongs in `destination.clickhouse`, not in `destination.clickhouse.credentials`.