### PR TITLE
Update index.js to fix galaxy events

### DIFF
--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -6,7 +6,7 @@ import clsx from "clsx";
 import IconClose from '@theme/Icon/Close';
 import styles from './styles.module.scss'
 import Feedback from '../../../../components/Feedback';
-import {galaxyOnClick} from "../../../../../lib/galaxy/galaxy";
+import {galaxyOnClick} from '@site/src/lib/galaxy/galaxy';
 
 const AD_DATA_ENDPOINT = 'https://cms.clickhouse-dev.com:1337/api/docs-ad'
 

--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -6,7 +6,7 @@ import clsx from "clsx";
 import IconClose from '@theme/Icon/Close';
 import styles from './styles.module.scss'
 import Feedback from '../../../../components/Feedback';
-import {galaxyOnClick} from "../../../../lib/galaxy/galaxy";
+import {galaxyOnClick} from "../../../../../lib/galaxy/galaxy";
 
 const AD_DATA_ENDPOINT = 'https://cms.clickhouse-dev.com:1337/api/docs-ad'
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes bug where galaxy events aren't getting pulled in because of incorrect import path.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
