### PR TITLE
Add some limitations for Object Storage ClickPipes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/integrations/data-ingestion/clickpipes/object-storage.md
@@ -129,7 +129,8 @@ To increase the throughput on large ingest jobs, we recommend scaling the ClickH
 - Role authentication is not available for S3 ClickPipes for ClickHouse Cloud instances deployed into GCP or Azure. It is only supported for AWS ClickHouse Cloud instances.
 - ClickPipes will only attempt to ingest objects at 10GB or smaller in size. If a file is greater than 10GB an error will be appended to the ClickPipes dedicated error table.
 - Azure Blob Storage pipes with continuous ingest on containers with over 100k files will have a latency of around 10–15 seconds in detecting new files. Latency increases with file count.
-- S3 / GCS ClickPipes **does not** share a listing syntax with the [S3 Table Function](/sql-reference/table-functions/s3), nor Azure with the [AzureBlobStorage Table function](/sql-reference/table-functions/azureBlobStorage).
+- Object Storage ClickPipes ClickPipes inserting into a destination using [Null table engine](/engines/table-engines/special/null) won't have data for "Total records" or "Data ingested" in the UI.
+- Object Storage ClickPipes **does not** share a listing syntax with the [S3 Table Function](/sql-reference/table-functions/s3), nor Azure with the [AzureBlobStorage Table function](/sql-reference/table-functions/azureBlobStorage).
   - `?` — Substitutes any single character
   - `*` — Substitutes any number of any characters except / including empty string
   - `**` — Substitutes any number of any character include / including empty string


### PR DESCRIPTION
## Summary
Mention a limitation about using Null table engine, and update working around table engine syntax to cover all types.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
