### PR TITLE
Legal: fix incorrect workflow bot name

### DIFF
--- a/.github/workflows/trademark-cla-approval.yml
+++ b/.github/workflows/trademark-cla-approval.yml
@@ -17,7 +17,7 @@ permissions: write-all
 jobs:
   process-cla-approval:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor != 'workflow-authentication-public')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && github.event.label.name == 'cla-signed' && github.actor != 'workflow-authentication-public[bot]')
 
     steps:
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Hopefully, this is it. The workflow app name was missing `[bot]` from it.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
