### PR TITLE
Allow configuring onBrokenAnchors for Docusaurus, add a README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ You can run a copy of this website locally within a few steps. Some folks find t
     # [INFO] Use `npm run serve` command to test your build locally.
     # ✨  Done in 105.96s.
     ```
+   
+> [!TIP]
+> If the build command is failing due to broken anchors, 
+> it is possible to ignore these temporarily by running `ON_BROKEN_ANCHORS=ignore yarn build` instead.
 
 1. Start the local web-server:
 

--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -57,7 +57,7 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   onDuplicateRoutes: "throw",
-  onBrokenAnchors: "throw",
+  onBrokenAnchors: process.env.ON_BROKEN_ANCHORS ?? "throw",
   favicon: "img/docs_favicon.ico",
   organizationName: "ClickHouse",
   trailingSlash: false,


### PR DESCRIPTION
## Summary

- Allow skipping broken anchors check with 

  ```sh
  ON_BROKEN_ANCHORS=ignore yarn build
  ```

- Added a README note