### PR TITLE
Fix backfilling manual

### DIFF
--- a/docs/data-modeling/backfilling.md
+++ b/docs/data-modeling/backfilling.md
@@ -196,13 +196,11 @@ If we experienced a failure at any point during this second load, we could simpl
 With our data load complete, we can move the data from our duplicate tables to the main tables using the [`ALTER TABLE MOVE PARTITION`](/sql-reference/statements/alter/partition#move-partition-to-table) clause.
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
 0 rows in set. Elapsed: 1.401 sec.
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 
 0 rows in set. Elapsed: 0.389 sec.
 ```
@@ -309,11 +307,9 @@ Filtering on timestamp columns in Parquet can be very efficient. ClickHouse will
 Once this insert is complete, we can move the associated partitions.
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 ```
 
 If the historical data is an isolated bucket, the above time filter is not required. If a time or monotonic column is unavailable, isolate your historical data.

--- a/i18n/jp/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
@@ -200,13 +200,11 @@ FROM pypi_downloads_v2
 データのロードが完了したら、[`ALTER TABLE MOVE PARTITION`](/sql-reference/statements/alter/partition#move-partition-to-table)句を使用して、重複テーブルからメインテーブルにデータを移動できます。
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
 0行のセット。経過時間: 1.401秒。
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 
 0行のセット。経過時間: 0.389秒。
 ```
@@ -312,11 +310,9 @@ WHERE timestamp < '2024-12-17 09:00:00'
 この挿入が完了したら、関連するパーティションを移動できます。
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 ```
 
 もし歴史的データが孤立したバケットであれば、上記の時間フィルタは必要ありません。時間または単調増加列が利用できない場合は、歴史的データを分離します。

--- a/i18n/ru/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
@@ -194,13 +194,11 @@ FROM pypi_downloads_v2
 После завершения загрузки данных мы можем переместить данные из наших дублирующих таблиц в основные таблицы, используя оператор [`ALTER TABLE MOVE PARTITION`](/sql-reference/statements/alter/partition#move-partition-to-table).
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
 0 rows in set. Elapsed: 1.401 sec.
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 
 0 rows in set. Elapsed: 0.389 sec.
 ```
@@ -306,11 +304,9 @@ WHERE timestamp < '2024-12-17 09:00:00'
 После завершения этой вставки мы можем переместить соответствующие партиции.
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 ```
 
 Если исторические данные находятся в изолированном облаке, фильтр по времени не требуется. Если временная или монотонная колонка недоступна, изолируйте свои исторические данные.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/data-modeling/backfilling.md
@@ -202,13 +202,11 @@ Peak memory usage: 688.77 KiB.
 完成数据加载后，我们可以使用 [`ALTER TABLE MOVE PARTITION`](/sql-reference/statements/alter/partition#move-partition-to-table) 子句将数据从重复表移动到主要表。
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
 0 rows in set. Elapsed: 1.401 sec.
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 
 0 rows in set. Elapsed: 0.389 sec.
 ```
@@ -315,11 +313,9 @@ WHERE timestamp < '2024-12-17 09:00:00'
 一旦此插入完成，我们可以移动相关的分区。
 
 ```sql
-ALTER TABLE pypi
- (MOVE PARTITION () FROM pypi_v2)
+ALTER TABLE pypi_v2 MOVE PARTITION () TO pypi
 
-ALTER TABLE pypi_downloads
- (MOVE PARTITION () FROM pypi_downloads_v2)
+ALTER TABLE pypi_downloads_v2 MOVE PARTITION () TO pypi_downloads
 ```
 
 如果历史数据在一个孤立的存储桶中，则不需要上述时间过滤。如果没有时间或单调列，请隔离您的历史数据。


### PR DESCRIPTION
## Summary
Change `move partition from` to `move partition to` queries.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
