### PR TITLE
Clarify that IP access lists only apply outside of PrivateLink

### DIFF
--- a/docs/cloud/security/setting-ip-filters.md
+++ b/docs/cloud/security/setting-ip-filters.md
@@ -24,8 +24,9 @@ Classless Inter-domain Routing (CIDR) notation, allows you to specify IP address
 
 ## Create or modify an IP access list {#create-or-modify-an-ip-access-list}
 
-:::note Not applicable to PrivateLink
-IP access lists only apply to connections outside of [PrivateLink](/cloud/security/private-link-overview)
+:::note Applicable only to connections outside of PrivateLink
+IP access lists only apply to connections from the public internet, outside of [PrivateLink](/cloud/security/private-link-overview).
+If you only want traffic from PrivateLink, set `DenyAll` in IP Allowlist.
 :::
 
 <details>

--- a/docs/cloud/security/setting-ip-filters.md
+++ b/docs/cloud/security/setting-ip-filters.md
@@ -26,7 +26,7 @@ Classless Inter-domain Routing (CIDR) notation, allows you to specify IP address
 
 :::note Applicable only to connections outside of PrivateLink
 IP access lists only apply to connections from the public internet, outside of [PrivateLink](/cloud/security/private-link-overview).
-If you only want traffic from PrivateLink, set `DenyAll` in IP Allowlist.
+If you only want traffic from PrivateLink, set `DenyAll` in IP Allow list.
 :::
 
 <details>

--- a/docs/cloud/security/setting-ip-filters.md
+++ b/docs/cloud/security/setting-ip-filters.md
@@ -24,6 +24,10 @@ Classless Inter-domain Routing (CIDR) notation, allows you to specify IP address
 
 ## Create or modify an IP access list {#create-or-modify-an-ip-access-list}
 
+:::note Not applicable to PrivateLink
+IP access lists only apply to connections outside of [PrivateLink](/cloud/security/private-link-overview)
+:::
+
 <details>
   <summary>IP access list for ClickHouse services</summary>
 
@@ -63,15 +67,15 @@ This screenshot shows an access list which allows traffic from a range of IP add
 
 <Image img={ip_filter_add_single_ip} size="md" alt="Adding a single IP to the access list in ClickHouse Cloud" border/>
 
-1. Delete an existing entry
+2. Delete an existing entry
 
   Clicking the cross (x) can deletes an entry
 
-1. Edit an existing entry
+3. Edit an existing entry
 
   Directly modifying the entry
 
-1. Switch to allow access from **Anywhere**
+4. Switch to allow access from **Anywhere**
 
   This is not recommended, but it is allowed.  We recommend that you expose an application built on top of ClickHouse to the public and restrict access to the back-end ClickHouse Cloud service.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Clarify that IP access lists only apply outside of PrivateLink
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
