### PR TITLE
Fix dangling directory reference

### DIFF
--- a/docs/deployment-guides/replication-sharding-examples/01_1_shard_2_replicas.md
+++ b/docs/deployment-guides/replication-sharding-examples/01_1_shard_2_replicas.md
@@ -65,7 +65,7 @@ for i in {01..02}; do
 done
 ```
 
-Add the following `docker-compose.yml` file to the `clickhouse-cluster` directory:
+Add the following `docker-compose.yml` file to the `cluster_1S_2R` directory:
 
 ```yaml title="docker-compose.yml"
 version: '3.8'


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

This patch fixes a dangling directory reference, likely a typo, in `Deployment and Scaling / Example / Replication` page https://clickhouse.com/docs/architecture/replication. 

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

