### PR TITLE
Example datasets: add a page for Hacker News example dataset

### DIFF
--- a/docs/getting-started/example-datasets/hacker-news.md
+++ b/docs/getting-started/example-datasets/hacker-news.md
@@ -433,7 +433,7 @@ LIMIT 5
 │ jetter   │        386  │              30    │
 │ hodgesrm │        312  │              50    │
 │ mechmind │        243  │              16    │
-│ tosh 	   │        198  │              12    │
+│ tosh     │        198  │              12    │
 └──────────┴─────────────┴────────────────────┘
 ```
 
@@ -650,4 +650,3 @@ WHERE hasToken(lower(comment), 'avx') AND hasToken(lower(comment), 'sve');
 ```
 
 </VerticalStepper>
-


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds a page for the Hacker News data sets which we host. These are commonly referenced in blogs but we don't have a page for them.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
