### PR TITLE
Cloud: remove unsupported in Cloud badge for UNDROP statement

### DIFF
--- a/docs/cloud/features/08_backups/overview.md
+++ b/docs/cloud/features/08_backups/overview.md
@@ -154,9 +154,7 @@ After you have successfully inserted the data into your original service, make s
 
 ## Undeleting or undropping tables {#undeleting-or-undropping-tables}
 
-<CloudNotSupportedBadge/>
-
-The `UNDROP` command is not supported in ClickHouse Cloud. If you accidentally `DROP` a table, the best course of action is to restore your last backup and recreate the table from the backup.
+The `UNDROP` command is supported in ClickHouse Cloud through [Shared Catalog](https://clickhouse.com/docs/cloud/reference/shared-catalog).
 
 To prevent users from accidentally dropping tables, you can use [`GRANT` statements](/sql-reference/statements/grant) to revoke permissions for the [`DROP TABLE` command](/sql-reference/statements/drop#drop-table) for a specific user or role.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes the badge stating `UNDROP` is not supported in Cloud.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
