### PR TITLE
Bug fix: duplicate KB articles show in search

### DIFF
--- a/knowledgebase/unable-to-access-cloud-service.mdx
+++ b/knowledgebase/unable-to-access-cloud-service.mdx
@@ -1,9 +1,9 @@
 ---
-title: Tips and tricks on optimizing basic data types in ClickHouse
-description: "Tips and tricks on optimizing basic data types in ClickHouse"
+title: I am unable to access a ClickHouse Cloud service
+description: "Troubleshooting access issues with ClickHouse Cloud services, including IP Access List configuration"
 date: 2024-07-02
-tags: ['Errors and Exceptions']
-keywords: ['accessing cloud service']
+tags: ['Errors and Exceptions', 'Managing Cloud']
+keywords: ['accessing cloud service', 'IP Access List']
 doc_type: 'guide'
 ---
 

--- a/src/components/KBArticleSearch/KBArticleSearch.js
+++ b/src/components/KBArticleSearch/KBArticleSearch.js
@@ -55,7 +55,7 @@ const KBArticleSearch = ({kb_articles, kb_articles_and_tags, onUpdateResults}) =
                 }
             );
             kb_articles_and_tags.forEach((article)=>{
-                index.add({id: article.id, title: article.title});
+                index.add({id: article.id, title: article.title, description: article.description});
             })
             indexRef.current = index;
 
@@ -111,6 +111,7 @@ const KBArticleSearch = ({kb_articles, kb_articles_and_tags, onUpdateResults}) =
         } else if (results && searchTerm.length > 1 && results.length === 0) {
             setMatchedArticles([]);
         } else {
+            // Extract all indices from all search field results and deduplicate
             const indices = results.flatMap(search_field_results => search_field_results.result);
             const unique_indices = [...new Set(indices)];
             const filteredArticles = kb_articles_and_tags.filter((article) => {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes a bug where multiple of the same KB article show in the search results.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
