### PR TITLE
Update debugging-memory-issues.md

### DIFF
--- a/docs/guides/developer/debugging-memory-issues.md
+++ b/docs/guides/developer/debugging-memory-issues.md
@@ -68,13 +68,15 @@ SELECT formatReadableSize(sum(memory_usage)) FROM system.processes;
 SELECT formatReadableSize(sum(bytes_allocated)) FROM system.dictionaries;
 ```
 
-## Output total memory used by primary keys {#output-total-memory-used-by-primary-keys}
+## Output total memory used by primary keys and index granularity {#output-total-memory-used-by-primary-keys}
 
 ```sql
 SELECT
-    sumIf(data_uncompressed_bytes, part_type = 'InMemory') as memory_parts,
+    sumIf(data_uncompressed_bytes, part_type = 'InMemory') AS memory_parts,
     formatReadableSize(sum(primary_key_bytes_in_memory)) AS primary_key_bytes_in_memory,
-    formatReadableSize(sum(primary_key_bytes_in_memory_allocated)) AS primary_key_bytes_in_memory_allocated
+    formatReadableSize(sum(primary_key_bytes_in_memory_allocated)) AS primary_key_bytes_in_memory_allocated,
+    formatReadableSize(sum(index_granularity_bytes_in_memory)) AS index_granularity_bytes_in_memory,
+    formatReadableSize(sum(index_granularity_bytes_in_memory_allocated)) AS index_granularity_bytes_in_memory_allocated
 FROM system.parts;
 ```
 


### PR DESCRIPTION
## Summary
Add `index_granularity_bytes_in_memory` and `index_granularity_bytes_in_memory_allocated` since they also reside in memory

