### PR TITLE
Add redirect for /docs/cloud/security/inviting-new-users

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3592,6 +3592,11 @@
       "source": "/docs/about-clickhouse",
       "destination": "/docs/intro",
       "permanent": true
+    },
+    {
+      "source": "/docs/cloud/security/inviting-new-users",
+      "destination": "/docs/cloud/security/manage-cloud-users#invite-users",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
