### PR TITLE
Change lowercase SQL keywords to uppercase to improve consistency

### DIFF
--- a/docs/best-practices/using_data_skipping_indices.md
+++ b/docs/best-practices/using_data_skipping_indices.md
@@ -140,7 +140,7 @@ LIMIT 1
 A simple analysis shows that `ViewCount` is correlated with the `CreationDate` (a primary key) as one might expect - the longer a post exists, the more time it has to be viewed.
 
 ```sql
-SELECT toDate(CreationDate) as day, avg(ViewCount) as view_count FROM stackoverflow.posts WHERE day > '2009-01-01'  GROUP BY day
+SELECT toDate(CreationDate) AS day, avg(ViewCount) AS view_count FROM stackoverflow.posts WHERE day > '2009-01-01'  GROUP BY day
 ```
 
 This therefore makes a logical choice for a data skipping index. Given the numeric type, a min_max index makes sense. We add an index using the following `ALTER TABLE` commands - first adding it, then "materializing it".

--- a/docs/cloud/get-started/query-endpoints.md
+++ b/docs/cloud/get-started/query-endpoints.md
@@ -29,16 +29,16 @@ If you have a saved query, you can skip this step.
 Open a new query tab. For demonstration purposes, we'll use the [youtube dataset](/getting-started/example-datasets/youtube-dislikes), which contains approximately 4.5 billion records. As an example query, we'll return the top 10 uploaders by average views per video in a user-inputted `year` parameter:
 
 ```sql
-with sum(view_count) as view_sum,
-    round(view_sum / num_uploads, 2) as per_upload
-select
+WITH sum(view_count) AS view_sum,
+    round(view_sum / num_uploads, 2) AS per_upload
+SELECT
     uploader,
-    count() as num_uploads,
-    formatReadableQuantity(view_sum) as total_views,
-    formatReadableQuantity(per_upload) as views_per_video
-from
+    count() AS num_uploads,
+    formatReadableQuantity(view_sum) AS total_views,
+    formatReadableQuantity(per_upload) AS views_per_video
+FROM
     youtube
-where
+WHERE
     toYear(upload_date) = {year: UInt16}
 group by uploader
 order by per_upload desc
@@ -149,7 +149,7 @@ To upgrade the endpoint version from `v1` to `v2`, include the `x-clickhouse-end
 **Query API Endpoint SQL:**
 
 ```sql
-SELECT database, name as num_tables FROM system.tables limit 3;
+SELECT database, name AS num_tables FROM system.tables LIMIT 3;
 ```
 
 #### Version 1 {#version-1}
@@ -365,7 +365,7 @@ OK
 **Query API Endpoint SQL:**
 
 ```sql
-SELECT * from system.tables;
+SELECT * FROM system.tables;
 ```
 
 **cURL:**
