### PR TITLE
Add temporary exception for new page

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -10,3 +10,4 @@
 integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 integrations/data-ingestion/clickpipes/postgres/maintenance.md
+operations/settings/tcp-connection-limits.md


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
In PR https://github.com/ClickHouse/ClickHouse/pull/81472 we need to add a new page. Adding this exception will allow the docs check to pass.

Afterwards we will follow up and add the page to https://github.com/ClickHouse/clickhouse-docs/blob/4ffab6326312b5d739dd25e4626aa3954cd5f54c/sidebars.js#L1410-L1427
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
