### PR TITLE
Styling: lighter background for yellow caution block

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -136,9 +136,6 @@ body {
 [data-theme='dark'] .theme-admonition-tip.alert--success .alert-content  {
   background-color: rgba(255,255,255,0.1);
 
-  code {
-    background: #bfbfbf !important;
-  }
 }
 
 [data-theme='dark'] .DocSearch-Hit-source {
@@ -1153,6 +1150,10 @@ button.DocSearch {
 
   .alert-content {
     background: var(--click-color-warning-background) !important;
+
+    code {
+      background: #bfbfbf !important;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes:

<img width="919" height="275" alt="Screenshot 2025-10-17 at 19 33 45" src="https://github.com/user-attachments/assets/375fbfb9-5d12-4714-84f6-aac303e92f8e" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
