### PR TITLE
Integrations landing page: fix url for static fallback file

### DIFF
--- a/src/components/IntegrationGrid/IntegrationGrid.tsx
+++ b/src/components/IntegrationGrid/IntegrationGrid.tsx
@@ -159,12 +159,13 @@ function useCMSIntegrations() {
   const [integrations, setIntegrations] = useState<IntegrationData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const fallbackPath = useBaseUrl('/integrations-fallback.json');
 
   useEffect(() => {
     const fetchIntegrations = async () => {
       // Step 1: Load fallback data first for immediate display
       try {
-        const fallbackResponse = await fetch('/integrations-fallback.json', {
+        const fallbackResponse = await fetch(fallbackPath, {
           cache: 'force-cache' // Use cached version if available
         });
 
@@ -235,7 +236,7 @@ function useCMSIntegrations() {
     };
 
     fetchIntegrations();
-  }, []);
+  }, [fallbackPath]);
 
   return { integrations, loading, error };
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes another issue where the fallback file is not working
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
