### PR TITLE
Update TPC-H docs

### DIFF
--- a/docs/getting-started/example-datasets/tpch.md
+++ b/docs/getting-started/example-datasets/tpch.md
@@ -233,8 +233,6 @@ ORDER BY
 **Q2**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     s_acctbal,
     s_name,
@@ -281,7 +279,8 @@ ORDER BY
 ```
 
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.5, the query did not work out-of-the box because scalar correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 
 This alternative formulation works and was verified to return the reference results.
 
@@ -366,8 +365,6 @@ ORDER BY
 **Q4**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     o_orderpriority,
     count(*) AS order_count
@@ -392,7 +389,8 @@ ORDER BY
 ```
 
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.4, the query did not work out-of-the box because correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 
 This alternative formulation works and was verified to return the reference results.
 
@@ -826,8 +824,6 @@ ORDER BY
 **Q17**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
@@ -848,7 +844,8 @@ WHERE
 ```
 
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.5, the query did not work out-of-the box because scalar correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 
 This alternative formulation works and was verified to return the reference results.
 
@@ -959,8 +956,6 @@ WHERE
 **Q20**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     s_name,
     s_address
@@ -1001,14 +996,13 @@ ORDER BY
 ```
 
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.5, the query did not work out-of-the box because scalar correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 ::::
 
 **Q21**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     s_name,
     count(*) AS numwait
@@ -1050,14 +1044,13 @@ ORDER BY
     s_name;
 ```
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.4, the query did not work out-of-the box because correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 ::::
 
 **Q22**
 
 ```sql
-SET allow_experimental_correlated_subqueries = 1; -- since v25.5
-
 SELECT
     cntrycode,
     count(*) AS numcust,
@@ -1097,5 +1090,6 @@ ORDER BY
 ```
 
 ::::note
-Until v25.5, the query did not work out-of-the box due to correlated subqueries. Corresponding issue: https://github.com/ClickHouse/ClickHouse/issues/6697
+Until v25.4, the query did not work out-of-the box because correlated subqueries were unsupported.
+Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
 ::::

--- a/docs/getting-started/example-datasets/tpch.md
+++ b/docs/getting-started/example-datasets/tpch.md
@@ -280,7 +280,7 @@ ORDER BY
 
 ::::note
 Until v25.5, the query did not work out-of-the box because scalar correlated subqueries were unsupported.
-Until v25.8, the query requires enabling allow_experimental_correlated_subqueries setting.
+Until v25.8, the query requires enabling the `allow_experimental_correlated_subqueries` setting.
 
 This alternative formulation works and was verified to return the reference results.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Since `25.8`, correlated subqueries are enabled by default in ClickHouse. Update TPC-H queries in the docs.

## Checklist
- [x] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
