### PR TITLE
Add redirects for removed system tables pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3375,6 +3375,16 @@
       "source": "/docs/manage/troubleshooting-billing-issues",
       "destination": "/docs/manage/clickhouse-cloud-billing-compliance",
       "permanent": true
+    },
+    {
+      "source": "/operations/system-tables/latency_log",
+      "destination": "/operations/system-tables/histogram_metrics",
+      "permanent": true
+    },
+    {
+      "source": "/operations/system-tables/latency_buckets",
+      "destination": "/operations/system-tables/histogram_metrics",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds redirects for two pages which were removed without adding redirects. Reported via community here: https://clickhousedb.slack.com/archives/CU478UEQZ/p1754772495010949
Requires https://github.com/ClickHouse/ClickHouse/pull/85550
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
