### PR TITLE
Add PCI and HIPAA self-service and 'allow from anywhere' ip filter note

### DIFF
--- a/docs/cloud/security/compliance-overview.md
+++ b/docs/cloud/security/compliance-overview.md
@@ -25,17 +25,17 @@ The U.S. Data Privacy Framework was developed to provide U.S. organizations with
 
 ### HIPAA (Since 2024) {#hipaa-since-2024}
 
-<EnterprisePlanFeatureBadge feature="HIPAA" support="true"/>
+<EnterprisePlanFeatureBadge feature="HIPAA"/>
 
-Customers must complete a Business Associate Agreement (BAA) and contact sales or support to onboard services to HIPAA compliant regions to load ePHI. Additionally, customers should review our [shared responsibility model](/cloud/security/shared-responsibility-model), select and implement appropriate controls for their use case.
+Customers that wish to deploy services to a HIPAA compliant region to load electronic protected health information (ePHI) may visit the **Organization** page in the console to request the feature to be enabled. A sales associate will reach out to obtain a signed Business Associate Agreement (BAA) to complete the setup. Customers deploying to HIPAA compliant regions should review our [shared responsibility model](/cloud/security/shared-responsibility-model), select and implement appropriate controls for their use case.
 
 The Health Insurance Portability and Accountability Act (HIPAA) of 1996 is a United States based privacy law focused on management of protected health information (PHI). HIPAA has several requirements, including the [Security Rule](https://www.hhs.gov/hipaa/for-professionals/security/index.html), which is focused on protecting electronic personal health information (ePHI). ClickHouse has implemented administrative, physical and technical safeguards to ensure the confidentiality, integrity and security of ePHI stored in designated services. These activities are incorporated in our SOC 2 Type II report available for download in our [Trust Center](https://trust.clickhouse.com).
 
 ### PCI Service Provider (Since 2025) {#pci-service-provider-since-2025}
 
-<EnterprisePlanFeatureBadge feature="PCI compliance" support="true"/>
+<EnterprisePlanFeatureBadge feature="PCI compliance"/>
 
-Customers must contact sales or support to onboard services to PCI compliant regions to load cardholder data. Additionally, customers should review our PCI responsibility overview available in our [Trust Center](https://trust.clickhouse.com), select and implement appropriate controls for their use case.
+Customers that wish to deploy services to PCI compliant regions to load cardholder data may visit the **Organization** page in the console to enable the feature. Once enabled, customers may select from a "PCI Compliant" region type when deploying new services. Customers deploying to PCI compliant regions should review our PCI responsibility overview available in our [Trust Center](https://trust.clickhouse.com), select and implement appropriate controls for their use case.
 
 The [Payment Card Industry Data Security Standard (PCI DSS)](https://www.pcisecuritystandards.org/standards/pci-dss/) is a set of rules created by the PCI Security Standards Council to protect credit card payment data. ClickHouse has undergone an external audit with a Qualified Security Assessor (QSA) that resulted in a passing Report on Compliance (ROC) against PCI criteria relevant to storing credit card data. To download a copy of our Attestation on Compliance (AOC) and PCI responsibility overview, please visit our [Trust Center](https://trust.clickhouse.com).
 

--- a/docs/cloud/security/setting-ip-filters.md
+++ b/docs/cloud/security/setting-ip-filters.md
@@ -14,7 +14,7 @@ import ip_filter_add_single_ip from '@site/static/images/cloud/security/ip-filte
 IP access lists filter traffic to ClickHouse services or API keys by specifying which source addresses are permitted to connect.  These lists are configurable for each service and each API key.  Lists can be configured during service or API key creation, or afterward.
 
 :::important
-If you skip the creation of the IP access list for a ClickHouse Cloud service then no traffic will be permitted to the service.
+If you skip the creation of the IP access list for a ClickHouse Cloud service then no traffic will be permitted to the service. If IP access lists for ClickHouse services are set to `Allow from anywhere` your service may be periodically moved from an idle to an active state by internet crawlers and scanners that look for public IPs, which may result in nominal unexpected cost.
 :::
 
 ## Prepare {#prepare}


### PR DESCRIPTION
## Summary
- Update compliance page to indicate PCI and HIPAA are available via self-service
- Update IP filters page with a note for services with 'Allow from anywhere' set that services may be periodically unidled by web scanners

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
