### PR TITLE
Menu: make sidebar menus collapsible

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -49,8 +49,8 @@ const sidebars = {
       type: "category",
       label: "Concepts",
       className: "top-nav-item",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "concepts/index" },
       items: [
         "concepts/olap",
@@ -76,8 +76,8 @@ const sidebars = {
     {
       type: "category",
       label: "Starter Guides",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "starter-guides/index" },
       items: [
         "guides/creating-tables",
@@ -89,8 +89,8 @@ const sidebars = {
     {
       type: "category",
       label: "Best Practices",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "best-practices/index" },
       items: [
         "best-practices/sizing-and-hardware-recommendations",
@@ -109,8 +109,8 @@ const sidebars = {
     {
       type: "category",
       label: "Use Case Guides",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "use-cases/index" },
       items: [
         {
@@ -188,8 +188,8 @@ const sidebars = {
     {
       type: "category",
       label: "Migration Guides",
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       link: { type: "doc", id: "migrations/index" },
       items: [
         {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Sidebar menu is really overwhelming with the number of items. If we have a more logical structure users will not battle to find where to go and we don't have to show everything.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
