### PR TITLE
Add Sqitch to ClickHouse schema migration tools documentation

### DIFF
--- a/knowledgebase/schema_migration_tools.mdx
+++ b/knowledgebase/schema_migration_tools.mdx
@@ -16,6 +16,7 @@ We often get asked about a good schema migration tool for ClickHouse and what is
 There is no standard schema migration tool for ClickHouse, but we have compiled the following list (in no particular order) of automatic schema migration tools with support for ClickHouse that we know:
 
 - [Goose](https://github.com/pressly/goose)
+- [Sqitch](https://sqitch.org/docs/manual/sqitchtutorial-clickhouse/)
 - [Atlas](https://atlasgo.io/guides/clickhouse?utm_source=clickhouse&utm_term=knowledge)
 - [Bytebase](https://www.bytebase.com/)
 - [Flyway](https://documentation.red-gate.com/fd/supported-databases-and-versions-143754067.html)


### PR DESCRIPTION
## Summary
Adds Sqitch to the [Automatic schema migration tools for ClickHouse](https://clickhouse.com/docs/knowledgebase/schema_migration_tools) documentation.
Sqitch recently introduced native support for the ClickHouse database, and this update includes it as one of the recommended schema migration tools.

Issue: https://github.com/ClickHouse/clickhouse-docs/issues/4687

## Checklist
- [x] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
