### PR TITLE
Add new allocation profiling page to sidebar

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -10,4 +10,3 @@
 integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 integrations/data-ingestion/clickpipes/postgres/maintenance.md
-operations/allocation-profiling-old.md

--- a/sidebars.js
+++ b/sidebars.js
@@ -1250,7 +1250,16 @@ const sidebars = {
         "operations/ssl-zookeeper",
         "operations/startup-scripts",
         "operations/storing-data",
-        "operations/allocation-profiling",
+        {
+          type: "category",
+          label: "Allocation profiling",
+          collapsed: true,
+          collapsible: true,
+          link: { type: "doc", id: "operations/allocation-profiling" },
+          items: [
+            "operations/allocation-profiling-old",
+          ]
+        },
         "operations/backup",
         "operations/caches",
         "operations/workload-scheduling",

--- a/sidebars.js
+++ b/sidebars.js
@@ -1257,6 +1257,7 @@ const sidebars = {
           collapsible: true,
           link: { type: "doc", id: "operations/allocation-profiling" },
           items: [
+            "operations/allocation-profiling",
             "operations/allocation-profiling-old",
           ]
         },


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
