### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *                      @ClickHouse/docs
-/docs/integrations/ @ClickHouse/integrations @ClickHouse/docs
+/docs/integrations/data-ingestion/clickpipes/ @ClickHouse/clickpipes @ClickHouse/docs
+/docs/integrations/ @ClickHouse/integrations-ecosystem @ClickHouse/docs


### PR DESCRIPTION
Proposing a more restrictive rule so modifications to ClickPipes documentation don't ping the integrations ecosystem team, too.