### PR TITLE
fix crash on empty code blocks

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -4,6 +4,8 @@ import CodeViewer from "../../components/CodeViewer";
 
 
 function countLines(text) {
+  // Handle undefined or null input
+  if (!text) return 1; // Return 1 as default line count
   // Split the string by newline characters
   const lines = text.split('\n');
   // Return the number of lines


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes an edge case which causes a crash when a codeblock is empty
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
