### PR TITLE
Docs: Update unity_catalog.md to mention need to enable it via setting

### DIFF
--- a/docs/use-cases/data_lake/unity_catalog.md
+++ b/docs/use-cases/data_lake/unity_catalog.md
@@ -23,6 +23,11 @@ ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, et
 
 Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog tables as both Delta and Iceberg.
 
+:::note
+As this feature is experimental, you will need to enable it using:
+`SET allow_experimental_database_unity_catalog = 1;`
+:::
+
 ## Configuring Unity in Databricks {#configuring-unity-in-databricks}
 
 To allow ClickHouse to interact with the Unity catalog, you need to make sure the Unity Catalog is configured to allow interaction with an external reader. This can be achieved by following the[ "Enable external data access to Unity Catalog"](https://docs.databricks.com/aws/en/external-access/admin) guide.


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Updating based on discussion here: https://clickhousedb.slack.com/archives/CU478UEQZ/p1750676732132329?thread_ts=1750676432.764169&cid=CU478UEQZ

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
