### PR TITLE
Legal: fix workflow bugs

### DIFF
--- a/.github/workflows/trademark-cla-approval.yml
+++ b/.github/workflows/trademark-cla-approval.yml
@@ -17,7 +17,7 @@ permissions: write-all
 jobs:
   process-cla-approval:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor != 'github-actions[bot]')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor != 'workflow-authentication-public')
 
     steps:
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The issue was that I was checking for github-actions[bot] but the actual bot name is workflow-authentication-public.

 Now the condition properly excludes the workflow when it's triggered by the workflow-authentication-public bot adding the cla-signed label, which will prevent the double execution and the unwanted error message.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
