### PR TITLE
Correct PostgreSQL integration page

### DIFF
--- a/docs/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
+++ b/docs/integrations/data-ingestion/dbms/postgresql/connecting-to-postgresql.md
@@ -14,10 +14,13 @@ import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 
 This page covers following options for integrating PostgreSQL with ClickHouse:
 
-- using [ClickPipes](/integrations/clickpipes/postgres), the managed integration service for ClickHouse Cloud powered by PeerDB.
-- using [PeerDB](https://github.com/PeerDB-io/peerdb), an open-source CDC tool specifically designed for PostgreSQL database replication to both self-hosted ClickHouse and ClickHouse Cloud.
 - using the `PostgreSQL` table engine, for reading from a PostgreSQL table
 - using the experimental `MaterializedPostgreSQL` database engine, for syncing a database in PostgreSQL with a database in ClickHouse
+
+:::tip
+We recommend using [ClickPipes](/integrations/clickpipes/postgres), a managed integration service for ClickHouse Cloud powered by PeerDB.
+Alternatively, [PeerDB](https://github.com/PeerDB-io/peerdb) is available as an an open-source CDC tool specifically designed for PostgreSQL database replication to both self-hosted ClickHouse and ClickHouse Cloud.
+:::
 
 ## Using the PostgreSQL table engine {#using-the-postgresql-table-engine}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
This page says that it covers ClickPipes and PeerDB, but then only covers using the `PostgreSQL` table engine and the `MaterializedPostgreSQL` database engine.

Removed the note about covering ClickPipes and PeerDB and added a tip that if you're looking for a managed solution ClickPipes is a good option, otherwise OS PeerDB is an option.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
