### PR TITLE
Improvement: add note about quick start script origins

### DIFF
--- a/docs/getting-started/quick-start/oss.mdx
+++ b/docs/getting-started/quick-start/oss.mdx
@@ -35,8 +35,8 @@ We recommend running the command below from a new and empty subdirectory as
 some configuration files will be created in the directory the binary is located
 in the first time ClickHouse server is run.
 
-If you are looking to install a production instance of ClickHouse, please see the [install page](/install).
 The script below is not the recommended way to install ClickHouse for production.
+If you are looking to install a production instance of ClickHouse, please see the [install page](/install).
 :::
 
 ```bash


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds a note to make clear that the quick start script is built from master.
Adds a note about visiting the install page if running a production instance.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
