### PR TITLE
Cleanup kinesis iam role for clickpipes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
+++ b/docs/integrations/data-ingestion/clickpipes/secure-kinesis.md
@@ -116,4 +116,3 @@ Using this approach, customers can manage all access to their Kinesis data strea
    ```
 
 - 4. Copy the new **IAM Role Arn** after creation. This is what is needed to access your Kinesis stream.
-</VerticalStepper>


### PR DESCRIPTION
## Summary
This fixes a few issues with the kinesis secure iam role documentation including separating the trust policy and the role policy, adds brackets around variables, and moves permissions to the correct path.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
