### PR TITLE
Update style-guide.md with information about `doc_type` front-matter field

### DIFF
--- a/contribute/style-guide.md
+++ b/contribute/style-guide.md
@@ -16,6 +16,7 @@ sidebar_label: 'Using clickhouse-local database'
 slug: /chdb/guides/clickhouse-local
 description: 'Learn how to use a clickhouse-local database with chDB'
 keywords: ['chdb', 'clickhouse-local']
+doc_type: 'reference' (or 'guide' or 'changelog')
 ---
 ```
 
@@ -26,7 +27,7 @@ keywords: ['chdb', 'clickhouse-local']
 There is a custom Docusaurus plugin which runs on build that makes the following
 checks on front-matter:
 
-- title, description and slug are specified.
+- title, description, slug and doc_type (either `reference`, `guide`, `landingpage` or `changelog`) are specified.
 - keywords use flow style arrays with single quoted items e.g. 
   `keywords: ['integrations']`
 - single quotes are used for title, description, slug, sidebar_label


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Updates the style guide to include `doc_type` information, otherwise nobody knows to include it. See: https://github.com/ClickHouse/ClickHouse/pull/87307#issuecomment-3317598970
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
