### PR TITLE
Legal: update trademark-cla-notice.yml

### DIFF
--- a/.github/workflows/trademark-cla-notice.yml
+++ b/.github/workflows/trademark-cla-notice.yml
@@ -1,7 +1,7 @@
 name: Trademark CLA Notice
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 # Set repository-level permissions


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Should (hopefully) fix a bug where the workflows works for internal users, but not external ones using a fork because they don't have access to the secrets.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
