### PR TITLE
Fix wrong variable name in query example

### DIFF
--- a/docs/integrations/language-clients/java/client/_snippets/_v0_8.mdx
+++ b/docs/integrations/language-clients/java/client/_snippets/_v0_8.mdx
@@ -491,7 +491,7 @@ Future of `QueryResponse` type - a result dataset and additional information lik
 Map<String, Object> queryParams = new HashMap<>();
 queryParams.put("param1", 2);
 
-try (QueryResponse queryResponse =
+try (QueryResponse response =
         client.query("SELECT * FROM " + table + " WHERE col1 >= {param1:UInt32}", queryParams, new QuerySettings()).get()) {
 
     // Create a reader to access the data in a convenient way

--- a/i18n/jp/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
@@ -429,7 +429,7 @@ CompletableFuture<QueryResponse> query(String sqlQuery, Map<String, Object> quer
 Map<String, Object> queryParams = new HashMap<>();
 queryParams.put("param1", 2);
 
-try (QueryResponse queryResponse =
+try (QueryResponse response =
         client.query("SELECT * FROM " + table + " WHERE col1 >= {param1:UInt32}", queryParams, new QuerySettings()).get()) {
 
     // データに便利にアクセスするためのリーダーを作成します

--- a/i18n/ru/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
@@ -431,7 +431,7 @@ Future типа `QueryResponse` - набор данных результатов
 Map<String, Object> queryParams = new HashMap<>();
 queryParams.put("param1", 2);
 
-try (QueryResponse queryResponse =
+try (QueryResponse response =
         client.query("SELECT * FROM " + table + " WHERE col1 >= {param1:UInt32}", queryParams, new QuerySettings()).get()) {
 
     // Создайте ридер для удобного доступа к данным

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/language-clients/java/client/_snippets/_v0_8.mdx
@@ -439,7 +439,7 @@ CompletableFuture<QueryResponse> query(String sqlQuery, Map<String, Object> quer
 Map<String, Object> queryParams = new HashMap<>();
 queryParams.put("param1", 2);
 
-try (QueryResponse queryResponse =
+try (QueryResponse response =
         client.query("SELECT * FROM " + table + " WHERE col1 >= {param1:UInt32}", queryParams, new QuerySettings()).get()) {
 
     // Create a reader to access the data in a convenient way


### PR DESCRIPTION
## Summary
In [query method example](https://clickhouse.com/docs/integrations/language-clients/java/client#querystring-sqlquery-mapltstring-object-queryparams-querysettings-settings), QueryResponse argument passed to `newBinaryFormatReader` is named response, while the declared variable name is queryResponse.

This change updates the example for consistency between the variable declaration and its usage.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
