### PR TITLE
Legal: trademark addendum - fix issue with step `check if docs changed`

### DIFF
--- a/.github/workflows/trademark-cla-notice.yml
+++ b/.github/workflows/trademark-cla-notice.yml
@@ -30,20 +30,41 @@ jobs:
           fetch-depth: 0
           # Use the GitHub App token if available, otherwise fallback to GITHUB_TOKEN
           token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          # For pull_request_target, we need to fetch the PR head
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check if docs changed
         id: docs-changed
         if: github.event_name == 'pull_request_target'
-        run: |
-          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha}} ${{ github.event.pull_request.head.sha}})
-          
-          if echo "$changed_files" | grep -E '^docs/integrations/|^docs/static/' > /dev/null; then
-            echo "docs_changed=true" >> $GITHUB_OUTPUT
-            echo "requires_cla=true" >> $GITHUB_OUTPUT
-          else
-            echo "docs_changed=false" >> $GITHUB_OUTPUT
-            echo "requires_cla=false" >> $GITHUB_OUTPUT
-          fi
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          script: |
+            // Get the list of changed files using GitHub API
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            
+            // Check if any files match our patterns
+            const hasDocsChanges = files.some(file => 
+              file.filename.startsWith('docs/integrations/') ||
+              file.filename.startsWith('docs/static/')
+            );
+            
+            console.log('Changed files:');
+            files.forEach(file => console.log(`  ${file.filename}`));
+            
+            if (hasDocsChanges) {
+              console.log('Found changes in docs/integrations/ or docs/static/ - CLA required');
+              core.setOutput('docs_changed', 'true');
+              core.setOutput('requires_cla', 'true');
+            } else {
+              console.log('No changes found in docs/integrations/ or docs/static/ - CLA not required');
+              core.setOutput('docs_changed', 'false');
+              core.setOutput('requires_cla', 'false');
+            }
 
       - name: Get PR info for comment events
         id: pr-info


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
 What Was Fixed

  1. Updated checkout step: Added ref: ${{ github.event.pull_request.head.sha }} to ensure we checkout the correct commit from the PR head.
  2. Replaced git diff with GitHub API: Instead of using git diff which was failing because the fork's commit wasn't available locally, I switched to using the GitHub API
  (github.rest.pulls.listFiles) which is more reliable for pull_request_target events.

  Why This Fixes the Issue

  The problem occurred because:
  - pull_request_target runs in the context of the base repository
  - The head SHA from the forked repository wasn't available in the local git history
  - git diff failed when trying to compare commits that weren't present locally

  The new approach:
  - Uses the GitHub API to get the list of changed files, which works regardless of fork status
  - Provides better logging to see exactly which files were changed
  - Is more reliable and doesn't depend on local git history

  The workflow should now work correctly for both internal contributors and external contributors from forks when they modify files in docs/integrations/ or docs/static/.


## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
