### PR TITLE
Update _verify_keeper_using_mntr.mdx

### DIFF
--- a/docs/deployment-guides/replication-sharding-examples/_snippets/_verify_keeper_using_mntr.mdx
+++ b/docs/deployment-guides/replication-sharding-examples/_snippets/_verify_keeper_using_mntr.mdx
@@ -16,7 +16,7 @@ Run the command below from a shell on `clickhouse-keeper-01`, `clickhouse-keeper
 for `clickhouse-keeper-01` is shown below:
 
 ```bash
-docker exec -it clickhouse-keeper-01 echo mntr | nc localhost 9181
+docker exec -it clickhouse-keeper-01  /bin/sh -c 'echo mntr | nc 127.0.0.1 9181'
 ```
 
 The response below shows an example response from a follower node:


### PR DESCRIPTION
## Summary
docker command must be run as `/bin/sh -c 'c....'` otherwise the command past '|' will be executed locally and not in the container. Additionally, instead of `localhost`  `127.0.0.1` should be used. By default localhost resolves to `::1` on the recent clickhouse-keeper image, while only 127.0.0.1 listens.

## Checklist
- [ X] Delete items not relevant to your PR
- [X ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ X] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
