### PR TITLE
Improvement: add category file for SQL console dropdown

### DIFF
--- a/docs/cloud/guides/SQL_console/_category_.json
+++ b/docs/cloud/guides/SQL_console/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "SQL console",
+  "collapsible": true,
+  "collapsed": true,
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes the funny looking "SQL_console"
<img width="285" height="239" alt="Screenshot 2025-10-08 at 18 10 20" src="https://github.com/user-attachments/assets/303c7b8f-9451-4fc0-9b4b-7b215dd2efd3" />
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
