### PR TITLE
missing some back ticks for closing a codeblock.

### DIFF
--- a/docs/guides/best-practices/skipping-indexes-examples.md
+++ b/docs/guides/best-practices/skipping-indexes-examples.md
@@ -14,7 +14,8 @@ This page consolidates ClickHouse data skipping index examples, showing how to d
 **Index syntax:** 
 
 ```sql
-INDEX name expr TYPE type(...) [GRANULARITY N]`
+INDEX name expr TYPE type(...) [GRANULARITY N]
+```
 
 ClickHouse supports five skip index types:
 


### PR DESCRIPTION
## Summary
Formatting issue discovered on data skipping index examples. Missing closing back ticks for codeblock.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
