### PR TITLE
pg clickpipes: remove troubleshooting section from timescale

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
@@ -107,16 +107,6 @@ steps and perform a one-time load of your data.
 
 After these steps, you should be able to proceed with [creating a ClickPipe](../index.md).
 
-## Troubleshooting {#troubleshooting}
-
-Initial load for tables can fail with an error:
-
-```sql
-ERROR: transparent decompression only supports tableoid system column (SQLSTATE 42P10)
-```
-
-You may need to disable [compression](https://docs.timescale.com/api/latest/compression/decompress_chunk) or [hypercore columnstore](https://docs.timescale.com/api/latest/hypercore/convert_to_rowstore) for these tables.
-
 ## Configure network access {#configure-network-access}
 
 If you want to restrict traffic to your Timescale instance, please allowlist the [documented static NAT IPs](../../index.md#list-of-static-ips).


### PR DESCRIPTION
## Summary
warning no longer applies, as we now correctly pull compressed hypertables with https://github.com/PeerDB-io/peerdb/pull/3318