### PR TITLE
Fixed errors in 01_1_shard_2_replicas.md

### DIFF
--- a/docs/deployment-guides/replication-sharding-examples/01_1_shard_2_replicas.md
+++ b/docs/deployment-guides/replication-sharding-examples/01_1_shard_2_replicas.md
@@ -633,8 +633,8 @@ FROM url(
     county String,
     d String,
     e String'
-) SETTINGS max_http_get_redirects=10;
-LIMIT 10000;
+) LIMIT 10000
+SETTINGS max_http_get_redirects=10;
 ```
 
 Notice that the data is completely replicated on each host:
@@ -772,8 +772,7 @@ FROM url(
     county String,
     d String,
     e String'
-    ) SETTINGS max_http_get_redirects=10
-LIMIT 10000;
+    ) SETTINGS max_http_get_redirects=10;
 ```
 
 Query the table from `clickhouse-02` or `clickhouse-01`:


### PR DESCRIPTION
Updated `LIMIT` statements and fixed full dataset load statement

## Summary
This is wrong:

```
SETTINGS max_http_get_redirects=10;
LIMIT 10000;
```

Statement should be:

```
LIMIT 10000
SETTINGS max_http_get_redirects=10;
```

Also, the `LIMIT` Statement was dropped from the whole table load.

*If at this stage you would like to ingest the full UK property price dataset to play around with, you can run the following queries to do so:...*

Note that [this](https://github.com/ClickHouse/clickhouse-docs/commit/ccbff678c609e1d906183ec674dbb85012f2b84a) commit is still wrong; the LIMIT statement should go first
