### PR TITLE
Exclude GA tag manager from preview deployments

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -197,9 +197,11 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
-        googleTagManager: {
-          containerId: 'GTM-WTNTDT7W',
-        },
+        ...(process.env.VERCEL_PREVIEW !== '1' && {
+          googleTagManager: {
+            containerId: 'GTM-WTNTDT7W',
+          },
+        }),
       }),
     ],
   ],

--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -162,9 +162,11 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
-        googleTagManager: {
-          containerId: 'GTM-WTNTDT7W',
-        },
+        ...(process.env.VERCEL_PREVIEW !== '1' && {
+          googleTagManager: {
+            containerId: 'GTM-WTNTDT7W',
+          },
+        }),
       }),
     ],
   ],

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -163,9 +163,11 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
-        gtag: {
-          trackingID: "G-KF1LLRTQ5Q",
-        },
+        ...(process.env.VERCEL_PREVIEW !== '1' && {
+          googleTagManager: {
+            containerId: 'GTM-WTNTDT7W',
+          },
+        }),
       }),
     ],
   ],

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -162,9 +162,11 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
-        gtag: {
-          trackingID: "G-KF1LLRTQ5Q",
-        },
+        ...(process.env.VERCEL_PREVIEW !== '1' && {
+          googleTagManager: {
+            containerId: 'GTM-WTNTDT7W',
+          },
+        }),
       }),
     ],
   ],


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Currently GA tag manager is included in preview deployments.
Added an environment variable to preview vercel deployment only called `VERCEL_PREVIEW`
Modified Docusaurus.config.js files to not include the GA tag manager plugin if this environment variable is detected.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
