### PR TITLE
Add Arrow Flight page to a sidebar

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -10,4 +10,3 @@
 integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 integrations/data-ingestion/clickpipes/postgres/maintenance.md
-interfaces/arrowflight.md

--- a/sidebars.js
+++ b/sidebars.js
@@ -884,6 +884,7 @@ const sidebars = {
             "interfaces/prometheus",
             "interfaces/ssh",
             "interfaces/grpc",
+            "interfaces/arrowflight"
           ],
         },
         "integrations/sql-clients/sql-console",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The Arrow Flight page was added but never added to a sidebar.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
