### PR TITLE
Fix warning admonition showing "danger"

### DIFF
--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -172,7 +172,7 @@ const aliases = {
   secondary: 'note',
   important: 'info',
   success: 'tip',
-  warning: 'caution',
+  warning: 'warning',
 };
 function getAdmonitionConfig(unsafeType) {
   const type = aliases[unsafeType] ?? unsafeType;

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -172,7 +172,7 @@ const aliases = {
   secondary: 'note',
   important: 'info',
   success: 'tip',
-  warning: 'danger',
+  warning: 'caution',
 };
 function getAdmonitionConfig(unsafeType) {
   const type = aliases[unsafeType] ?? unsafeType;

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -172,7 +172,7 @@ const aliases = {
   secondary: 'note',
   important: 'info',
   success: 'tip',
-  warning: 'warning',
+  warning: 'caution',
 };
 function getAdmonitionConfig(unsafeType) {
   const type = aliases[unsafeType] ?? unsafeType;


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The warning admonition shows "danger". Fix for this.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
