### PR TITLE
Integrations: remove double header

### DIFF
--- a/docs/integrations/data-sources/deltalake.md
+++ b/docs/integrations/data-sources/deltalake.md
@@ -8,8 +8,6 @@ doc_type: 'reference'
 
 import DeltaLakeFunction from '@site/docs/sql-reference/table-functions/deltalake.md';
 
-# Delta Lake integration
-
-Users can integrate with the Delta lake table format via the table function. 
+> Users can integrate with the Delta lake table format via the table function. 
 
 <DeltaLakeFunction/>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes the double header which looks weird
<img width="926" height="270" alt="Screenshot 2025-10-24 at 23 36 44" src="https://github.com/user-attachments/assets/e52b967e-f10c-4ba2-9cf9-f9f5626c0639" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
