### PR TITLE
Menu: make install section collapsible

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -9,8 +9,8 @@ const sidebars = {
     {
       type: "category",
       label: "Introduction",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "introduction-index" },
       items: [
         "intro",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Install section is not currently collapsible. Makes the install section collapsible.
<img width="277" height="457" alt="Screenshot 2025-07-20 at 21 07 22" src="https://github.com/user-attachments/assets/07dda8e8-7f1a-4bed-b9d1-d43230e609fb" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
