### PR TITLE
Style: fix links appearing white in caution block

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1161,6 +1161,10 @@ button.DocSearch {
     color: black !important;
 }
 
+[data-theme='dark'] .alert a {
+    color: black !important;
+}
+
 .theme-admonition-tip {
   &.alert--warning {
     .alert-icon {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fix:

<img width="720" height="338" alt="image" src="https://github.com/user-attachments/assets/fb48c4da-5f2c-403c-ab26-181fc8f4dfdc" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
