### PR TITLE
Code blocks: allow crawlers and LLMs to see code

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -70,17 +70,36 @@ export default function CodeBlockWrapper(props) {
     };
   }, [handleIntersection]); // Add handleIntersection to dependency array
 
+  const settings = parseMetaString(props.metastring);
+  settings['language'] = props.className ? props.className.replace('language-', ''): 'txt';
+
   if (!isLoaded) {
     return (
         <div ref={codeBlockRef} className={styles.wrapper} style={{ height: estimatedHeight + 'px' }}>
+            {/* Invisible content for crawlers/SEO */}
+            <div style={{ 
+              position: 'absolute', 
+              left: '-9999px', 
+              top: '-9999px',
+              opacity: 0,
+              pointerEvents: 'none',
+              width: '1px',
+              height: '1px',
+              overflow: 'hidden'
+            }}>
+              <pre className={`language-${settings.language}`}>
+                <code className={`language-${settings.language}`}>
+                  {typeof props.children === 'string' ? props.children : ''}
+                </code>
+              </pre>
+            </div>
+            
+            {/* Visible loading animation */}
             <div className={styles.activity}></div>
         </div>
     );
-  }
-
+  } 
   
-  const settings = parseMetaString(props.metastring); 
-  settings['language'] = props.className ? props.className.replace('language-', ''): 'txt';
   return (
     <>
         <CodeViewer {...settings}>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
See discussion [here](https://clickhouse-inc.slack.com/archives/C03A9B0H05T/p1755800827902579?thread_ts=1755738663.615539&cid=C03A9B0H05T). With the lazy loading in the current form LLMs and crawlers can't see the code.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
