### PR TITLE
UTM Persistence for `.cloud` Links

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -36,6 +36,9 @@ const config = {
       defer: true, // execute after document parsing, but before firing DOMContentLoaded event
     },
   ],
+  clientModules: [
+    require.resolve('./src/clientModules/utmPersistence.js')
+  ],
   // Settings for Docusaurus Faster - build optimizations
   future: {
     experimental_faster: {

--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -28,6 +28,9 @@ const config = {
       defer: true, // execute after document parsing, but before firing DOMContentLoaded event
     }
   ],
+  clientModules: [
+    require.resolve('./src/clientModules/utmPersistence.js')
+  ],
   // Settings for Docusaurus Faster - build optimizations
   future: {
     experimental_faster: {

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -28,6 +28,9 @@ const config = {
       defer: true, // execute after document parsing, but before firing DOMContentLoaded event
     }
   ],
+  clientModules: [
+    require.resolve('./src/clientModules/utmPersistence.js')
+  ],
   // Settings for Docusaurus Faster - build optimizations
   future: {
     experimental_faster: {

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -28,6 +28,9 @@ const config = {
       defer: true, // execute after document parsing, but before firing DOMContentLoaded event
     }
   ],
+  clientModules: [
+    require.resolve('./src/clientModules/utmPersistence.js')
+  ],
   // Settings for Docusaurus Faster - build optimizations
   future: {
     experimental_faster: {

--- a/src/clientModules/utmPersistence.js
+++ b/src/clientModules/utmPersistence.js
@@ -1,0 +1,137 @@
+function putUTMsInStorage() {
+    const expirationTime = new Date()
+    expirationTime.setDate(expirationTime.getDate() + 14) // Set expiration to 14 days from now
+
+    const urlParams = new URLSearchParams(window.location.search)
+    const utmValues = {}
+
+    // Convert iterator to array
+    Array.from(urlParams.entries()).forEach(([key, value]) => {
+        if (key.startsWith('utm_') || key === 'gclid') {
+            utmValues[key] = value
+        }
+    })
+
+    // No values, don't save
+    if (!Object.keys(utmValues).length) return
+
+    // Save values
+    window.localStorage.setItem('ch-utms', JSON.stringify({
+        data: utmValues,
+        timestamp: expirationTime.getTime()
+    }))
+}
+
+function putPagePathsInStorage() {
+    const currentPath = window.location.pathname
+
+    // Already has value, abort
+    if (window.localStorage.getItem('origPath')) return
+
+    // Save value
+    window.localStorage.setItem('origPath', currentPath)
+}
+
+function getUTMsFromStorage() {
+    const utms = window.localStorage.getItem('ch-utms')
+    if (utms) {
+        const { data, timestamp } = JSON.parse(utms)
+        const convertedTimestamp = new Date(parseInt(timestamp))
+        const dateNow = new Date()
+
+        // Handle expired UTMS
+        if (dateNow.getTime() > convertedTimestamp.getTime()) {
+            window.localStorage.removeItem('ch-utms')
+            return null
+        }
+
+        return data
+    }
+
+    return null
+}
+
+function getGoogleAnalyticsCookie() {
+    // Get all cookies in the format "cookieName=cookieValue; ..."
+    const cookies = document.cookie.split(';')
+
+    // Loop through each cookie
+    for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i].trim()
+
+        // Check if the cookie starts with "_ga="
+        if (cookie.startsWith('_ga=')) {
+            // Return the value part, which is everything after "_ga="
+            return cookie.substring(4)
+        }
+    }
+
+    return null
+}
+
+function appendUTMsToLink(url) {
+    const utms = getUTMsFromStorage()
+    const urlObject = new URL(url, window.location.toString())
+    if (utms) {
+        Object.entries(utms).forEach(([key, value]) => {
+            urlObject.searchParams.set(key, value)
+        })
+    }
+    return urlObject.toString()
+}
+
+function appendPagePathsToLink(url) {
+    const urlObject = new URL(url)
+
+    // Append current page path
+    urlObject.searchParams.set('pagePath', window.location.pathname)
+
+    // Append original page path from local storage if available
+    const origPath = window.localStorage.getItem('origPath')
+    if (origPath) {
+        urlObject.searchParams.set('origPath', origPath)
+    }
+
+    return urlObject.toString()
+}
+
+function appendGoogleAnalyticsCookieToLink(url) {
+    const cookieValue = getGoogleAnalyticsCookie()
+
+    if (!cookieValue) return url
+
+    const urlObject = new URL(url)
+    urlObject.searchParams.set('utm_ga', cookieValue)
+    return urlObject.toString()
+}
+
+function appendGalaxySessionIDToLink(url) {
+    const galaxy_id = window?.galaxy?.getSessionId() || null
+
+    if (!galaxy_id) return url
+
+    const urlObject = new URL(url)
+    urlObject.searchParams.set('glxid', galaxy_id)
+    return urlObject.toString()
+}
+
+
+// After DOM renedered
+export function onRouteDidUpdate({location, previousLocation}) {
+    // Take UTMs from the URL and update local storage
+    putUTMsInStorage()
+
+    // Save origPath
+    putPagePathsInStorage()
+
+    Array.from(document.querySelectorAll('a[href*=".cloud"]')).forEach(el => {
+        try {
+            let href = el.href
+            href = appendUTMsToLink(href)
+            href = appendGalaxySessionIDToLink(href)
+            href = appendPagePathsToLink(href)
+            href = appendGoogleAnalyticsCookieToLink(href)
+            el.href = href
+        } catch {}
+    });
+}

--- a/src/clientModules/utmPersistence.js
+++ b/src/clientModules/utmPersistence.js
@@ -1,3 +1,5 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
 function putUTMsInStorage() {
     const expirationTime = new Date()
     expirationTime.setDate(expirationTime.getDate() + 14) // Set expiration to 14 days from now
@@ -134,9 +136,8 @@ function updateLinks() {
     });
 }
 
-// Bedore DOM renders
-export function onRouteUpdate() {
 
+if (ExecutionEnvironment.canUseDOM) {
     const observer = new MutationObserver(() => {
         updateLinks()
     });
@@ -147,13 +148,4 @@ export function onRouteUpdate() {
         subtree: true,
         attributes: false // Set to false, allows us to update the href without causing an infinite loop
     });
-
-    // Cleanup
-    return () => observer.disconnect()
-}
-
-
-// After DOM renedered
-export function onRouteDidUpdate() {
-    updateLinks()
 }

--- a/src/clientModules/utmPersistence.js
+++ b/src/clientModules/utmPersistence.js
@@ -115,15 +115,13 @@ function appendGalaxySessionIDToLink(url) {
     return urlObject.toString()
 }
 
+function updateLinks() {
 
-// After DOM renedered
-export function onRouteDidUpdate({location, previousLocation}) {
-    // Take UTMs from the URL and update local storage
-    putUTMsInStorage()
+    // First, gather data
+    putUTMsInStorage() // Take UTMs from the URL and update local storage
+    putPagePathsInStorage() // Save origPath
 
-    // Save origPath
-    putPagePathsInStorage()
-
+    // Next, append gathered data to cloud links
     Array.from(document.querySelectorAll('a[href*=".cloud"]')).forEach(el => {
         try {
             let href = el.href
@@ -134,4 +132,28 @@ export function onRouteDidUpdate({location, previousLocation}) {
             el.href = href
         } catch {}
     });
+}
+
+// Bedore DOM renders
+export function onRouteUpdate() {
+
+    const observer = new MutationObserver(() => {
+        updateLinks()
+    });
+
+    // Observe the entire body for DOM changes
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: false // Set to false, allows us to update the href without causing an infinite loop
+    });
+
+    // Cleanup
+    return () => observer.disconnect()
+}
+
+
+// After DOM renedered
+export function onRouteDidUpdate() {
+    updateLinks()
 }


### PR DESCRIPTION
## Summary

This PR adds persistence for UTM and tracking parameters on `.cloud` links to improve attribution.

Using the **MutationObserver API**, it watches for DOM changes and automatically appends collected parameters to `.cloud` links, specifically targeting `clickhouse.cloud/signup`.

### Parameters Appended

- `utm_*` - Standard UTM parameters
- `utm_ga` - Google Analytics cookie ID
- `origPath` - First path the user landed on
- `pagePath` - Current page path
- `glxid` - Internal tracking ID