### PR TITLE
Fixed typo in part_intersects_previous_part

### DIFF
--- a/knowledgebase/part_intersects_previous_part.mdx
+++ b/knowledgebase/part_intersects_previous_part.mdx
@@ -38,7 +38,7 @@ Execute the following queries on all replicas:
 ```sql
 DETACH TABLE table_name;  -- Required for DROP REPLICA
 
-SYSTEM DROP REPLICA 'replica_name' FROM ZK PATH '/table_path_in_zk/'; -- It will remove everything from /table_path_in_zk
+SYSTEM DROP REPLICA 'replica_name' FROM ZKPATH '/table_path_in_zk/'; -- It will remove everything from /table_path_in_zk
 
 ATTACH TABLE table_name;  -- Table will be in readonly mode, because there is no metadata in ZK
 ```


### PR DESCRIPTION
## Summary

Stray space in "SYSTEM DROP REPLICA COMMAND" - see https://clickhouse.com/docs/sql-reference/statements/system#drop-replica

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
