### PR TITLE
addressing documentation gap with minimum permissions

### DIFF
--- a/docs/cloud/features/05_admin_features/api/openapi.md
+++ b/docs/cloud/features/05_admin_features/api/openapi.md
@@ -36,6 +36,10 @@ This document covers the ClickHouse Cloud API. For database API endpoints, pleas
 Permissions align with ClickHouse Cloud [predefined roles](/cloud/security/console-roles). The developer role has read-only permissions for assigned services and the admin role has full read and write permissions.
 :::
 
+:::tip Query API Endpoints
+To use API keys with [Query API Endpoints](/cloud/get-started/query-endpoints), set Organization Role to `Member` (minimum) and grant Service Role access to `Query Endpoints`.
+:::
+
   <Image img={image_03} size="md" alt="Create API key form" border/>
 
 4. The next screen will display your Key ID and Key secret. Copy these values and put them somewhere safe, such as a vault. The values will not be displayed after you leave this screen.

--- a/docs/cloud/guides/SQL_console/query-endpoints.md
+++ b/docs/cloud/guides/SQL_console/query-endpoints.md
@@ -24,10 +24,14 @@ The **Query API Endpoints** feature allows you to create an API endpoint directl
 ## Pre-requisites {#quick-start-guide}
 
 Before proceeding, ensure you have:
-- an API key
-- an Admin Console Role.
+- An API key with appropriate permissions
+- An Admin Console Role
 
 You can follow this guide to [create an API key](/cloud/manage/openapi) if you don't yet have one.
+
+:::note Minimum permissions
+To query an API endpoint, the API key needs `Member` organization role with `Query Endpoints` service access. The database role is configured when you create the endpoint.
+:::
 
 <VerticalStepper headerLevel="h3">
 


### PR DESCRIPTION
## Summary
Slack user feedback. Missing minimum permissions required for cloud api testing.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
