### PR TITLE
House keeping: remove double header from Redis page

### DIFF
--- a/docs/integrations/data-sources/redis.md
+++ b/docs/integrations/data-sources/redis.md
@@ -4,7 +4,7 @@ sidebar_label: 'Redis'
 title: 'Redis'
 description: 'Page describing the Redis table function'
 doc_type: 'reference'
-hide_title: false
+hide_title: true
 keywords: ['redis', 'cache', 'integration', 'data source', 'key-value store']
 ---
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
<img width="521" height="217" alt="Screenshot 2025-10-28 at 09 57 11" src="https://github.com/user-attachments/assets/c5242d4a-f013-4c6e-b0d7-699cf938abc5" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
