### PR TITLE
Fix page showing with a double header

### DIFF
--- a/docs/integrations/data-sources/redis.md
+++ b/docs/integrations/data-sources/redis.md
@@ -4,12 +4,9 @@ sidebar_label: 'Redis'
 title: 'Redis'
 description: 'Page describing the Redis table function'
 doc_type: 'reference'
+show_title: false
 ---
 
 import RedisFunction from '@site/docs/sql-reference/table-functions/redis.md';
-
-# Redis integration
-
-Users can integrate with Redis via the table function. 
 
 <RedisFunction/>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
<img width="1321" height="708" alt="Screenshot 2025-10-08 at 18 19 42" src="https://github.com/user-attachments/assets/f43136f3-726d-4f35-a7af-b160e6b98624" />
## Checklist

- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
