### PR TITLE
adding doc_type ranking so references and guides appear first

### DIFF
--- a/scripts/search/settings.json
+++ b/scripts/search/settings.json
@@ -22,7 +22,8 @@
       "url_without_anchor",
       "type",
       "title",
-      "doc_type"
+      "doc_type",
+      "doc_type_rank"
     ],
     "camelCaseAttributes": [
       "h1",
@@ -53,7 +54,7 @@
       "an"
     ],
     "attributesForFaceting": [
-      "doc_type"
+      "filterOnly(doc_type)"
     ],
     "attributesToSnippet": [
       "content:15",
@@ -83,6 +84,7 @@
       "custom"
     ],
     "customRanking": [
+      "desc(doc_type_rank)",
       "desc(score)",
       "desc(page_rank)"
     ],

--- a/src/theme/SearchBar/utils/searchConfig.js
+++ b/src/theme/SearchBar/utils/searchConfig.js
@@ -8,7 +8,7 @@ export const createDocTypeFilters = (docTypes) => {
   if (!docTypes) return [];
   
   const types = Array.isArray(docTypes) ? docTypes : [docTypes];
-  return types.map(type => `doc_type:'${type}'`);
+  return types.map(type => `doc_type:${type}`);
 };
 
 /**


### PR DESCRIPTION
## Summary
Compute search is returning changelog before the reference material. Changelog should not be first.

<img width="1232" height="1596" alt="image" src="https://github.com/user-attachments/assets/b87d0954-17be-4e91-a297-6fef2827ab8e" />

Fixed so that doc_type ranking is taken into account in the algolia index.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
