### PR TITLE
Correct documentation on DROP table limit of 1TB in ClickHouse Cloud

### DIFF
--- a/docs/cloud/manage/backups/overview.md
+++ b/docs/cloud/manage/backups/overview.md
@@ -165,7 +165,7 @@ Should you wish to drop tables greater than this threshold you can use setting `
 
 ```sql
 DROP TABLE IF EXISTS table_to_drop
-SYNC SETTINGS max_table_size_to_drop=2097152 -- increases the limit to 2TB
+SYNC SETTINGS max_table_size_to_drop=2000000000000 -- increases the limit to 2TB
 ```
 :::
 


### PR DESCRIPTION
Correcting the documentation for the DROP limit.

According to our docs, the setting max_table_size_to_drop is measured in bytes: https://clickhouse.com/docs/operations/server-configuration-parameters/settings#max_table_size_to_drop

Therefore, the value "2097152" would not be equal to 2TB. It would in fact be closer to 2MB.

Finally, our default setting in ClickHouse Cloud is "1000000000000" so we should keep the measurement consistently in either the decimal or binary system, so recommending the example be changed to "1200000000000" here

SELECT getSetting('max_table_size_to_drop');

```
   ┌─getSetting('⋯e_to_drop')─┐
1. │            1000000000000 │ -- 1.00 trillion
   └──────────────────────────┘
```

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
