### PR TITLE
Docs: remove references to deprecated object type

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/04_snowflake/03_sql_translation_reference.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/04_snowflake/03_sql_translation_reference.md
@@ -56,7 +56,7 @@ Snowflake supports the `VARIANT`, `OBJECT` and `ARRAY` types for semi-structured
 data.
 
 ClickHouse offers the equivalent [`Variant`](/sql-reference/data-types/variant),
-[`Object`](/sql-reference/data-types/object-data-type) (deprecated) and [`Array`](/sql-reference/data-types/array)
+`Object` (now deprecated in favor of the native `JSON` type) and [`Array`](/sql-reference/data-types/array)
 types. Additionally, ClickHouse has the [`JSON`](/sql-reference/data-types/newjson) 
 type which replaces the now deprecated `Object('json')` type and is particularly
 performant and storage efficient in [comparison to other native JSON types](https://jsonbench.com/).

--- a/docs/integrations/data-ingestion/data-formats/json/formats.md
+++ b/docs/integrations/data-ingestion/data-formats/json/formats.md
@@ -348,7 +348,7 @@ Note that `JSONAsString` works perfectly fine in cases we have JSON object-per-l
 
 ## Schema for nested objects {#schema-for-nested-objects}
 
-In cases when we're dealing with [nested JSON objects](../assets/list-nested.json), we can additionally define an explicit schema and use complex types ([`Array`](/sql-reference/data-types/array.md), [`Object Data Type`](/sql-reference/data-types/object-data-type) or [`Tuple`](/sql-reference/data-types/tuple.md)) to load data:
+In cases when we're dealing with [nested JSON objects](../assets/list-nested.json), we can additionally define an explicit schema and use complex types ([`Array`](/sql-reference/data-types/array.md), [`JSON`](/integrations/data-formats/json/overview) or [`Tuple`](/sql-reference/data-types/tuple.md)) to load data:
 
 ```sql
 SELECT *


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes references to deprecated object type required to merge https://github.com/ClickHouse/ClickHouse/pull/85718
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
