### PR TITLE
Legal: fix token issue when trying to push changes to repo

### DIFF
--- a/.github/workflows/trademark-cla-approval.yml
+++ b/.github/workflows/trademark-cla-approval.yml
@@ -308,6 +308,11 @@ jobs:
           # Commit the updated file
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Configure git to use the token for authentication
+          TOKEN="${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}"
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
+          
           git add cla-signatures.json
           git commit -m "Add manual approval for @$USERNAME (PR #$PR_NUMBER) by @$APPROVED_BY" || echo "No changes to commit"
           git push


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Issue:

```
Available outputs:
  pr_number: '4116'
  pr_author: 'contributor-test-user'
  approved_by: 'contributor-test-user'
Created new cla-signatures.json file
Recording manual trademark addendum approval:
  Username: contributor-test-user
  PR Number: 4116
  Approved by: contributor-test-user
  Date: 2025-07-19T18:26:13Z
New trademark adendum signature added
[main 50b3b31af] Add manual approval for @contributor-test-user (PR #4116) by @contributor-test-user
 1 file changed, 10 insertions(+)
 create mode 100644 cla-signatures.json
remote: Permission to ClickHouse/clickhouse-docs.git denied to workflow-authentication-public[bot].
fatal: unable to access 'https://github.com/ClickHouse/clickhouse-docs/': The requested URL returned error: 403
```

Fixed. The workflow now configures git to use the authentication token (either from the GitHub app or GITHUB_TOKEN) when pushing changes to the repository. This should
  resolve the 403 permission error.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