@@ -401,7 +401,7 @@ fetch(
 **Query API Endpoint SQL:**
 
 ```sql
-SELECT name, database from system.tables;
+SELECT name, database FROM system.tables;
 ```
 
 **Typescript:**

--- a/docs/cloud/get-started/sql-console.md
+++ b/docs/cloud/get-started/sql-console.md
@@ -251,17 +251,17 @@ Query result sets can be easily exported to CSV format directly from the SQL con
 Some data can be more easily interpreted in chart form. You can quickly create visualizations from query result data directly from the SQL console in just a few clicks. As an example, we'll use a query that calculates weekly statistics for NYC taxi trips:
 
 ```sql
-select
-   toStartOfWeek(pickup_datetime) as week,
-   sum(total_amount) as fare_total,
-   sum(trip_distance) as distance_total,
-   count(*) as trip_total
-from
+SELECT
+   toStartOfWeek(pickup_datetime) AS week,
+   sum(total_amount) AS fare_total,
+   sum(trip_distance) AS distance_total,
+   count(*) AS trip_total
+FROM
    nyc_taxi
-group by
+GROUP BY
    1
-order by
-   1 asc
+ORDER BY
+   1 ASC
 ```
 
 <Image img={tabular_query_results} size="md" alt='Tabular query results' />

--- a/docs/cloud/reference/warehouses.md
+++ b/docs/cloud/reference/warehouses.md
@@ -135,8 +135,8 @@ Once compute-compute is enabled for a service (at least one secondary service wa
 6. **CREATE/RENAME/DROP DATABASE queries could be blocked by idled/stopped services by default.** These queries can hang. To bypass this, you  can run database management queries with `settings distributed_ddl_task_timeout=0` at the session or per query level. For example:
 
 ```sql
-create database db_test_ddl_single_query_setting
-settings distributed_ddl_task_timeout=0
+CREATE DATABASE db_test_ddl_single_query_setting
+SETTINGS distributed_ddl_task_timeout=0
 ```
 
 6. **In very rare cases, secondary services that are idled or stopped for a long time (days) without waking/starting up can cause performance degradation to other services in the same warehouse.** This issue will be resolved soon and is connected to mutations running in the background. If you think you are experiencing this issue, please contact ClickHouse [Support](https://clickhouse.com/support/program).

--- a/docs/data-modeling/backfilling.md
+++ b/docs/data-modeling/backfilling.md
@@ -371,7 +371,7 @@ While we can add the target table, prior to adding the materialized view we modi
 ```sql
 CREATE MATERIALIZED VIEW pypi_downloads_per_day_mv TO pypi_downloads_per_day
 AS SELECT
- toStartOfHour(timestamp) as hour,
+ toStartOfHour(timestamp) AS hour,
  project, count() AS count
 FROM pypi WHERE timestamp >= '2024-12-17 09:00:00'
 GROUP BY hour, project

--- a/docs/getting-started/example-datasets/covid19.md
+++ b/docs/getting-started/example-datasets/covid19.md
@@ -152,7 +152,7 @@ WITH latest_deaths_data AS
             date,
             new_deceased,
             new_confirmed,
-            ROW_NUMBER() OVER (PARTITION BY location_key ORDER BY date DESC) as rn
+            ROW_NUMBER() OVER (PARTITION BY location_key ORDER BY date DESC) AS rn
      FROM covid19)
 SELECT location_key,
        date,

--- a/docs/getting-started/example-datasets/environmental-sensors.md
+++ b/docs/getting-started/example-datasets/environmental-sensors.md
@@ -168,7 +168,7 @@ WITH
 SELECT day, count() FROM sensors
 WHERE temperature >= 40 AND temperature <= 50 AND humidity >= 90
 GROUP BY day
-ORDER BY day asc;
+ORDER BY day ASC;
 ```
 
 Here's a visualization of the result:

--- a/docs/getting-started/example-datasets/github.md
+++ b/docs/getting-started/example-datasets/github.md
@@ -1245,8 +1245,8 @@ The `sign = -1` indicates a code deletion. We exclude punctuation and the insert
 
 ```sql
 SELECT
-    prev_author || '(a)' as add_author,
-    author  || '(d)' as delete_author,
+    prev_author || '(a)' AS add_author,
+    author  || '(d)' AS delete_author,
     count() AS c
 FROM git.line_changes
 WHERE (sign = -1) AND (file_extension IN ('h', 'cpp')) AND (line_type NOT IN ('Punct', 'Empty')) AND (author != prev_author) AND (prev_author != '')

--- a/docs/getting-started/example-datasets/ontime.md
+++ b/docs/getting-started/example-datasets/ontime.md
@@ -209,7 +209,7 @@ ORDER BY count(*) DESC;
 Q5. The percentage of delays by carrier for 2007
 
 ```sql
-SELECT Carrier, c, c2, c*100/c2 as c3
+SELECT Carrier, c, c2, c*100/c2 AS c3
 FROM
 (
     SELECT
@@ -245,7 +245,7 @@ ORDER BY c3 DESC
 Q6. The previous request for a broader range of years, 2000-2008
 
 ```sql
-SELECT Carrier, c, c2, c*100/c2 as c3
+SELECT Carrier, c, c2, c*100/c2 AS c3
 FROM
 (
     SELECT
@@ -284,19 +284,19 @@ Q7. Percentage of flights delayed for more than 10 minutes, by year
 SELECT Year, c1/c2
 FROM
 (
-    select
+    SELECT
         Year,
-        count(*)*100 as c1
-    from ontime
+        count(*)*100 AS c1
+    FROM ontime
     WHERE DepDelay>10
     GROUP BY Year
 ) q
 JOIN
 (
-    select
+    SELECT
         Year,
-        count(*) as c2
-    from ontime
+        count(*) AS c2
+    FROM ontime
     GROUP BY Year
 ) qq USING (Year)
 ORDER BY Year;
@@ -316,7 +316,7 @@ Q8. The most popular destinations by the number of directly connected cities for
 ```sql
 SELECT DestCityName, uniqExact(OriginCityName) AS u
 FROM ontime
-WHERE Year >= 2000 and Year <= 2010
+WHERE Year >= 2000 AND Year <= 2010
 GROUP BY DestCityName
 ORDER BY u DESC LIMIT 10;
 ```
@@ -341,9 +341,9 @@ WHERE
    DayOfWeek NOT IN (6,7) AND OriginState NOT IN ('AK', 'HI', 'PR', 'VI')
    AND DestState NOT IN ('AK', 'HI', 'PR', 'VI')
    AND FlightDate < '2010-01-01'
-GROUP by Carrier
-HAVING cnt>100000 and max(Year)>1990
-ORDER by rate DESC
+GROUP BY Carrier
+HAVING cnt>100000 AND max(Year)>1990
+ORDER BY rate DESC
 LIMIT 1000;
 ```
 

--- a/docs/getting-started/example-datasets/tpch.md
+++ b/docs/getting-started/example-datasets/tpch.md
@@ -698,7 +698,7 @@ FROM
     lineitem
 WHERE
     o_orderkey = l_orderkey
-    AND l_shipmode in ('MAIL', 'SHIP')
+    AND l_shipmode IN ('MAIL', 'SHIP')
     AND l_commitdate < l_receiptdate
     AND l_shipdate < l_commitdate
     AND l_receiptdate >= DATE '1994-01-01'
@@ -718,7 +718,7 @@ SELECT
 FROM (
     SELECT
         c_custkey,
-        count(o_orderkey) as c_count
+        count(o_orderkey) AS c_count
     FROM
         customer LEFT OUTER JOIN orders ON
             c_custkey = o_custkey
@@ -796,7 +796,7 @@ SELECT
     p_brand,
     p_type,
     p_size,
-    count(distinct ps_suppkey) AS supplier_cnt
+    count(DISTINCT ps_suppkey) AS supplier_cnt
 FROM
     partsupp,
     part
@@ -804,8 +804,8 @@ WHERE
     p_partkey = ps_partkey
     AND p_brand <> 'Brand#45'
     AND p_type NOT LIKE 'MEDIUM POLISHED%'
-    AND p_size in (49, 14, 23,  45, 19, 3, 36, 9)
-    AND ps_suppkey NOT in (
+    AND p_size IN (49, 14, 23,  45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
         SELECT
             s_suppkey
         FROM
@@ -894,7 +894,7 @@ FROM
     orders,
     lineitem
 WHERE
-    o_orderkey in (
+    o_orderkey IN (
         SELECT
             l_orderkey
         FROM
@@ -929,30 +929,30 @@ WHERE
     (
         p_partkey = l_partkey
         AND p_brand = 'Brand#12'
-        AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
         AND l_quantity >= 1 AND l_quantity <= 1 + 10
         AND p_size BETWEEN 1 AND 5
-        AND l_shipmode in ('AIR', 'AIR REG')
+        AND l_shipmode IN ('AIR', 'AIR REG')
         AND l_shipinstruct = 'DELIVER IN PERSON'
     )
     OR
     (
         p_partkey = l_partkey
         AND p_brand = 'Brand#23'
-        AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
         AND l_quantity >= 10 AND l_quantity <= 10 + 10
         AND p_size BETWEEN 1 AND 10
-        AND l_shipmode in ('AIR', 'AIR REG')
+        AND l_shipmode IN ('AIR', 'AIR REG')
         AND l_shipinstruct = 'DELIVER IN PERSON'
     )
     OR
     (
         p_partkey = l_partkey
         AND p_brand = 'Brand#34'
-        AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
         AND l_quantity >= 20 AND l_quantity <= 20 + 10
         AND p_size BETWEEN 1 AND 15
-        AND l_shipmode in ('AIR', 'AIR REG')
+        AND l_shipmode IN ('AIR', 'AIR REG')
         AND l_shipinstruct = 'DELIVER IN PERSON'
     );
 ```

--- a/docs/getting-started/example-datasets/youtube-dislikes.md
+++ b/docs/getting-started/example-datasets/youtube-dislikes.md
@@ -287,8 +287,8 @@ Enabling comments seems to be correlated with a higher rate of engagement.
 SELECT
     toStartOfMonth(toDateTime(upload_date)) AS month,
     uniq(uploader_id) AS uploaders,
-    count() as num_videos,
-    sum(view_count) as view_count
+    count() AS num_videos,
+    sum(view_count) AS view_count
 FROM youtube
 GROUP BY month
 ORDER BY month ASC;
@@ -411,9 +411,9 @@ SELECT
 FROM
 (
 SELECT
-    power(10, CEILING(log10(view_count + 1))) as view_range,
+    power(10, CEILING(log10(view_count + 1))) AS view_range,
     is_comments_enabled,
-    avg(like_count / dislike_count) as like_ratio
+    avg(like_count / dislike_count) AS like_ratio
 FROM youtube WHERE dislike_count > 0
 GROUP BY
     view_range,

--- a/docs/guides/best-practices/prewhere.md
+++ b/docs/guides/best-practices/prewhere.md
@@ -113,7 +113,7 @@ SELECT
 FROM
    uk.uk_price_paid_simple
 WHERE
-   town = 'LONDON' and date > '2024-12-31' and price < 10_000
+   town = 'LONDON' AND date > '2024-12-31' AND price < 10_000
 SETTINGS optimize_move_to_prewhere = false;
 ```
 
@@ -137,7 +137,7 @@ SELECT
 FROM
    uk.uk_price_paid_simple
 WHERE
-   town = 'LONDON' and date > '2024-12-31' and price < 10_000
+   town = 'LONDON' AND date > '2024-12-31' AND price < 10_000
 SETTINGS optimize_move_to_prewhere = true;
 ```
 
@@ -188,7 +188,7 @@ SELECT
 FROM
    uk.uk_price_paid_simple
 WHERE
-   town = 'LONDON' and date > '2024-12-31' and price < 10_000
+   town = 'LONDON' AND date > '2024-12-31' AND price < 10_000
 SETTINGS send_logs_level = 'test';
 ```
 

--- a/docs/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/guides/best-practices/sparse-primary-indexes.md
@@ -125,7 +125,7 @@ after loading data into it. Why this is necessary for this example will become a
 Now we execute our first web analytics query. The following is calculating the top 10 most clicked urls for the internet user with the UserID 749927693:
 
 ```sql
-SELECT URL, count(URL) as Count
+SELECT URL, count(URL) AS Count
 FROM hits_NoPrimaryKey
 WHERE UserID = 749927693
 GROUP BY URL
@@ -924,7 +924,7 @@ Insert all 8.87 million rows from our [original table](#a-table-with-a-primary-k
 
 ```sql
 INSERT INTO hits_URL_UserID
-SELECT * from hits_UserID_URL;
+SELECT * FROM hits_UserID_URL;
 ```
 
 The response looks like:

--- a/docs/guides/developer/cascading-materialized-views.md
+++ b/docs/guides/developer/cascading-materialized-views.md
@@ -113,7 +113,7 @@ AS
 SELECT
     toYear(toStartOfYear(month)) AS year,
     domain_name,
-    sumMerge(sumCountViews) as sumCountViews
+    sumMerge(sumCountViews) AS sumCountViews
 FROM analytics.monthly_aggregated_data
 GROUP BY
     domain_name,
@@ -179,7 +179,7 @@ Instead, let's try using the `Merge` suffix to get the `sumCountViews` value:
 
 ```sql
 SELECT
-   sumMerge(sumCountViews) as sumCountViews
+   sumMerge(sumCountViews) AS sumCountViews
 FROM analytics.monthly_aggregated_data;
 ```
 
@@ -197,7 +197,7 @@ In the `AggregatingMergeTree` we have defined the `AggregateFunction` as `sum`, 
 SELECT
     month,
     domain_name,
-    sumMerge(sumCountViews) as sumCountViews
+    sumMerge(sumCountViews) AS sumCountViews
 FROM analytics.monthly_aggregated_data
 GROUP BY
     domain_name,
@@ -212,7 +212,7 @@ Now that we have the data stored in the target table `monthly_aggregated_data` w
 SELECT
    month,
    domain_name,
-   sumMerge(sumCountViews) as sumCountViews
+   sumMerge(sumCountViews) AS sumCountViews
 FROM analytics.monthly_aggregated_data
 GROUP BY
    domain_name,

--- a/docs/guides/developer/debugging-memory-issues.md
+++ b/docs/guides/developer/debugging-memory-issues.md
@@ -33,10 +33,10 @@ SELECT
 FROM
     system.asynchronous_metrics
 WHERE
-    metric like '%Cach%'
-    or metric like '%Mem%'
-order by
-    value desc;
+    metric LIKE '%Cach%'
+    OR metric LIKE '%Mem%'
+ORDER BY
+    value DESC;
 ```
 
 ## List tables by current memory usage {#list-tables-by-current-memory-usage}

--- a/docs/guides/developer/deduplicating-inserts-on-retries.md
+++ b/docs/guides/developer/deduplicating-inserts-on-retries.md
@@ -105,7 +105,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─key─┬─value─┬─_part─────┐
 │   1 │ B     │ all_0_0_0 │
@@ -120,7 +120,7 @@ SELECT
     *,
     _part
 FROM mv_dst
-ORDER by all;
+ORDER BY all;
 
 ┌─key─┬─value─┬─_part─────┐
 │   0 │ B     │ all_0_0_0 │
@@ -140,7 +140,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─key─┬─value─┬─_part─────┐
 │   1 │ B     │ all_0_0_0 │
@@ -192,7 +192,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─'from dst'─┬─key─┬─value─┬─_part─────┐
 │ from dst   │   0 │ A     │ all_0_0_0 │
@@ -232,7 +232,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─'from dst'─┬─key─┬─value─┬─_part─────┐
 │ from dst   │   0 │ A     │ all_2_2_0 │
@@ -243,7 +243,7 @@ ORDER by all;
 Two identical blocks have been inserted as expected.
 
 ```sql
-select 'second attempt';
+SELECT 'second attempt';
 
 INSERT INTO dst SELECT
     0 AS key,
@@ -256,7 +256,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─'from dst'─┬─key─┬─value─┬─_part─────┐
 │ from dst   │   0 │ A     │ all_2_2_0 │
@@ -267,7 +267,7 @@ ORDER by all;
 Retried insertion is deduplicated as expected.
 
 ```sql
-select 'third attempt';
+SELECT 'third attempt';
 
 INSERT INTO dst SELECT
     1 AS key,
@@ -280,7 +280,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─'from dst'─┬─key─┬─value─┬─_part─────┐
 │ from dst   │   0 │ A     │ all_2_2_0 │
@@ -442,7 +442,7 @@ ORDER by all;
 Two equal blocks inserted to the table `mv_dst` (as expected).
 
 ```sql
-select 'second attempt';
+SELECT 'second attempt';
 
 INSERT INTO dst VALUES (1, 'A');
 
@@ -451,7 +451,7 @@ SELECT
     *,
     _part
 FROM dst
-ORDER by all;
+ORDER BY all;
 
 ┌─'from dst'─┬─key─┬─value─┬─_part─────┐
 │ from dst   │   1 │ A     │ all_0_0_0 │

--- a/docs/guides/examples/aggregate_function_combinators/anyIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/anyIf.md
@@ -42,8 +42,8 @@ INSERT INTO sales VALUES
 
 ```sql
 SELECT
-    anyIf(transaction_id, amount < 200) as tid_lt_200,
-    anyIf(transaction_id, amount > 200) as tid_gt_200
+    anyIf(transaction_id, amount < 200) AS tid_lt_200,
+    anyIf(transaction_id, amount > 200) AS tid_gt_200
 FROM sales;
 ```
 

--- a/docs/guides/examples/aggregate_function_combinators/argMaxIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/argMaxIf.md
@@ -39,7 +39,7 @@ INSERT INTO product_sales VALUES
     ('Watch', 199.99, 5),
     ('Headphones', 79.99, 20);
 
-SELECT argMaxIf(product_name, price, sales_count >= 10) as most_expensive_popular_product
+SELECT argMaxIf(product_name, price, sales_count >= 10) AS most_expensive_popular_product
 FROM product_sales;
 ```
 

--- a/docs/guides/examples/aggregate_function_combinators/argMinIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/argMinIf.md
@@ -41,7 +41,7 @@ INSERT INTO product_prices VALUES
 
 SELECT
     product_id,
-    argMinIf(price, timestamp, in_stock = 1) as lowest_price_when_in_stock
+    argMinIf(price, timestamp, in_stock = 1) AS lowest_price_when_in_stock
 FROM product_prices
 GROUP BY product_id;
 ```

--- a/docs/guides/examples/aggregate_function_combinators/avgIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/avgIf.md
@@ -35,7 +35,7 @@ INSERT INTO sales VALUES
     (6, 175.25, 1);
 
 SELECT
-    avgIf(amount, is_successful = 1) as avg_successful_sale
+    avgIf(amount, is_successful = 1) AS avg_successful_sale
 FROM sales;
 ```
 

--- a/docs/guides/examples/aggregate_function_combinators/countIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/countIf.md
@@ -36,7 +36,7 @@ INSERT INTO login_attempts VALUES
 
 SELECT
     user_id,
-    countIf(is_successful = 1) as successful_logins
+    countIf(is_successful = 1) AS successful_logins
 FROM login_attempts
 GROUP BY user_id;
 ```

--- a/docs/guides/examples/aggregate_function_combinators/sumArray.md
+++ b/docs/guides/examples/aggregate_function_combinators/sumArray.md
@@ -39,8 +39,8 @@ INSERT INTO daily_category_sales VALUES
 SELECT 
     date,
     category_sales,
-    sumArray(category_sales) as total_sales_sumArray,
-    sum(arraySum(category_sales)) as total_sales_arraySum
+    sumArray(category_sales) AS total_sales_sumArray,
+    sum(arraySum(category_sales)) AS total_sales_arraySum
 FROM daily_category_sales
 GROUP BY date, category_sales;
 ```

--- a/docs/guides/examples/aggregate_function_combinators/sumIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/sumIf.md
@@ -35,7 +35,7 @@ INSERT INTO sales VALUES
     (6, 175.25, 1);
 
 SELECT
-    sumIf(amount, is_successful = 1) as total_successful_sales
+    sumIf(amount, is_successful = 1) AS total_successful_sales
 FROM sales;
 ```
 

--- a/docs/guides/examples/aggregate_function_combinators/uniqArray.md
+++ b/docs/guides/examples/aggregate_function_combinators/uniqArray.md
@@ -38,8 +38,8 @@ INSERT INTO user_interests VALUES
     (3, ['reading', 'cooking']);
 
 SELECT 
-    uniqArray(interests) as unique_interests_total,
-    uniq(arrayJoin(interests)) as unique_interests_arrayJoin
+    uniqArray(interests) AS unique_interests_total,
+    uniq(arrayJoin(interests)) AS unique_interests_arrayJoin
 FROM user_interests;
 ```
 

--- a/docs/guides/sre/keeper/index.md
+++ b/docs/guides/sre/keeper/index.md
@@ -1049,7 +1049,7 @@ Query id: 8f542664-4548-4a02-bd2a-6f2c973d0dc4
 4.  Create a distributed table
 
 ```sql
-create table db_uuid.dist_uuid_table1 on cluster 'cluster_1S_2R'
+CREATE TABLE db_uuid.dist_uuid_table1 ON CLUSTER 'cluster_1S_2R'
    (
      id UInt64,
      column1 String

--- a/docs/integrations/data-ingestion/apache-spark/spark-native-connector.md
+++ b/docs/integrations/data-ingestion/apache-spark/spark-native-connector.md
@@ -481,7 +481,7 @@ so you can directly execute commands such as CREATE TABLE, TRUNCATE, and more - 
 
 ```sql
 
-use clickhouse; 
+USE clickhouse; 
 
 CREATE TABLE test_db.tbl_sql (
   create_time TIMESTAMP NOT NULL,

--- a/docs/integrations/data-ingestion/clickpipes/postgres/deduplication.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/deduplication.md
@@ -81,7 +81,7 @@ This is the simplest query you can run to check if the synchronization went fine
 SELECT count(*) FROM posts;
 
 -- ClickHouse 
-SELECT count(*) FROM posts FINAL where _peerdb_is_deleted=0;
+SELECT count(*) FROM posts FINAL WHERE _peerdb_is_deleted=0;
 ```
 
 -  **Simple aggregation with JOIN**: Top 10 users who have accumulated the most views.
@@ -92,8 +92,8 @@ An example of an aggregation on a single table. Having duplicates here would gre
 -- PostgreSQL 
 SELECT
     sum(p.viewcount) AS viewcount,
-    p.owneruserid as user_id,
-    u.displayname as display_name
+    p.owneruserid AS user_id,
+    u.displayname AS display_name
 FROM posts p
 LEFT JOIN users u ON u.id = p.owneruserid
 -- highlight-next-line
@@ -128,7 +128,7 @@ This setting can be applied either per query or for an entire session.
 
 ```sql
 -- Per query FINAL setting
-SELECT count(*) FROM posts SETTINGS final = 1;
+SELECT count(*) FROM posts SETTINGS FINAL = 1;
 
 -- Set FINAL for the session
 SET final = 1;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/toast.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/toast.md
@@ -21,7 +21,7 @@ You can read more about TOAST and its implementation in PostgreSQL here: https:/
 To identify if a table has TOAST columns, you can use the following SQL query:
 
 ```sql
-SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod) as data_type
+SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type
 FROM pg_attribute a
 JOIN pg_class c ON a.attrelid = c.oid
 WHERE c.relname = 'your_table_name'

--- a/docs/integrations/data-ingestion/data-formats/binary.md
+++ b/docs/integrations/data-ingestion/data-formats/binary.md
@@ -117,7 +117,7 @@ Suppose we want to read an entire binary file and save it into a field in a tabl
 This is the case when the [RawBLOB format](/interfaces/formats.md/#rawblob) can be used. This format can be directly used with a single-column table only:
 
 ```sql
-CREATE TABLE images(data String) Engine = Memory
+CREATE TABLE images(data String) ENGINE = Memory
 ```
 
 Let's save an image file to the `images` table:

--- a/docs/integrations/data-ingestion/data-formats/json/other.md
+++ b/docs/integrations/data-ingestion/data-formats/json/other.md
@@ -61,7 +61,7 @@ FROM people
 The [`JSONExtract`](/sql-reference/functions/json-functions#jsonextract-functions) functions can be used to retrieve values from this JSON. Consider the simple example below:
 
 ```sql
-SELECT JSONExtractString(tags, 'holidays') as holidays FROM people
+SELECT JSONExtractString(tags, 'holidays') AS holidays FROM people
 
 ┌─holidays──────────────────────────────────────┐
 │ [{"year":2024,"location":"Azores, Portugal"}] │
@@ -581,11 +581,11 @@ size FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/http/doc
 Querying this data requires us to access the request fields as arrays. Below, we summarize the errors and http methods over a fixed time period.
 
 ```sql
-SELECT status, request.method[1] as method, count() as c
+SELECT status, request.method[1] AS method, count() AS c
 FROM http
 WHERE status >= 400
   AND toDateTime(timestamp) BETWEEN '1998-01-01 00:00:00' AND '1998-06-01 00:00:00'
-GROUP by method, status
+GROUP BY method, status
 ORDER BY c DESC LIMIT 5;
 
 ┌─status─┬─method─┬─────c─┐
@@ -646,13 +646,13 @@ FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/http/document
 Querying this structure requires using the [`indexOf`](/sql-reference/functions/array-functions#indexOf) function to identify the index of the required key (which should be consistent with the order of the values). This can be used to access the values array column i.e. `values[indexOf(keys, 'status')]`. We still require a JSON parsing method for the request column - in this case, `simpleJSONExtractString`.
 
 ```sql
-SELECT toUInt16(values[indexOf(keys, 'status')])                           as status,
-       simpleJSONExtractString(values[indexOf(keys, 'request')], 'method') as method,
-       count()                                                             as c
+SELECT toUInt16(values[indexOf(keys, 'status')])                           AS status,
+       simpleJSONExtractString(values[indexOf(keys, 'request')], 'method') AS method,
+       count()                                                             AS c
 FROM http_with_arrays
 WHERE status >= 400
   AND toDateTime(values[indexOf(keys, '@timestamp')]) BETWEEN '1998-01-01 00:00:00' AND '1998-06-01 00:00:00'
-GROUP by method, status ORDER BY c DESC LIMIT 5;
+GROUP BY method, status ORDER BY c DESC LIMIT 5;
 
 ┌─status─┬─method─┬─────c─┐
 │    404 │ GET    │ 11267 │

--- a/docs/integrations/data-ingestion/data-formats/json/schema.md
+++ b/docs/integrations/data-ingestion/data-formats/json/schema.md
@@ -549,7 +549,7 @@ json: {"address":[{"city":"Wisokyburgh","geo":{"lat":-43.9509,"lng":-34.4618},"s
 We can determine the inferred sub columns and their types using [introspection functions](/sql-reference/data-types/newjson#introspection-functions). For example:
 
 ```sql
-SELECT JSONDynamicPathsWithTypes(json) as paths
+SELECT JSONDynamicPathsWithTypes(json) AS paths
 FROM people
 FORMAT PrettyJsonEachRow
 

--- a/docs/integrations/data-ingestion/emqx/index.md
+++ b/docs/integrations/data-ingestion/emqx/index.md
@@ -176,11 +176,11 @@ Here's the rule used in this tutorial:
 
 ```sql
 SELECT
-   clientid as client_id,
-   (timestamp div 1000) as timestamp,
-   topic as topic,
-   payload.temp as temp,
-   payload.hum as hum
+   clientid AS client_id,
+   (timestamp div 1000) AS timestamp,
+   topic AS topic,
+   payload.temp AS temp,
+   payload.hum AS hum
 FROM
 "temp_hum/emqx"
 ```

--- a/docs/integrations/data-ingestion/etl-tools/dbt/index.md
+++ b/docs/integrations/data-ingestion/etl-tools/dbt/index.md
@@ -170,19 +170,19 @@ The execution of these may vary depending on your bandwidth, but each should onl
 
 ```sql
 SELECT id,
-       any(actor_name)          as name,
-       uniqExact(movie_id)    as num_movies,
-       avg(rank)                as avg_rank,
-       uniqExact(genre)         as unique_genres,
-       uniqExact(director_name) as uniq_directors,
-       max(created_at)          as updated_at
+       any(actor_name)          AS name,
+       uniqExact(movie_id)    AS num_movies,
+       avg(rank)                AS avg_rank,
+       uniqExact(genre)         AS unique_genres,
+       uniqExact(director_name) AS uniq_directors,
+       max(created_at)          AS updated_at
 FROM (
-         SELECT imdb.actors.id  as id,
-                concat(imdb.actors.first_name, ' ', imdb.actors.last_name)  as actor_name,
-                imdb.movies.id as movie_id,
-                imdb.movies.rank as rank,
+         SELECT imdb.actors.id  AS id,
+                concat(imdb.actors.first_name, ' ', imdb.actors.last_name)  AS actor_name,
+                imdb.movies.id AS movie_id,
+                imdb.movies.rank AS rank,
                 genre,
-                concat(imdb.directors.first_name, ' ', imdb.directors.last_name) as director_name,
+                concat(imdb.directors.first_name, ' ', imdb.directors.last_name) AS director_name,
                 created_at
          FROM imdb.actors
                   JOIN imdb.roles ON imdb.roles.actor_id = imdb.actors.id
@@ -776,37 +776,37 @@ Note how much faster that incremental was compared to the insertion of "Clicky".
 Checking again the query_log table reveals the differences between the 2 incremental runs:
 
    ```sql
-   insert into imdb_dbt.actor_summary ("id", "name", "num_movies", "avg_rank", "genres", "directors", "updated_at")
-   with actor_summary as (
-      SELECT id,
-         any(actor_name) as name,
-         uniqExact(movie_id)    as num_movies,
-         avg(rank)                as avg_rank,
-         uniqExact(genre)         as genres,
-         uniqExact(director_name) as directors,
-         max(created_at) as updated_at
-      FROM (
-         SELECT imdb.actors.id as id,
-            concat(imdb.actors.first_name, ' ', imdb.actors.last_name) as actor_name,
-            imdb.movies.id as movie_id,
-            imdb.movies.rank as rank,
-            genre,
-            concat(imdb.directors.first_name, ' ', imdb.directors.last_name) as director_name,
-            created_at
-         FROM imdb.actors
-            JOIN imdb.roles ON imdb.roles.actor_id = imdb.actors.id
-            LEFT OUTER JOIN imdb.movies ON imdb.movies.id = imdb.roles.movie_id
-            LEFT OUTER JOIN imdb.genres ON imdb.genres.movie_id = imdb.movies.id
-            LEFT OUTER JOIN imdb.movie_directors ON imdb.movie_directors.movie_id = imdb.movies.id
-            LEFT OUTER JOIN imdb.directors ON imdb.directors.id = imdb.movie_directors.director_id
-      )
-      GROUP BY id
+INSERT INTO imdb_dbt.actor_summary ("id", "name", "num_movies", "avg_rank", "genres", "directors", "updated_at")
+WITH actor_summary AS (
+   SELECT id,
+      any(actor_name) AS name,
+      uniqExact(movie_id)    AS num_movies,
+      avg(rank)                AS avg_rank,
+      uniqExact(genre)         AS genres,
+      uniqExact(director_name) AS directors,
+      max(created_at) AS updated_at
+   FROM (
+      SELECT imdb.actors.id AS id,
+         concat(imdb.actors.first_name, ' ', imdb.actors.last_name) AS actor_name,
+         imdb.movies.id AS movie_id,
+         imdb.movies.rank AS rank,
+         genre,
+         concat(imdb.directors.first_name, ' ', imdb.directors.last_name) AS director_name,
+         created_at
+      FROM imdb.actors
+         JOIN imdb.roles ON imdb.roles.actor_id = imdb.actors.id
+         LEFT OUTER JOIN imdb.movies ON imdb.movies.id = imdb.roles.movie_id
+         LEFT OUTER JOIN imdb.genres ON imdb.genres.movie_id = imdb.movies.id
+         LEFT OUTER JOIN imdb.movie_directors ON imdb.movie_directors.movie_id = imdb.movies.id
+         LEFT OUTER JOIN imdb.directors ON imdb.directors.id = imdb.movie_directors.director_id
    )
+   GROUP BY id
+)
 
-   select *
-   from actor_summary
-   -- this filter will only be applied on an incremental run
-   where id > (select max(id) from imdb_dbt.actor_summary) or updated_at > (select max(updated_at) from imdb_dbt.actor_summary)
+SELECT *
+FROM actor_summary
+-- this filter will only be applied on an incremental run
+WHERE id > (SELECT max(id) FROM imdb_dbt.actor_summary) OR updated_at > (SELECT max(updated_at) FROM imdb_dbt.actor_summary)
    ```
 
 In this run, only the new rows are added straight to `imdb_dbt.actor_summary` table and there is no table creation involved.

--- a/docs/integrations/data-ingestion/gcs/index.md
+++ b/docs/integrations/data-ingestion/gcs/index.md
@@ -167,7 +167,7 @@ INSERT INTO trips_gcs SELECT trip_id, pickup_date, pickup_datetime, dropoff_date
 Depending on the hardware, this latter insert of 1m rows may take a few minutes to execute. You can confirm the progress via the system.processes table. Feel free to adjust the row count up to the limit of 10m and explore some sample queries.
 
 ```sql
-SELECT passenger_count, avg(tip_amount) as avg_tip, avg(total_amount) as avg_amount FROM trips_gcs GROUP BY passenger_count;
+SELECT passenger_count, avg(tip_amount) AS avg_tip, avg(total_amount) AS avg_amount FROM trips_gcs GROUP BY passenger_count;
 ```
 
 ### Handling Replication {#handling-replication}

--- a/docs/integrations/data-ingestion/kafka/kafka-table-engine.md
+++ b/docs/integrations/data-ingestion/kafka/kafka-table-engine.md
@@ -180,7 +180,7 @@ CREATE TABLE github_queue
     member_login LowCardinality(String)
 )
    ENGINE = Kafka('kafka_host:9092', 'github', 'clickhouse',
-            'JSONEachRow') settings kafka_thread_per_consumer = 0, kafka_num_consumers = 1;
+            'JSONEachRow') SETTINGS kafka_thread_per_consumer = 0, kafka_num_consumers = 1;
 ```
 
 
@@ -263,7 +263,7 @@ ATTACH TABLE github_queue;
 
 ```sql
 CREATE MATERIALIZED VIEW github_mv TO github AS
-SELECT *, _topic as topic, _partition as partition
+SELECT *, _topic AS topic, _partition as partition
 FROM github_queue;
 ```
 
@@ -414,7 +414,7 @@ CREATE TABLE github_out_queue
     member_login LowCardinality(String)
 )
    ENGINE = Kafka('host:port', 'github_out', 'clickhouse_out',
-            'JSONEachRow') settings kafka_thread_per_consumer = 0, kafka_num_consumers = 1;
+            'JSONEachRow') SETTINGS kafka_thread_per_consumer = 0, kafka_num_consumers = 1;
 ```
 
 Now create a new materialized view `github_out_mv` to point at the GitHub table, inserting rows to the above engine when it triggers. Additions to the GitHub table will, as a result, be pushed to our new Kafka topic.

--- a/docs/integrations/data-ingestion/kafka/kafka-vector.md
+++ b/docs/integrations/data-ingestion/kafka/kafka-vector.md
@@ -125,7 +125,7 @@ By default, a [health check](https://vector.dev/docs/reference/configuration/sin
 5. Confirm the insertion of the data.
 
 ```sql
-SELECT count() as count FROM github;
+SELECT count() AS count FROM github;
 ```
 
 | count |

--- a/docs/integrations/data-ingestion/s3/index.md
+++ b/docs/integrations/data-ingestion/s3/index.md
@@ -638,7 +638,7 @@ INSERT INTO trips_s3 SELECT trip_id, pickup_date, pickup_datetime, dropoff_datet
 Depending on the hardware, this latter insert of 1m rows may take a few minutes to execute. You can confirm the progress via the system.processes table. Feel free to adjust the row count up to the limit of 10m and explore some sample queries.
 
 ```sql
-SELECT passenger_count, avg(tip_amount) as avg_tip, avg(total_amount) as avg_amount FROM trips_s3 GROUP BY passenger_count;
+SELECT passenger_count, avg(tip_amount) AS avg_tip, avg(total_amount) AS avg_amount FROM trips_s3 GROUP BY passenger_count;
 ```
 
 ### Modifying a Table {#modifying-a-table}
@@ -1286,7 +1286,7 @@ SETTINGS storage_policy = 's3_express';
 S3 storage is also supported but only for `Object URL` paths. Example:
 
 ``` sql
-select * from s3('https://test-bucket--eun1-az1--x-s3.s3express-eun1-az1.eu-north-1.amazonaws.com/file.csv', ...)
+SELECT * FROM s3('https://test-bucket--eun1-az1--x-s3.s3express-eun1-az1.eu-north-1.amazonaws.com/file.csv', ...)
 ```
 
 it also requires specifying bucket region in the config:

--- a/docs/integrations/migration/clickhouse-to-cloud.md
+++ b/docs/integrations/migration/clickhouse-to-cloud.md
@@ -61,9 +61,9 @@ GRANT SELECT ON db.table TO exporter;
 
 - Copy the table definition
 ```sql
-select create_table_query
-from system.tables
-where database = 'db' and table = 'table'
+SELECT create_table_query
+FROM system.tables
+WHERE database = 'db' AND table = 'table'
 ```
 
 ### On the destination ClickHouse Cloud system: {#on-the-destination-clickhouse-cloud-system}

--- a/docs/integrations/sql-clients/sql-console.md
+++ b/docs/integrations/sql-clients/sql-console.md
@@ -330,17 +330,17 @@ Query result sets can be easily exported to CSV format directly from the SQL con
 Some data can be more easily interpreted in chart form. You can quickly create visualizations from query result data directly from the SQL console in just a few clicks. As an example, we'll use a query that calculates weekly statistics for NYC taxi trips:
 
 ```sql
-select
-   toStartOfWeek(pickup_datetime) as week,
-   sum(total_amount) as fare_total,
-   sum(trip_distance) as distance_total,
-   count(*) as trip_total
-from
+SELECT
+   toStartOfWeek(pickup_datetime) AS week,
+   sum(total_amount) AS fare_total,
+   sum(trip_distance) AS distance_total,
+   count(*) AS trip_total
+FROM
    nyc_taxi
-group by
+GROUP BY
    1
-order by
-   1 asc
+ORDER BY
+   1 ASC
 ```
 
 <Image img={tabular_query_results} size="lg" border alt="Tabular query results"/>

--- a/docs/managing-data/core-concepts/primary-indexes.md
+++ b/docs/managing-data/core-concepts/primary-indexes.md
@@ -75,7 +75,7 @@ The following query lists the number of entries in the primary index for each da
 ```sql
 SELECT
     part_name,
-    max(mark_number) as entries
+    max(mark_number) AS entries
 FROM mergeTreeIndex('uk', 'uk_price_paid_simple')
 GROUP BY part_name;
 ```
@@ -93,7 +93,7 @@ This query shows the first 10 entries from the primary index of one of the curre
 
 ```sql 
 SELECT 
-    mark_number + 1 as entry,
+    mark_number + 1 AS entry,
     town,
     street
 FROM mergeTreeIndex('uk', 'uk_price_paid_simple')

--- a/docs/migrations/bigquery/loading-data.md
+++ b/docs/migrations/bigquery/loading-data.md
@@ -94,7 +94,7 @@ To retrieve the data to `INSERT`, we can use the [s3Cluster function](/sql-refer
 INSERT INTO mytable
 SELECT
     timestamp,
-    ifNull(some_text, '') as some_text
+    ifNull(some_text, '') AS some_text
 FROM s3Cluster(
     'default',
     'https://storage.googleapis.com/mybucket/mytable/*.parquet.gz',
@@ -116,7 +116,7 @@ Alternatively, you can `SET input_format_null_as_default=1` and any missing or N
 To test whether your data was properly inserted, simply run a `SELECT` query on your new table:
 
 ```sql
-SELECT * FROM mytable limit 10;
+SELECT * FROM mytable LIMIT 10;
 ```
 
 To export more BigQuery tables, simply redo the steps above for each additional table.

--- a/docs/migrations/snowflake.md
+++ b/docs/migrations/snowflake.md
@@ -105,5 +105,5 @@ Nested structures such as `some_file` are converted to JSON strings on copy by S
 To test whether your data was properly inserted, simply run a `SELECT` query on your new table:
 
 ```sql
-SELECT * FROM mydataset limit 10;
+SELECT * FROM mydataset LIMIT 10;
 ```

--- a/docs/use-cases/observability/build-your-own/grafana.md
+++ b/docs/use-cases/observability/build-your-own/grafana.md
@@ -88,22 +88,22 @@ Users wishing to write more complex queries can switch to the `SQL Editor`.
 As shown above, Trace ids are rendered as clickable links. On clicking on a trace Id, a user can choose to view the associated spans via the link `View Trace`. This issues the following query (assuming OTel columns) to retrieve the spans in the required structure, rendering the results as a waterfall.
 
 ```sql
-WITH '<trace_id>' as trace_id,
+WITH '<trace_id>' AS trace_id,
   (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts"
-    WHERE TraceId = trace_id) as trace_start,
+    WHERE TraceId = trace_id) AS trace_start,
   (SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts"
-    WHERE TraceId = trace_id) as trace_end
-SELECT "TraceId" as traceID,
-  "SpanId" as spanID,
-  "ParentSpanId" as parentSpanID,
-  "ServiceName" as serviceName,
-  "SpanName" as operationName,
-  "Timestamp" as startTime,
-  multiply("Duration", 0.000001) as duration,
+    WHERE TraceId = trace_id) AS trace_end
+SELECT "TraceId" AS traceID,
+  "SpanId" AS spanID,
+  "ParentSpanId" AS parentSpanID,
+  "ServiceName" AS serviceName,
+  "SpanName" AS operationName,
+  "Timestamp" AS startTime,
+  multiply("Duration", 0.000001) AS duration,
   arrayMap(key -> map('key', key, 'value',"SpanAttributes"[key]),
-  mapKeys("SpanAttributes")) as tags,
+  mapKeys("SpanAttributes")) AS tags,
   arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]),
-  mapKeys("ResourceAttributes")) as serviceTags
+  mapKeys("ResourceAttributes")) AS serviceTags
 FROM "default"."otel_traces"
 WHERE traceID = trace_id
   AND startTime >= trace_start
@@ -122,9 +122,9 @@ Note how the above query uses the materialized view `otel_traces_trace_id_ts` to
 If logs contain trace ids, users can navigate from a trace to its associated logs. To view the logs click on a trace id and select `View Logs`. This issues the following query assuming default OTel columns.
 
 ```sql
-SELECT Timestamp as "timestamp",
-  Body as "body", SeverityText as "level",
-  TraceId as "traceID" FROM "default"."otel_logs"
+SELECT Timestamp AS "timestamp",
+  Body AS "body", SeverityText AS "level",
+  TraceId AS "traceID" FROM "default"."otel_logs"
 WHERE ( traceID = '<trace_id>' )
 ORDER BY timestamp ASC LIMIT 1000
 ```

--- a/docs/use-cases/observability/build-your-own/schema-design.md
+++ b/docs/use-cases/observability/build-your-own/schema-design.md
@@ -651,7 +651,7 @@ CREATE TABLE geoip_url(
         latitude Float64,
         longitude Float64,
         timezone Nullable(String)
-) engine=URL('https://raw.githubusercontent.com/sapics/ip-location-db/master/dbip-city/dbip-city-ipv4.csv.gz', 'CSV')
+) ENGINE=URL('https://raw.githubusercontent.com/sapics/ip-location-db/master/dbip-city/dbip-city-ipv4.csv.gz', 'CSV')
 
 select count() from geoip_url;
 
@@ -665,18 +665,18 @@ Because our `ip_trie` dictionary requires IP address ranges to be expressed in C
 This CIDR for each range can be succinctly computed with the following query:
 
 ```sql
-with
-        bitXor(ip_range_start, ip_range_end) as xor,
-        if(xor != 0, ceil(log2(xor)), 0) as unmatched,
-        32 - unmatched as cidr_suffix,
-        toIPv4(bitAnd(bitNot(pow(2, unmatched) - 1), ip_range_start)::UInt64) as cidr_address
-select
+WITH
+        bitXor(ip_range_start, ip_range_end) AS xor,
+        if(xor != 0, ceil(log2(xor)), 0) AS unmatched,
+        32 - unmatched AS cidr_suffix,
+        toIPv4(bitAnd(bitNot(pow(2, unmatched) - 1), ip_range_start)::UInt64) AS cidr_address
+SELECT
         ip_range_start,
         ip_range_end,
-        concat(toString(cidr_address),'/',toString(cidr_suffix)) as cidr    
-from
+        concat(toString(cidr_address),'/',toString(cidr_suffix)) AS cidr    
+FROM
         geoip_url
-limit 4;
+LIMIT 4;
 
 ┌─ip_range_start─┬─ip_range_end─┬─cidr───────┐
 │ 1.0.0.0        │ 1.0.0.255    │ 1.0.0.0/24 │


### PR DESCRIPTION
I wrote some code to extract sql from code blocks and used [sqruff](https://github.com/quarylabs/sqruff) to lint and fix sql, see https://github.com/DamianMaslanka5/sqruff-md.   
The code is WIP, the `fix` command works only when length of formatted sql doesn't change. I just wanted to learn some rust and check if it would be easy to extract the sql + run sqruff on extracted sql.

These changes were made automatically by running `cargo run -- fix --paths "/git/clickhouse-docs/docs/**/*.md"`

Config for sqruff is in https://github.com/DamianMaslanka5/sqruff-md/blob/master/config.cfg.

I reviewed the changes manually, I don't see any obvious issues. 

Looks like there is no existing linter for sql embedded in markdown, but it might be useful to introduce a sql linter in CI to make the formatting more consistent.

* Rules available in sqruff - https://github.com/quarylabs/sqruff/blob/main/docs/rules.md
* sqlfluff, the same as sqruff, more popular, written in python, slower - https://docs.sqlfluff.com/en/stable/reference/rules.html


