### PR TITLE
Search Results: Upping the constants value to 10 instead of 3

### DIFF
--- a/src/theme/SearchBar/searchConstants.js
+++ b/src/theme/SearchBar/searchConstants.js
@@ -5,7 +5,7 @@
 // Default search parameters
 export const DEFAULT_SEARCH_PARAMS = {
   clickAnalytics: true,
-  hitsPerPage: 3,
+  hitsPerPage: 10,
 };
 
 // Keyboard shortcuts


### PR DESCRIPTION
## Summary
During refactor this value got reset to 3, we want 10 search results.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
