### PR TITLE
Clarify AWS PrivateLink region support and IP whitelisting details

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
+++ b/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
@@ -237,7 +237,7 @@ You can manage existing reverse private endpoints in the ClickHouse Cloud servic
 ## Supported AWS regions {#aws-privatelink-regions}
 
 AWS PrivateLink support is limited to specific AWS regions for ClickPipes.
-Please refer to the [ClickPipes regions list]() to see the available regions.
+Please refer to the [ClickPipes regions list](/integrations/clickpipes#list-of-static-ips) to see the available regions.
 
 This restriction does not apply to PrivateLink VPC endpoint service with a cross-region connectivity enabled.
 

--- a/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
+++ b/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
@@ -236,13 +236,10 @@ You can manage existing reverse private endpoints in the ClickHouse Cloud servic
 
 ## Supported AWS regions {#aws-privatelink-regions}
 
-The following AWS regions are supported for AWS PrivateLink:
+AWS PrivateLink support is limited to specific AWS regions for ClickPipes.
+Please refer to the [ClickPipes regions list]() to see the available regions.
 
-- `us-east-1` - for ClickHouse services running in `us-east-1` region
-- `eu-central-1` for ClickHouse services running in EU regions
-- `us-east-2` - for ClickHouse services running everywhere else
-
-This restriction does not apply to PrivateLink VPC endpoint service type since it supports cross-region connectivity.
+This restriction does not apply to PrivateLink VPC endpoint service with a cross-region connectivity enabled.
 
 ## Limitations {#limitations}
 

--- a/docs/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/index.md
@@ -57,21 +57,21 @@ More connectors will get added to ClickPipes, you can find out more by [contacti
 The following are the static NAT IPs (separated by region) that ClickPipes uses to connect to your external services. Add your related instance region IPs to your IP allow list to allow traffic.
 
 For all services, ClickPipes traffic will originate from a default region based on your service's location:
-- **eu-central-1**: For all services in EU regions.
-- **us-east-1**: For all services in `us-east-1`.
-- **ap-south-1**: For services in `ap-south-1` created on or after 25 Jun 2025 (services created before this date use `us-east-1` IPs).
-- **ap-southeast-2**: For services in `ap-southeast-2` created on or after 25 Jun 2025 (services created before this date use `us-east-1` IPs).
-- **us-west-2**: For services in `us-west-2` created on or after 24 Jun 2025 (services created before this date use `us-east-1` IPs).
-- **us-east-2**: For all other regions not explicitly listed.
+- **eu-central-1**: For all services in EU regions. (this includes GCP and Azure EU regions)
+- **us-east-1**: For all services in AWS `us-east-1`.
+- **ap-south-1**: For services in AWS `ap-south-1` created on or after 25 Jun 2025 (services created before this date use `us-east-2` IPs).
+- **ap-southeast-2**: For services in AWS `ap-southeast-2` created on or after 25 Jun 2025 (services created before this date use `us-east-2` IPs).
+- **us-west-2**: For services in AWS `us-west-2` created on or after 24 Jun 2025 (services created before this date use `us-east-2` IPs).
+- **us-east-2**: For all other regions not explicitly listed. (this includes GCP and Azure US regions)
 
-| ClickHouse Cloud region                  | IP Addresses                                                                                                                                     |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **eu-central-1**                         | `18.195.233.217`, `3.127.86.90`, `35.157.23.2`, `18.197.167.47`, `3.122.25.29`, `52.28.148.40`                                                     |
-| **us-east-1**                            | `54.82.38.199`, `3.90.133.29`, `52.5.177.8`, `3.227.227.145`, `3.216.6.184`, `54.84.202.92`, `3.131.130.196`, `3.23.172.68`, `3.20.208.150`         |
-| **us-east-2**                            | `3.131.130.196`, `3.23.172.68`, `3.20.208.150`, `3.132.20.192`, `18.119.76.110`, `3.134.185.180`                                                     |
-| **ap-south-1** (from 25 Jun 2025)        | `13.203.140.189`, `13.232.213.12`, `13.235.145.208`, `35.154.167.40`, `65.0.39.245`, `65.1.225.89`                                                     |
-| **ap-southeast-2** (from 25 Jun 2025)    | `3.106.48.103`, `52.62.168.142`, `13.55.113.162`, `3.24.61.148`, `54.206.77.184`, `54.79.253.17`                                                     |
-| **us-west-2** (from 24 Jun 2025)         | `52.42.100.5`, `44.242.47.162`, `52.40.44.52`, `44.227.206.163`, `44.246.241.23`, `35.83.230.19`                                                     |
+| AWS region                            | IP Addresses                                                                                                                                     |
+|---------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **eu-central-1**                      | `18.195.233.217`, `3.127.86.90`, `35.157.23.2`, `18.197.167.47`, `3.122.25.29`, `52.28.148.40`                                                     |
+| **us-east-1**                         | `54.82.38.199`, `3.90.133.29`, `52.5.177.8`, `3.227.227.145`, `3.216.6.184`, `54.84.202.92`, `3.131.130.196`, `3.23.172.68`, `3.20.208.150`         |
+| **us-east-2**                         | `3.131.130.196`, `3.23.172.68`, `3.20.208.150`, `3.132.20.192`, `18.119.76.110`, `3.134.185.180`                                                     |
+| **ap-south-1** (from 25 Jun 2025)     | `13.203.140.189`, `13.232.213.12`, `13.235.145.208`, `35.154.167.40`, `65.0.39.245`, `65.1.225.89`                                                     |
+| **ap-southeast-2** (from 25 Jun 2025) | `3.106.48.103`, `52.62.168.142`, `13.55.113.162`, `3.24.61.148`, `54.206.77.184`, `54.79.253.17`                                                     |
+| **us-west-2** (from 24 Jun 2025)      | `52.42.100.5`, `44.242.47.162`, `52.40.44.52`, `44.227.206.163`, `44.246.241.23`, `35.83.230.19`                                                     |
 
 ## Adjusting ClickHouse settings {#adjusting-clickhouse-settings}
 ClickHouse Cloud provides sensible defaults for most of the use cases. However, if you need to adjust some ClickHouse settings for the ClickPipes destination tables, a dedicated role for ClickPipes is the most flexible solution.


### PR DESCRIPTION
- Refer supported AWS PrivateLink regions to a main page table
- Fix `us-east-2` as an "old" region for services running in newly provisioned ClickPipes regions
- Explicit mention available regions are AWS
