### PR TITLE
Adjust mobile/tablet breakpoints

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1715,7 +1715,7 @@ const sidebars = {
   dropdownCategories: [
     {
       type: "category",
-      label: "Getting Started",
+      label: "Get Started",
       description: "Learn how to use ClickHouse",
       customProps: {
         href: "/introduction-clickhouse",

--- a/src/components/MobileSideBarMenu/index.jsx
+++ b/src/components/MobileSideBarMenu/index.jsx
@@ -27,7 +27,7 @@ const MobileSideBarMenu = ({sidebar, menu}) => {
     }, [currentMenuState]);
 
     // Define the breakpoint where mobile menu should be hidden (laptop breakpoint)
-    const LAPTOP_BREAKPOINT = 1330;
+    const LAPTOP_BREAKPOINT = 1100;
 
     // Initialize the previous location ref on first render and monitor location changes
     useEffect(() => {

--- a/src/css/breakpoints.scss
+++ b/src/css/breakpoints.scss
@@ -1,6 +1,6 @@
-$mobile-breakpoint: 996px;
-$tablet-breakpoint: 1024px;
-$laptop-breakpoint: 1330px;
+$mobile-breakpoint: 768px;
+$tablet-breakpoint: 900px;
+$laptop-breakpoint: 1100px;
 $large-desktop-breakpoint: 1440px;
 
 // If you change these breakpoints, make sure to update

--- a/src/theme/Navbar/Content/styles.module.scss
+++ b/src/theme/Navbar/Content/styles.module.scss
@@ -52,7 +52,7 @@
   }
 }
 
-@media screen and (min-width: breakpoints.$mobile-breakpoint) {
+@media screen and (min-width: breakpoints.$laptop-breakpoint) {
   .navRight .mobileSearchBar {
     display: none;
   }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
In response to user feedback, adjust breakpoints so that mobile/tablet with burger menu doesn't show so soon.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
