### PR TITLE
clickpipes: remove limitation for object storage ClickPipe

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/object-storage.md
+++ b/docs/integrations/data-ingestion/clickpipes/object-storage.md
@@ -128,7 +128,6 @@ To increase the throughput on large ingest jobs, we recommend scaling the ClickH
 - Role authentication is not available for S3 ClickPipes for ClickHouse Cloud instances deployed into GCP or Azure. It is only supported for AWS ClickHouse Cloud instances.
 - ClickPipes will only attempt to ingest objects at 10GB or smaller in size. If a file is greater than 10GB an error will be appended to the ClickPipes dedicated error table.
 - Azure Blob Storage pipes with continuous ingest on containers with over 100k files will have a latency of around 10–15 seconds in detecting new files. Latency increases with file count.
-- Object Storage ClickPipes ClickPipes inserting into a destination using [Null table engine](/engines/table-engines/special/null) won't have data for "Total records" or "Data ingested" in the UI.
 - Object Storage ClickPipes **does not** share a listing syntax with the [S3 Table Function](/sql-reference/table-functions/s3), nor Azure with the [AzureBlobStorage Table function](/sql-reference/table-functions/azureBlobStorage).
   - `?` — Substitutes any single character
   - `*` — Substitutes any number of any characters except / including empty string


### PR DESCRIPTION
Fixed in [`clickpipes-platform` #4510](https://github.com/ClickHouse/clickpipes-platform/pull/4510).

@kitop: is it worth it to mention the possibility of double-counting, or still mention that as a limitation under certain scenarios?

<img width="1218" height="733" alt="Screenshot 2025-08-07 at 12 26 14" src="https://github.com/user-attachments/assets/ea60e2fc-6240-4bf2-8dd0-0c672a9143c3" />
