### PR TITLE
mariadb: recommend enabling log_slave_updates when source is replica

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/source/generic_maria.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/source/generic_maria.md
@@ -49,6 +49,8 @@ binlog_row_metadata = FULL  ; only in 10.5.0 and newer
 expire_logs_days = 1
 ```
 
+If the source database is a replica, make sure to also turn on `log_slave_updates`.
+
 You NEED to RESTART the MariaDB instance for the changes to take effect.
 
 :::note


### PR DESCRIPTION
https://mariadb.com/docs/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#log_slave_updates

Off by default, whereas [log_replica_updates](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_log_replica_updates) is on by default for MySQL, so this issue hasn't come up there