### PR TITLE
Completely remove Cloud Available badge for KTE

### DIFF
--- a/docs/integrations/data-ingestion/kafka/kafka-table-engine.md
+++ b/docs/integrations/data-ingestion/kafka/kafka-table-engine.md
@@ -6,7 +6,6 @@ description: 'Using the Kafka Table Engine'
 title: 'Using the Kafka table engine'
 ---
 
-import CloudAvailableBadge from '@theme/badges/CloudAvailableBadge';
 import Image from '@theme/IdealImage';
 import kafka_01 from '@site/static/images/integrations/data-ingestion/kafka/kafka_01.png';
 import kafka_02 from '@site/static/images/integrations/data-ingestion/kafka/kafka_02.png';
@@ -14,8 +13,6 @@ import kafka_03 from '@site/static/images/integrations/data-ingestion/kafka/kafk
 import kafka_04 from '@site/static/images/integrations/data-ingestion/kafka/kafka_04.png';
 
 # Using the Kafka table engine
-
-<CloudAvailableBadge/>
 
 The Kafka table engine can be used to [**read** data from](#kafka-to-clickhouse) and [**write** data to](#clickhouse-to-kafka) Apache Kafka and other Kafka API-compatible brokers (e.g., Redpanda, Amazon MSK).
 


### PR DESCRIPTION
I didn't render the docs while changing the badge in #4005 and assumed `CloudAvailable` would mark the feature as available in cloud. Turns out it marks it as cloud-only, so completely removing the badge instead.