### PR TITLE
minor change in spark-native-connector.md

### DIFF
--- a/docs/integrations/data-ingestion/apache-spark/spark-native-connector.md
+++ b/docs/integrations/data-ingestion/apache-spark/spark-native-connector.md
@@ -137,7 +137,7 @@ If you want to avoid copying the JAR files to your Spark client node, you can us
 
 ```text
   --repositories https://{maven-central-mirror or private-nexus-repo} \
-  --packages com.clickhouse.spark:clickhouse-spark-runtime-{{ spark_binary_version }}_{{ scala_binary_version }}:{{ stable_version }},com.clickhouse:clickhouse-jdbc:{{ clickhouse_jdbc_version }}:all
+  --packages com.clickhouse.spark:clickhouse-spark-runtime-{{ spark_binary_version }}_{{ scala_binary_version }}:{{ stable_version }},com.clickhouse:clickhouse-jdbc:{{ clickhouse_jdbc_version }}
 ```
 
 Note: For SQL-only use cases, [Apache Kyuubi](https://github.com/apache/kyuubi) is recommended


### PR DESCRIPTION
I am following the guide to set up connection between Apache Spark and ClickHouse. 2 minor issues:


1. I guess `:::note` is the correct syntax for the docusaurus markdown
2. if I load those 2 jars from maven in spark-sql CLI, I cannot use `com.clickhouse:clickhouse-jdbc:0.9.1:all`. The error message is 

> Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: Provided Maven Coordinates must be in the form 'groupId:artifactId:version'. The coordinate provided is: com.clickhouse:clickhouse-jdbc:0.9.1:all

So I propose removing the `:all`. Maven/ivy can load necessary jars for clickhouse jdbc driver.

Please review.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
