### PR TITLE
BYOC: remove `,` which makes policy invalid

### DIFF
--- a/docs/cloud/features/08_backups/backups-to-own-cloud/backup_restore_from_ui.md
+++ b/docs/cloud/features/08_backups/backups-to-own-cloud/backup_restore_from_ui.md
@@ -62,7 +62,7 @@ AWS uses role based authentication, so create an IAM role that the ClickHouse Cl
         "AWS":  "arn:aws:iam::463754717262:role/CH-S3-bordeaux-ar-90-ue2-29-Role"
       },
       "Action": "sts:AssumeRole"
-    },
+    }
   ]
 }
 ```


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The additional `,` gives an error when trying to define the policy in AWS
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
