### PR TITLE
Doc fix: s/min/max fixes in maxSimpleState.md

### DIFF
--- a/docs/guides/examples/aggregate_function_combinators/maxSimpleState.md
+++ b/docs/guides/examples/aggregate_function_combinators/maxSimpleState.md
@@ -1,13 +1,13 @@
 ---
 slug: '/examples/aggregate-function-combinators/maxSimpleState'
 title: 'maxSimpleState'
-description: 'Example of using the minSimpleState combinator'
-keywords: ['min', 'state', 'simple', 'combinator', 'examples', 'minSimpleState']
-sidebar_label: 'minSimpleState'
+description: 'Example of using the maxSimpleState combinator'
+keywords: ['max', 'state', 'simple', 'combinator', 'examples', 'maxSimpleState']
+sidebar_label: 'maxSimpleState'
 doc_type: 'reference'
 ---
 
-# minSimpleState {#minsimplestate}
+# maxSimpleState {#maxsimplestate}
 
 ## Description {#description}
 


### PR DESCRIPTION
## Summary
Simple typo fixes on a misleading doc page. Currently the maxSimpleState sidebar entry is entitled minSimpleState.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
