### PR TITLE
Update index.md

### DIFF
--- a/docs/chdb/index.md
+++ b/docs/chdb/index.md
@@ -45,7 +45,6 @@ chDB has the following language bindings:
   * [Querying Parquet files](guides/querying-parquet.md)
   * [Querying remote ClickHouse](guides/query-remote-clickhouse.md)
   * [Using clickhouse-local database](guides/clickhouse-local.md)
-  
 
 ## An introductory video {#an-introductory-video}
 


### PR DESCRIPTION
added chdb on demand course links to docs overview page

## Summary
A new course on chDB has been released! I added two links to the new course on the docs overview page for chDB.


