### PR TITLE
Styling: fix tabList scrolling

### DIFF
--- a/src/theme/Tabs/styles.module.css
+++ b/src/theme/Tabs/styles.module.css
@@ -1,7 +1,6 @@
 .tabList {
   scrollbar-width: none;
   border-bottom: 1px solid var(--click-color-stroke);
-  overflow: auto;
 }
 .tabList::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
tabLists have an overflow inside of them 

https://github.com/user-attachments/assets/8ca9ffb4-b9bb-4362-8d04-18e6e9927b9e

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
