### PR TITLE
Propagate slug locale fixes to i18n pages

### DIFF
--- a/i18n/jp/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
@@ -4,7 +4,7 @@ description: 'This table contains histogram metrics that can be calculated insta
 keywords:
 - 'system table'
 - 'histogram_metrics'
-slug: '/en/operations/system-tables/histogram_metrics'
+slug: '/operations/system-tables/histogram_metrics'
 title: 'system.histogram_metrics'
 ---
 

--- a/i18n/jp/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
@@ -1,7 +1,7 @@
 ---
 description: 'Calculates the population variance.'
 sidebar_position: 210
-slug: '/en/sql-reference/aggregate-functions/reference/varPop'
+slug: '/sql-reference/aggregate-functions/reference/varPop'
 title: 'varPop'
 ---
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
@@ -2,7 +2,7 @@
 description: 'Эта таблица содержит метрики гистограммы, которые могут быть рассчитаны мгновенно
   и экспортированы в формате Prometheus. Она всегда актуальна.'
 keywords: ['системная таблица', 'метрики_гистограммы']
-slug: /ru/operations/system-tables/histogram_metrics
+slug: /operations/system-tables/histogram_metrics
 title: 'system.histogram_metrics'
 ---
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
@@ -1,7 +1,7 @@
 ---
 description: 'Вычисляет дисперсию населения.'
 sidebar_position: 210
-slug: /ru/sql-reference/aggregate-functions/reference/varPop
+slug: /sql-reference/aggregate-functions/reference/varPop
 title: 'varPop'
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/operations/system-tables/histogram_metrics.md
@@ -3,7 +3,7 @@
 'keywords':
 - 'system table'
 - 'histogram_metrics'
-'slug': '/en/operations/system-tables/histogram_metrics'
+'slug': '/operations/system-tables/histogram_metrics'
 'title': 'system.histogram_metrics'
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/sql-reference/aggregate-functions/reference/varpop.md
@@ -1,7 +1,7 @@
 ---
 'description': '计算人口方差。'
 'sidebar_position': 210
-'slug': '/en/sql-reference/aggregate-functions/reference/varPop'
+'slug': '/sql-reference/aggregate-functions/reference/varPop'
 'title': 'varPop'
 ---
 


### PR DESCRIPTION
## Summary
These PRs removed /en slugs from the english versions
- from `histogram_metrics` https://github.com/ClickHouse/ClickHouse/pull/85550
- from `varpop` https://github.com/ClickHouse/ClickHouse/pull/87447

But the changes haven't been reflected in the i18n versions yet.

This leads to weird links like
- https://clickhouse.com/docs/ru/ru/operations/system-tables/histogram_metrics
- https://clickhouse.com/docs/zh/en/operations/system-tables/histogram_metrics
- https://clickhouse.com/docs/jp/en/operations/system-tables/histogram_metrics

- https://clickhouse.com/docs/ru/ru/sql-reference/aggregate-functions/reference/varPop
- https://clickhouse.com/docs/zh/en/sql-reference/aggregate-functions/reference/varPop
- https://clickhouse.com/docs/jp/en/sql-reference/aggregate-functions/reference/varPop

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
