### PR TITLE
Redirects: add redirect for weird language issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3500,6 +3500,11 @@
       "source": "/docs/migrations/migrations",
       "destination": "/docs/integrations/migration/overview",
       "permanent": true
+    },
+    {
+      "source": "/docs/:lang1(ru|zh|jp)/:lang2(ru|zh|jp|en)/:path*",
+      "destination": "/docs/:lang1/:path*",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Google Search Console reports many links which aren't indexed or served on Google such as:
- https://clickhouse.com/docs/zh/jp/sql-reference/aggregate-functions/reference/uniqcombined64
- https://clickhouse.com/docs/zh/en/sql-reference/functions/geo/polygons
- https://clickhouse.com/docs/zh/ru/sql-reference/aggregate-functions/reference/last_value
- https://clickhouse.com/docs/zh/en/best-practices/selecting-an-insert-strategy
etc

Adds a redirect to the correct path based on the first language code. e.g. `https://clickhouse.com/docs/zh/en/sql-reference/functions/geo/polygons` -> `- https://clickhouse.com/docs/zh/sql-reference/functions/geo/polygons`
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
