### PR TITLE
Styling: fix link color on admonition blocks

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1161,7 +1161,7 @@ button.DocSearch {
     color: black !important;
 }
 
-[data-theme='dark'] .alert a {
+[data-theme='dark'] .theme-admonition-warning .alert a {
     color: black !important;
 }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Fixes:

<img width="595" height="159" alt="Screenshot 2025-10-23 at 13 29 15" src="https://github.com/user-attachments/assets/afc87a05-eb2b-482d-86b7-2868c59a135a" />

E.g. https://clickhouse.com/docs/operations/system-tables/iceberg_metadata_log
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
