### PR TITLE
Generate list of pages with community maintained vs ClickHouse maintained badges

### DIFF
--- a/scripts/list-integrations-badges.sh
+++ b/scripts/list-integrations-badges.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# This script is used to generate a list of integration badges in use in docs/integrations
+
+# Default to 'docs/integrations' directory if no argument provided
+DOCS_DIR="${1:-docs/integrations}"
+
+# Check if directory exists
+if [ ! -d "$DOCS_DIR" ]; then
+    echo "Error: Directory '$DOCS_DIR' does not exist"
+    exit 1
+fi
+
+# Components to search for
+components=(
+    "ClickHouseSupportedBadge"
+    "CommunityMaintainedBadge"
+)
+
+# Custom display names (must match order of components array)
+display_names=(
+    "ClickHouse Supported Integrations"
+    "Community Maintained Integrations"
+)
+
+# Function to extract slug from a file's frontmatter
+extract_slug_from_file() {
+    local filepath="$1"
+    local slug=""
+    # Look for "slug: some/path/slug" in the file
+    slug=$(grep -m 1 "^slug:" "$filepath" 2>/dev/null | sed 's/^slug:[[:space:]]*//' | tr -d '"' | tr -d "'")
+    # If no slug found, return the filepath as fallback
+    if [ -z "$slug" ]; then
+        slug="[no slug] $filepath"
+    fi
+    echo "$slug"
+}
+
+# Search for each component and collect all slugs
+for i in "${!components[@]}"; do
+    component="${components[$i]}"
+    display_name="${display_names[$i]}"
+
+    echo "$display_name:"
+    # Get unique files containing the component
+    files=$(grep -rl --include="*.md" --include="*.mdx" --include="*.jsx" --include="*.tsx" \
+        -E "<$component[[:space:]/>]|</$component>" "$DOCS_DIR" 2>/dev/null | sort -u)
+
+    if [ -z "$files" ]; then
+        echo "  (none)"
+    else
+        while IFS= read -r file; do
+            if [ -n "$file" ]; then
+                slug=$(extract_slug_from_file "$file")
+                if [[ "$slug" == \[no\ slug\]* ]]; then
+                    echo "$slug"
+                else
+                    echo "/docs$slug"
+                fi
+            fi
+        done <<< "$files"
+    fi
+    echo
+done


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds a script which produces two lists of slugs - one for community maintained integrations, the other for ClickHouse maintained ones. CC @laeg 

Can be used to analyse integrations trends on docs
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
