### PR TITLE
Integrations: landing page revamp

### DIFF
--- a/src/components/IntegrationGrid/IntegrationGrid.tsx
+++ b/src/components/IntegrationGrid/IntegrationGrid.tsx
@@ -175,9 +175,25 @@ function useCMSIntegrations() {
         setIntegrations(transformedData);
         setError(null);
       } catch (err) {
-        console.error('Failed to fetch integrations from CMS:', err);
-        setError(err instanceof Error ? err.message : 'Failed to fetch integrations');
-        setIntegrations([]);
+        console.error('Error loading integrations data from endpoint. Falling back to static JSON file.');
+
+        // Fallback to static JSON file
+        try {
+          const fallbackResponse = await fetch('/integrations-fallback.json');
+
+          if (!fallbackResponse.ok) {
+            throw new Error(`Failed to load fallback data: ${fallbackResponse.status}`);
+          }
+
+          const fallbackData = await fallbackResponse.json();
+          const transformedData = transformCMSData(fallbackData.data || []);
+          setIntegrations(transformedData);
+          setError(null);
+        } catch (fallbackErr) {
+          console.error('Failed to load fallback integrations data:', fallbackErr);
+          setError(fallbackErr instanceof Error ? fallbackErr.message : 'Failed to fetch integrations');
+          setIntegrations([]);
+        }
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Changes introduced in https://github.com/ClickHouse/clickhouse-docs/pull/4477. Reverted as some links needed to be fixed in the CMS first. Also added a fallback mechanism so that if the CMS endpoint is inaccessible it will fall back to a static version kept in the docs repo.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
