### PR TITLE
Fix top level menu links which go to the wrong place

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1624,7 +1624,7 @@ const sidebars = {
           type: "link",
           label: "Migration Guides",
           description: "Migrate your database to ClickHouse",
-          href: "/migrations/migrations"
+          href: "/integrations/migration/overview"
         },
         {
           type: "link",
@@ -1829,7 +1829,7 @@ const sidebars = {
           type: "link",
           label: "Data Sources",
           description: "Load data into ClickHouse from your prefered source",
-          href: "/integrations/index"
+          href: "/integrations/data-sources/index"
         },
         {
           type: "link",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes links for 'Migrating data' and 'Data sources' which are linked to pages which no longer exist.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
