### PR TITLE
Cross linking: update page to link to the guide on cascading materialized views

### DIFF
--- a/docs/materialized-view/incremental-materialized-view.md
+++ b/docs/materialized-view/incremental-materialized-view.md
@@ -366,9 +366,10 @@ WHERE PostId IN (
 1 row in set. Elapsed: 0.012 sec. Processed 88.61 thousand rows, 771.37 KB (7.09 million rows/s., 61.73 MB/s.)
 ```
 
-### Chaining {#chaining}
+### Chaining / cascading materialized views {#chaining}
 
-Materialized views can be chained, allowing complex workflows to be established. For a practical example, we recommend reading this [blog post](https://clickhouse.com/blog/chaining-materialized-views).
+Materialized views can be chained (or cascaded), allowing complex workflows to be established.
+For more information see the guide ["Cascading materialized views"](https://clickhouse.com/docs/guides/developer/cascading-materialized-views).
 
 ## Materialized views and JOINs {#materialized-views-and-joins}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
In response to https://clickhouse-inc.slack.com/archives/C03A9B0H05T/p1755071831966079 cross links to a docs guide rather than an older blog post.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
