### PR TITLE
Navigation: update top level menu to match marketing website

### DIFF
--- a/src/components/Navigation/sub-navs/NavigationSubNavResources.js
+++ b/src/components/Navigation/sub-navs/NavigationSubNavResources.js
@@ -55,7 +55,7 @@ export default function NavigationSubNavResources() {
               onClick={galaxyOnClick('topNav.resourcesMenu.learnSelect')}>
               {translate({
                   id: 'topNav.navItems.resources.Learn',
-                  message: 'Learning and Certification',
+                  message: 'Learning and certification',
               })}
           </NavigationLink>
       </li>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
<img width="298" height="358" alt="Screenshot 2025-10-24 at 18 13 26" src="https://github.com/user-attachments/assets/1cdc08fe-aa00-4325-8bd8-0ddcc1952e85" />

Should be:
<img width="302" height="425" alt="Screenshot 2025-10-24 at 18 13 10" src="https://github.com/user-attachments/assets/387c132d-d00b-4734-8748-845c6cf8e21f" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
