### PR TITLE
remove marketing from docs

### DIFF
--- a/docs/cloud/manage/billing.md
+++ b/docs/cloud/manage/billing.md
@@ -367,7 +367,7 @@ affordable for customers to move data from Postgres to ClickHouse for
 real-time analytics.
 
 The connector is over **5x more cost-effective** than external
-ETL tools and similar features in other database platforms. $^*$
+ETL tools and similar features in other database platforms.
 
 :::note
 Pricing will start being metered in monthly bills beginning **September 1st, 2025,**
@@ -376,10 +376,6 @@ then, usage is free. Customers have a 3-month window starting May 29 (GA announc
 to review and optimize their costs if needed, although we expect most will not need
 to make any changes.
 :::
-
-$^*$ _For example, the external ETL tool Airbyte, which offers similar CDC capabilities,
-charges $10/GB (excluding credits)—more than 20 times the cost of Postgres CDC in
-ClickPipes for moving 1TB of data._
 
 #### Pricing dimensions {#pricing-dimensions}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes marketing lingo from the doc
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
