### PR TITLE
Redirects: fixing redirect for /docs/cloud/security/secure-s3

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3528,7 +3528,7 @@
     },
     {
       "source": "/docs/cloud/security/secure-s3",
-      "destination": "/cloud/data-sources/secure-s3",
+      "destination": "/docs/cloud/data-sources/secure-s3",
       "permanent": true
     },
     {
@@ -3562,8 +3562,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/cloud/security/secure-s3",
-      "destination": "/docs/cloud/data-sources/secure-s3",
       "source": "/docs/operations/system-tables/crash-log",
       "destination": "/docs/operations/system-tables/crash_log",
       "permanent": true


### PR DESCRIPTION
## Summary
Fixing a broken redirect to /docs/cloud/security/secure-s3

https://clickhouse.com/docs/cloud/security/secure-s3 actually is redirected to https://clickhouse.com/cloud/data-sources/secure-s3 which is not a valid page.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
