### PR TITLE
fixing overflow display issue on install for mobile

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1430,6 +1430,15 @@ input::-ms-input-placeholder { /* Microsoft Edge */
   display: flex;
 }
 
+@media (max-width: 768px) {
+  .installContainer {
+    flex-wrap: wrap;
+  }
+  .install-card {
+    margin: 0;
+  }
+}
+
 .install-card {
   margin: 0em 0.5em;
 }


### PR DESCRIPTION
## Summary
An mobile display issue was reported here
https://clickhouse-inc.slack.com/archives/C03A9B0H05T/p1756229827114659

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
