### PR TITLE
Add redirect for kafka connect page

### DIFF
--- a/docs/integrations/data-ingestion/kafka/confluent/confluent-cloud.md
+++ b/docs/integrations/data-ingestion/kafka/confluent/confluent-cloud.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: 'Kafka Connector Sink on Confluent Cloud'
 sidebar_position: 2
-slug: /integrations/kafka/cloud/confluent/custom-connector-cloud
+slug: /integrations/kafka/cloud/confluent/sink-connector
 description: 'Guide to using the fully managed ClickHouse Connector Sinkon Confluent Cloud'
 title: 'Integrating Confluent Cloud with ClickHouse'
 keywords: ['Kafka', 'Confluent Cloud']

--- a/vercel.json
+++ b/vercel.json
@@ -3377,13 +3377,18 @@
       "permanent": true
     },
     {
-      "source": "/operations/system-tables/latency_log",
-      "destination": "/operations/system-tables/histogram_metrics",
+      "source": "/docs/operations/system-tables/latency_log",
+      "destination": "/docs/operations/system-tables/histogram_metrics",
       "permanent": true
     },
     {
-      "source": "/operations/system-tables/latency_buckets",
-      "destination": "/operations/system-tables/histogram_metrics",
+      "source": "/docs/operations/system-tables/latency_buckets",
+      "destination": "/docs/operations/system-tables/histogram_metrics",
+      "permanent": true
+    },
+    {
+      "source": "/docs/integrations/kafka/cloud/confluent/custom-connector-cloud",
+      "destination": "/docs/integrations/kafka/cloud/confluent/sink-connector",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Changes https://clickhouse.com/docs/integrations/kafka/cloud/confluent/custom-connector-cloud to https://clickhouse.com/docs/integrations/kafka/cloud/confluent/sink-connector and adds in a redirect.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
