### PR TITLE
Clarify TDE cannot be disabled once enabled

### DIFF
--- a/docs/cloud/security/cmek.md
+++ b/docs/cloud/security/cmek.md
@@ -19,7 +19,7 @@ Enhanced encryption is currently available in AWS and GCP services. Azure is com
 
 ## Transparent Data Encryption (TDE) {#transparent-data-encryption-tde}
 
-TDE must be enabled on service creation. Existing services cannot be encrypted after creation.
+TDE must be enabled on service creation. Existing services cannot be encrypted after creation. Once TDE is enabled, it cannot be disabled. All data in the service will remain encrypted. If you want to disable TDE after it has been enabled, you must create a new service and migrate your data there.
 
 1. Select `Create new service`
 2. Name the service


### PR DESCRIPTION
Updated the TDE section in the CMEK doc to make it explicit that:
- Once TDE is enabled, it cannot be disabled.
- If a customer wants to disable it, they must create a new instance and migrate data.

This change is intended to avoid confusion for users asking if TDE can be turned off.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
