### PR TITLE
Improvement: fix double header

### DIFF
--- a/docs/integrations/data-sources/iceberg.md
+++ b/docs/integrations/data-sources/iceberg.md
@@ -8,8 +8,6 @@ doc_type: 'guide'
 
 import IcebergFunction from '@site/docs/sql-reference/table-functions/iceberg.md';
 
-# Iceberg integration
-
-Users can integrate with the Iceberg table format via the table function. 
+> Users can integrate with the Iceberg table format via the table function.
 
 <IcebergFunction/>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The double header here looks weird:
<img width="940" height="517" alt="Screenshot 2025-10-24 at 23 34 46" src="https://github.com/user-attachments/assets/e38a663b-f4ae-42e9-bb0d-76bfaff3e3f4" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
