### PR TITLE
Styling: fix video width issue

### DIFF
--- a/docs/integrations/data-ingestion/data-formats/json/intro.md
+++ b/docs/integrations/data-ingestion/data-formats/json/intro.md
@@ -11,17 +11,13 @@ doc_type: 'guide'
 
 # JSON Overview
 
-<div style={{width:'1024px', height: '576px'}}>
-  <iframe src="//www.youtube.com/embed/gCg5ISOujtc"
-    width="1024"
-    height="576"
-    frameborder="0"
-    allow="autoplay;
-    fullscreen;
-    picture-in-picture"
-    allowfullscreen>
-  </iframe>
-</div>
+<iframe src="//www.youtube.com/embed/gCg5ISOujtc"
+frameborder="0"
+allow="autoplay;
+fullscreen;
+picture-in-picture"
+allowfullscreen>
+</iframe>
 
 <br/>
 ClickHouse provides several approaches for handling JSON, each with its respective pros and cons and usage. In this guide, we will cover how to load JSON and design your schema optimally. This guide consists of the following sections:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes:
<img width="511" height="684" alt="Screenshot 2025-10-25 at 15 19 22" src="https://github.com/user-attachments/assets/8b69b7a1-b1a5-46f6-8a63-ef8f8f79e8e4" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
