### PR TITLE
CI: temp fix for docs check

### DIFF
--- a/scripts/sed_links.sh
+++ b/scripts/sed_links.sh
@@ -15,6 +15,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i '' 's|(/sql-reference/statements/select#replace)|(/sql-reference/statements/select)|g' docs/guides/developer/dynamic-column-selection.md
     sed -i '' 's|(/sql-reference/statements/select#except)|(/sql-reference/statements/select)|g' docs/guides/developer/dynamic-column-selection.md
     sed -i '' 's|(/cloud/reference/cloud-compatibility.md)|(/whats-new/cloud-compatibility)|g' docs/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md
+    sed -i '' 's|<auxiliary_zookeepers>|`<auxiliary_zookeepers>`|g' docs/operations/server-configuration-parameters/settings.md
 else
     # Linux
     sed -i 's|(../../quick-start\.mdx)|(/get-started/quick-start)|g' docs/operations/utilities/clickhouse-local.md
@@ -23,4 +24,5 @@ else
     sed -i 's|(/sql-reference/statements/select#replace)|(/sql-reference/statements/select)|g' docs/guides/developer/dynamic-column-selection.md
     sed -i 's|(/sql-reference/statements/select#except)|(/sql-reference/statements/select)|g' docs/guides/developer/dynamic-column-selection.md
     sed -i 's|(/cloud/reference/cloud-compatibility.md)|(/whats-new/cloud-compatibility)|g' docs/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md
+    sed -i 's|<auxiliary_zookeepers>|`<auxiliary_zookeepers>`|g' docs/operations/server-configuration-parameters/settings.md
 fi


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Temp fix for docs check because it will take some time before the change is available for autogeneration script to use. Docs check will fail until then.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
