### PR TITLE
fix: Correct CODEOWNERS entry order for ClickPipes documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *                      @ClickHouse/docs
-/docs/integrations/data-ingestion/clickpipes/ @ClickHouse/clickpipes @ClickHouse/docs
 /docs/integrations/ @ClickHouse/integrations-ecosystem @ClickHouse/docs
+/docs/integrations/data-ingestion/clickpipes/ @ClickHouse/clickpipes @ClickHouse/docs


### PR DESCRIPTION
If I'm reading https://github.com/orgs/community/discussions/23644#discussioncomment-3241280 correctly, we should have ClickPipes entry as last, because it's a subpath for `/docs/integrations/`
