### PR TITLE
Adjusted timezone messaging

### DIFF
--- a/docs/use-cases/observability/clickstack/integration-examples/kafka-metrics.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/kafka-metrics.md
@@ -256,8 +256,8 @@ Once loaded, the quickest way to see your metrics is through the pre-built dashb
 
 Proceed to the [Dashboards and visualization](#dashboards) section to import the dashboard and view all Kafka metrics at once.
 
-:::note
-The demo dataset time range is 2025-11-05 16:00:00 to 2025-11-06 16:00:00. Make sure your time range in HyperDX matches this window.
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans **2025-11-05 16:00:00 - 2025-11-06 16:00:00 (UTC)**. Set your time range to **2025-11-04 16:00:00 - 2025-11-07 16:00:00** to ensure you see the demo metrics regardless of your location. Once you see the metrics, you can narrow the range to a 24-hour period for clearer visualizations.
 :::
 
 </VerticalStepper>
@@ -288,7 +288,7 @@ The dashboard will be created with all visualizations pre-configured:
 <Image img={example_dashboard} alt="Kafka Metrics dashboard"/>
 
 :::note
-For the demo dataset, ensure the time range is set to 2025-11-05 16:00:00 to 2025-11-06 16:00:00.
+For the demo dataset, set the time range to **2025-11-05 16:00:00 - 2025-11-06 16:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 </VerticalStepper>

--- a/docs/use-cases/observability/clickstack/integration-examples/nginx-logs.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/nginx-logs.md
@@ -250,14 +250,16 @@ docker run --name clickstack-demo \
 
 #### Verify logs in HyperDX {#verify-demo-logs}
 
-Once ClickStack is running (you may have to create an account and login first):
+Once ClickStack is running:
 
-1. Open [HyperDX with demo time range](http://localhost:8080/search?from=1760976000000&to=1761062400000&isLive=false&source=690235c1a9b7fc5a7c0fffc7&select=Timestamp,ServiceName,SeverityText,Body&where=&whereLanguage=lucene&filters=[]&orderBy=)
+1. Open [HyperDX](http://localhost:8080/) and log in to your account (you may need to create an account first)
+2. Navigate to the Search view and set the source to `Logs`
+3. Set the time range to **2025-10-19 11:00:00 - 2025-10-22 11:00:00**
 
 Here's what you should see in your search view:
 
-:::note
-If you don't see logs, ensure the time range is set to 2025-10-20 11:00:00 - 2025-10-21 11:00:00 and 'Logs' is selected as the source. Using the link is important to get the proper time range of results.
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans 2025-10-20 11:00:00 - 2025-10-21 11:00:00 UTC. The wide time range ensures you'll see the demo logs regardless of your location. Once you see the logs, you can narrow the range to a 24-hour period for clearer visualizations.
 :::
 
 <Image img={search_view} alt="Log view"/>
@@ -287,7 +289,7 @@ To help you get started monitoring nginx with ClickStack, we provide essential v
 #### The dashboard will be created with all visualizations pre-configured {#created-dashboard}
 
 :::note
-Ensure the time range is set to 2025-10-20 11:00:00 - 2025-10-21 11:00:00. The imported dashboard will not have a time range specified by default.
+For the demo dataset, set the time range to **2025-10-20 11:00:00 - 2025-10-21 11:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 <Image img={example_dashboard} alt="Example Dashboard"/>

--- a/docs/use-cases/observability/clickstack/integration-examples/nginx-traces.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/nginx-traces.md
@@ -238,12 +238,14 @@ You should see a response like `{"partialSuccess":{}}` indicating the traces wer
 
 #### Verify traces in HyperDX {#verify-demo-traces}
 
-1. Open [HyperDX with demo time range](http://localhost:8080/search?from=1761501600000&to=1761588000000&isLive=false&source=69023d1b4f1d41a964641b09&where=&select=Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName&whereLanguage=lucene&orderBy=&filters=[])
+1. Open [HyperDX](http://localhost:8080/) and log in to your account (you may need to create an account first)
+2. Navigate to the Search view and set the source to `Traces`
+3. Set the time range to **2025-10-25 13:00:00 - 2025-10-28 13:00:00**
 
 Here's what you should see in your search view:
 
-:::note
-If you don't see logs, ensure the time range is set to 2025-10-26 13:00:00 - 2025-10-27 13:00:00 and 'Logs' is selected as the source. Using the link is important to get the proper time range of results.
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans **2025-10-26 13:00:00 - 2025-10-27 13:00:00 (UTC)**. The wide time range ensures you'll see the demo traces regardless of your location. Once you see the traces, you can narrow the range to a 24-hour period for clearer visualizations.
 :::
 
 <Image img={view_traces} alt="View Traces"/>
@@ -271,7 +273,7 @@ To help you get started monitoring traces with ClickStack, we provide essential 
 #### The dashboard will be created with all visualizations pre-configured. {#created-dashboard}
 
 :::note
-Ensure the time range is set to 2025-10-26 13:00:00 - 2025-10-27 13:00:00. The imported dashboard will not have a time range specified by default.
+For the demo dataset, set the time range to **2025-10-26 13:00:00 - 2025-10-27 13:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 <Image img={example_dashboard} alt="Example Dashboard"/>

--- a/docs/use-cases/observability/clickstack/integration-examples/postgres-logs.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/postgres-logs.md
@@ -292,7 +292,11 @@ Once ClickStack is running:
 
 1. Open [HyperDX](http://localhost:8080/) and log in to your account (you may need to create an account first)
 2. Navigate to the Search view and set the source to `Logs`
-3. Set the time range to **2025-11-10 00:00:00 - 2025-11-11 00:00:00**
+3. Set the time range to **2025-11-09 00:00:00 - 2025-11-12 00:00:00**
+
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans **2025-11-10 00:00:00 - 2025-11-11 00:00:00 (UTC)**. The wide time range ensures you'll see the demo logs regardless of your location. Once you see the logs, you can narrow the range to a 24-hour period for clearer visualizations.
+:::
 
 <Image img={logs_search_view} alt="Logs search view"/>
 
@@ -326,7 +330,7 @@ The dashboard will be created with all visualizations pre-configured:
 <Image img={logs_dashboard} alt="Logs dashboard"/>
 
 :::note
-For the demo dataset, ensure the time range is set to 2025-11-10 00:00:00 - 2025-11-11 00:00:00. The imported dashboard will not have a time range specified by default.
+For the demo dataset, set the time range to **2025-11-10 00:00:00 - 2025-11-11 00:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 </VerticalStepper>

--- a/docs/use-cases/observability/clickstack/integration-examples/postgres-metrics.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/postgres-metrics.md
@@ -186,8 +186,8 @@ Once loaded, the quickest way to see your metrics is through the pre-built dashb
 
 Proceed to the [Dashboards and visualization](#dashboards) section to import the dashboard and view many PostgreSQL metrics at once.
 
-:::note
-The demo dataset time range is November 10, 2025 00:00:00 to November 11, 2025 00:00:00. Make sure your time range in HyperDX matches this window.
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans **2025-11-10 00:00:00 - 2025-11-11 00:00:00 (UTC)**. Set your time range to **2025-11-09 00:00:00 - 2025-11-12 00:00:00** to ensure you see the demo metrics regardless of your location. Once you see the metrics, you can narrow the range to a 24-hour period for clearer visualizations.
 :::
 
 </VerticalStepper>
@@ -218,7 +218,7 @@ The dashboard will be created with all visualizations pre-configured:
 <Image img={example_dashboard} alt="PostgreSQL metrics dashboard"/>
 
 :::note
-For the demo dataset, ensure the time range is set to November 10, 2025 00:00:00 - November 11, 2025 00:00:00.
+For the demo dataset, set the time range to **2025-11-10 00:00:00 - 2025-11-11 00:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 </VerticalStepper>

--- a/docs/use-cases/observability/clickstack/integration-examples/redis-logs.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/redis-logs.md
@@ -257,11 +257,12 @@ docker run --name clickstack-demo \
 
 Once ClickStack is running:
 
-1. Open [HyperDX](http://localhost:8080/) and log in to your account, you may need to create an account first.
-2. Once logged in, open this [link](http://localhost:8080/search?from=1761577200000&to=1761663600000&isLive=false&source=690280cfd3754c36b73402cc&where=&select=Timestamp,ServiceName,SeverityText,Body&whereLanguage=lucene&orderBy=&filters=[]). You should see what's pictured in the screenshots below.
+1. Open [HyperDX](http://localhost:8080/) and log in to your account (you may need to create an account first)
+2. Navigate to the Search view and set the source to `Logs`
+3. Set the time range to **2025-10-26 10:00:00 - 2025-10-29 10:00:00**
 
-:::note
-If you don't see logs, ensure the time range is set to 2025-10-27 10:00:00 - 2025-10-28 10:00:00 and 'Logs' is selected as the source. Using the link is important to get the proper time range of results.
+:::note[Timezone Display]
+HyperDX displays timestamps in your browser's local timezone. The demo data spans **2025-10-27 10:00:00 - 2025-10-28 10:00:00 (UTC)**. The wide time range ensures you'll see the demo logs regardless of your location. Once you see the logs, you can narrow the range to a 24-hour period for clearer visualizations.
 :::
 
 <Image img={log_view} alt="Log view"/>
@@ -292,7 +293,7 @@ To help you get started monitoring Redis with ClickStack, we provide essential v
 #### The dashboard will be created with all visualizations pre-configured {#created-dashboard}
 
 :::note
-Ensure the time range is set to 2025-10-27 10:00:00 - 2025-10-28 10:00:00. The imported dashboard will not have a time range specified by default.
+For the demo dataset, set the time range to **2025-10-27 10:00:00 - 2025-10-28 10:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 <Image img={example_dashboard} alt="Example Dashboard"/>

--- a/docs/use-cases/observability/clickstack/integration-examples/redis-metrics.md
+++ b/docs/use-cases/observability/clickstack/integration-examples/redis-metrics.md
@@ -310,7 +310,7 @@ The dashboard will be created with all visualizations pre-configured:
 <Image img={example_dashboard} alt="Redis Metrics dashboard"/>
 
 :::note
-For the demo dataset, ensure the time range is set to 2025-10-20 05:00:00 - 2025-10-21 05:00:00.
+For the demo dataset, set the time range to **2025-10-20 05:00:00 - 2025-10-21 05:00:00 (UTC)** (adjust based on your local timezone). The imported dashboard will not have a time range specified by default.
 :::
 
 </VerticalStepper>


### PR DESCRIPTION
## Summary
HyperDX displays time ranges in local timezone, need to add messaging that the static demo data is in UTC, but the user needs to adjust based on their local timezone for visualizations.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
