### PR TITLE
Postgres ClickPipe FAQ: ReceiveMessage EOF and Generated Columns Breaking Via Schema Changes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/faq.md
@@ -224,6 +224,8 @@ max_slot_wal_keep_size = 200GB
 
 `ReceiveMessage` is a function in the Postgres logical decoding protocol that reads messages from the replication stream. An EOF (End of File) error indicates that the connection to the Postgres server was unexpectedly closed while trying to read from the replication stream.
 
+It is a recoverable, completely non-fatal error. ClickPipes will automatically attempt to reconnect and resume the replication process.
+
 It can happen for a few reasons:
 - **Low wal_sender_timeout:** Make sure `wal_sender_timeout` is 5 minutes or higher. This setting controls how long the server waits for a response from the client before closing the connection. If the timeout is too low, it can lead to premature disconnections.
 - **Network Issues:** Temporary network disruptions can cause the connection to drop.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/postgres_generated_columns.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/postgres_generated_columns.md
@@ -12,6 +12,8 @@ When using PostgreSQL's generated columns in tables that are being replicated, t
 
 2. **Issues with Primary Keys:** If a generated column is part of your primary key, it can cause deduplication problems on the destination. Since the generated column values are not replicated, the destination system won't have the necessary information to properly identify and deduplicate rows.
 
+3. **Issues with schema changes**: If you add a generated column to a table that is already being replicated, the new column will not be populated in the destination - as Postgres does not give us the RelationMessage for the new column. If you then add a new non-generated column to the same table, the ClickPipe, when trying to reconcile the schema, will not be able to find the generated column in the destination, leading to a failure in the replication process.
+
 ## Best practices {#best-practices}
 
 To work around these limitations, consider the following best practices:


### PR DESCRIPTION
## Summary
- Adds a point in the generated columns doc for Postgres where some schema changes with generated columns can break replication.
- Adds an FAQ point explaining ReceiveMessage EOF

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
