### PR TITLE
Styling: adjust inline code block styling for light-mode

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -278,15 +278,20 @@ html[data-theme='dark'] pre,
 html[data-theme='dark'] pre code,
 html[data-theme='dark'] code {
   background: none !important;
-  background-color: #282828 !important;
+  background-color: #323131 !important;
   box-shadow: none !important;
   filter: none !important;
   border: none !important;
+  font-weight: normal;
+  border-radius: 3px !important;
 }
 
 html[data-theme='light'] code {
-  background-color: #f5f5f5 !important;
+  font-weight: normal;
+  background-color: #f6f5f5 !important;
   color: #000 !important;
+  border: none !important;
+  border-radius: 3px !important;
 }
 
 /* === Block code (pre) === */


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adjusts inline code-block styling in light-mode to make it less distracting:

<img width="4040" height="2048" alt="image" src="https://github.com/user-attachments/assets/85e1e655-c540-4cb7-80dd-19422f3e6f9e" />

After (left)
Before (right)
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
