### PR TITLE
Making codeblock titles smaller and lighter

### DIFF
--- a/src/components/CodeViewer/index.tsx
+++ b/src/components/CodeViewer/index.tsx
@@ -100,7 +100,7 @@ function CodeViewer({
   }
 
   const header = title ? (
-    <Text className='pl-[16px] pt-[14px]' size='md'>{title}</Text>
+    <Text className='pl-[16px] pt-[14px]' size='sm' style={{ opacity: 0.6 }}>{title}</Text>
   ) : null
 
   // Always show as editable Monaco editor when editable=true


### PR DESCRIPTION
## Summary
Making codeblock titles smaller and lighter to more easily differentiate between actual code and the title metadata

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
