### PR TITLE
Legal: fix bug in workflow-authentication comments

### DIFF
--- a/.github/workflows/trademark-cla-approval.yml
+++ b/.github/workflows/trademark-cla-approval.yml
@@ -17,7 +17,7 @@ permissions: write-all
 jobs:
   process-cla-approval:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cla-signed' || github.event_name == 'issue_comment'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor != 'github-actions[bot]') || github.event_name == 'issue_comment'
 
     steps:
 
@@ -123,6 +123,7 @@ jobs:
             }
             
             // For non-comment approvals, check if the person has the right permissions
+            console.log(`isCommentApproval: ${isCommentApproval}, context.eventName: ${context.eventName}, context.actor: ${context.actor}`);
             if (!isCommentApproval) {
               try {
                 const { data: collaboration } = await github.rest.repos.getCollaboratorPermissionLevel({

--- a/.github/workflows/trademark-cla-notice.yml
+++ b/.github/workflows/trademark-cla-notice.yml
@@ -170,8 +170,8 @@ jobs:
             
               if (!existingClaComment && context.eventName === 'pull_request_target') {
                 const claText = '# Trademark License Addendum\n\n' +
-                  'Merging of this pull request is temporarily blocked as it potentially
-                  'contains a contribution containing a trademark. Please \n' +
+                  'Merging of this pull request is temporarily blocked as it potentially ' +
+                  'contains a contribution containing a trademark. git diffPlease \n' +
                   'read and agree to the Trademark License Addendum below to \n' +
                   'unblock merging of this pull request.\n\n' +
                   '<details>\n' +


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The Problem

  The workflow was running twice:
  1. First on issue_comment when user posts CLA agreement (correct)
  2. Second on pull_request_target when the workflow adds the cla-signed label (incorrect)

  On the second run:
  - The actor becomes github-actions[bot]
  - isCommentApproval stays false (since it's not an issue_comment event)
  - The bot fails the maintainer permission check
  - Posts the error message and removes the label

  The Fix

  Updated the job condition to exclude bot-triggered label events:

  if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor !=
  'github-actions[bot]') || github.event_name == 'issue_comment'

  This ensures:
  -  Manual approvals via workflow_dispatch still work
  - Maintainer approvals via adding cla-signed label still work (but not when done by bots)
  - Comment-based CLA agreements work without double-triggering
  - Signature recording should now work since the second unwanted run is prevented

  Both issues should now be resolved:
  1. No more unwanted error messages from the bot failing permission checks
  2. Signature recording will work since the workflow runs only once and sets the outputs properly
  
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
