### PR TITLE
Clickpipes: fix doc paths

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -782,9 +782,9 @@ const sidebars = {
               type: "category",
               label: "Operations",
               items: [
-                "integrations/data-ingestion/clickpipes/postgres/add_table",
-                "integrations/data-ingestion/clickpipes/postgres/pause_and_resume",
-                "integrations/data-ingestion/clickpipes/postgres/remove_table",
+                "integrations/data-ingestion/clickpipes/mysql/add_table",
+                "integrations/data-ingestion/clickpipes/mysql/pause_and_resume",
+                "integrations/data-ingestion/clickpipes/mysql/remove_table",
                 "integrations/data-ingestion/clickpipes/mysql/resync",
                 "integrations/data-ingestion/clickpipes/mysql/controlling_sync"
               ],


### PR DESCRIPTION
## Summary
Referencing the correct docs in the sidebar

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
