### PR TITLE
Add a command to build swagger from local OpenAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "copy-clickhouse-repo-docs": "bash scripts/copy-clickhouse-repo-docs.sh",
     "serve": "docusaurus serve",
     "build-swagger": "yarn redocly build-docs https://api.clickhouse.cloud/v1 --output build/cloud/manage/api/swagger.html",
+    "build-swagger-local": "yarn redocly build-docs http://localhost:2023/v1 --output build/cloud/manage/api/swagger.html",
     "prep-from-local": "bash ./scripts/copy-clickhouse-repo-docs.sh -l $1",
     "autogenerate-settings": "bash ./scripts/settings/autogenerate-settings.sh",
     "autogenerate-table-of-contents": "bash ./scripts/autogenerate-table-of-contents.sh",


### PR DESCRIPTION
## Summary
Add a command to build swagger from locally hosted OpenAPI, to easily test changes end to end when updating the spec.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
