### PR TITLE
Redirects: add redirect from time-series-analysis to time-series functions page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3597,6 +3597,11 @@
       "source": "/docs/cloud/security/inviting-new-users",
       "destination": "/docs/cloud/security/manage-cloud-users#invite-users",
       "permanent": true
+    },
+    {
+      "source": "/docs/sql-reference/functions/time-series-analysis-functions",
+      "destination": "/docs/sql-reference/functions/time-series-functions",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
We merged time-series analysis functions into the time-series page. Adding redirect for the now removed time-series-analysis page.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
