### PR TITLE
Styling: fix padding of 404 page

### DIFF
--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Heading from '@theme/Heading';
+import styles from "../styles.module.css";
+export default function NotFoundContent({className}) {
+  return (
+    <main>
+      <div>
+          <div className={styles.notFoundMain}>
+          <Heading as="h1" className="hero__title">
+            <Translate
+              id="theme.NotFound.title"
+              description="The title of the 404 page">
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>
+            <Translate
+              id="theme.NotFound.p1"
+              description="The first paragraph of the 404 page">
+              We could not find what you were looking for.
+            </Translate>
+          </p>
+          <p>
+            <Translate
+              id="theme.NotFound.p2"
+              description="The 2nd paragraph of the 404 page">
+              Please contact the owner of the site that linked you to the
+              original URL and let them know their link is broken.
+            </Translate>
+          </p>
+          </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/NotFound/index.js
+++ b/src/theme/NotFound/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+export default function Index() {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <NotFoundContent />
+    </>
+  );
+}

--- a/src/theme/NotFound/styles.module.css
+++ b/src/theme/NotFound/styles.module.css
@@ -1,0 +1,7 @@
+.notFoundMain {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding-top: 10rem;
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The 404 page styling needs improvement:

<img width="720" height="336" alt="image" src="https://github.com/user-attachments/assets/77f10ad8-93cb-469c-b40a-74cbb06fbbac" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
