### PR TITLE
Update export-backups-to-own-cloud-account.md

### DIFF
--- a/docs/cloud/manage/backups/export-backups-to-own-cloud-account.md
+++ b/docs/cloud/manage/backups/export-backups-to-own-cloud-account.md
@@ -12,7 +12,7 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 ClickHouse Cloud supports taking backups to your own cloud service provider (CSP) account (AWS S3, Google Cloud Storage, or Azure Blob Storage).
 For details of how ClickHouse Cloud backups work, including "full" vs. "incremental" backups, see the [backups](overview.md) docs.
 
-Here we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups. The BACKUP commands listed below are run within the original service. The RESTORE commands are run from a new service where the backup is going to be restored. 
+Here we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups. The BACKUP commands listed below are run within the original service. The RESTORE commands are run from a new service where the backup should be restored. 
 
 :::note
 Users should be aware that any usage where backups are being exported to a different region in the same cloud provider, or to another cloud provider (in the same or different region) will incur [data transfer](../network-data-transfer.mdx) charges.

--- a/docs/cloud/manage/backups/export-backups-to-own-cloud-account.md
+++ b/docs/cloud/manage/backups/export-backups-to-own-cloud-account.md
@@ -12,10 +12,14 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 ClickHouse Cloud supports taking backups to your own cloud service provider (CSP) account (AWS S3, Google Cloud Storage, or Azure Blob Storage).
 For details of how ClickHouse Cloud backups work, including "full" vs. "incremental" backups, see the [backups](overview.md) docs.
 
-Here we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups.
+Here we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups. The BACKUP commands listed below are run within the original service. The RESTORE commands are run from a new service where the backup is going to be restored. 
 
 :::note
 Users should be aware that any usage where backups are being exported to a different region in the same cloud provider, or to another cloud provider (in the same or different region) will incur [data transfer](../network-data-transfer.mdx) charges.
+:::
+
+:::note
+Backup / Restore into your own bucket for services utilizing [TDE](https://clickhouse.com/docs/cloud/security/cmek#transparent-data-encryption-tde) is currently not supported. 
 :::
 
 ## Requirements {#requirements}
@@ -58,6 +62,11 @@ You will need the following details to export/restore backups to your own CSP st
 
 <hr/>
 # Backup / Restore
+
+:::note:::
+1. For restoring the backup from your own bucket into a new service, you will need to update the trust policy of your backups storage bucket to allow access from the new service.
+2. The Backup / Restore commands need to be run from the database command line. For restore to a new service, you will first need to create the service and then run the command.   
+:::
 
 ## Backup / Restore to AWS S3 Bucket {#backup--restore-to-aws-s3-bucket}
 


### PR DESCRIPTION
Added notes to clarify the following:
1. Clarified that backup/restore to customer bucket is not supported for services using TDE
2. Restore to a new service requires updating the trust policy of  backups storage bucket.
3. Backup / Restore commands need to be run from the database command line

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
