### PR TITLE
Legal: fix branch issue with workflow 

### DIFF
--- a/.github/workflows/trademark-cla-approval.yml
+++ b/.github/workflows/trademark-cla-approval.yml
@@ -141,7 +141,7 @@ jobs:
             core.setOutput('pr_number', prNumber);
             core.setOutput('pr_author', prAuthor);
             core.setOutput('approved_by', prAuthor);
-            core.setOutput('pr_head_sha', pr.head.sha);
+            core.setOutput('pr_head_ref', pr.head.ref);
             
             // Add confirmation comment
             const confirmationBody = [
@@ -170,8 +170,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # For issue_comment events, checkout the PR head
-          ref: ${{ steps.process-comment.outputs.pr_head_sha }}
+          # For issue_comment events, checkout the PR head branch
+          ref: ${{ steps.process-comment.outputs.pr_head_ref }}
           token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Record signature to file


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

The key changes:
  - pr.head.sha → pr.head.ref (commit hash → branch name)
  - This ensures we checkout the branch itself, not just a specific commit

This should resolve the "fatal: You are not currently on a branch" error and allow the signature file to be committed and pushed properly to the PR branch.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
