### PR TITLE
fix: typo “mehthod” → “method” in Pi article

### DIFF
--- a/knowledgebase/calculate-pi-using-sql.mdx
+++ b/knowledgebase/calculate-pi-using-sql.mdx
@@ -106,7 +106,7 @@ SELECT 22 / 7
 └───────────────────┘
 ```
 
-8. Another indirect mehthod (this one came from Alexey Milovidov) that is accurate to 7 decimal places - and it's quick:
+8. Another indirect method (this one came from Alexey Milovidov) that is accurate to 7 decimal places - and it's quick:
 
 ```sql
 WITH


### PR DESCRIPTION
This PR fixes a minor typo in the Knowledge Base article
“Let’s calculate pi using SQL”: “mehthod” → “method”.

