### PR TITLE
Add DeregisterStreamConsumer permission to blanket wildcard statement for kinesis iam setup process

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
+++ b/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
@@ -88,7 +88,8 @@ IAM policy (Please replace `{STREAM_NAME}` with your Kinesis stream name):
         {
             "Action": [
                 "kinesis:SubscribeToShard",
-                "kinesis:DescribeStreamConsumer"
+                "kinesis:DescribeStreamConsumer",
+                "kinesis:DeregisterStreamConsumer"
             ],
             "Resource": [
                 "arn:aws:kinesis:region:account-id:stream/{STREAM_NAME}/*"

--- a/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
+++ b/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
@@ -89,6 +89,7 @@ IAM policy (Please replace `{STREAM_NAME}` with your Kinesis stream name):
             "Action": [
                 "kinesis:SubscribeToShard",
                 "kinesis:DescribeStreamConsumer",
+                "kinesis:RegisterStreamConsumer",
                 "kinesis:DeregisterStreamConsumer"
             ],
             "Resource": [


### PR DESCRIPTION

## Summary
This fixes an issue where the kinesis IAM role was missing the permission to register and deregister the stream consumer for wildcard statements causing some consumers to not be able to [de]register their streams.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
