### PR TITLE
Add logging docs for C# client

### DIFF
--- a/docs/integrations/language-clients/csharp.md
+++ b/docs/integrations/language-clients/csharp.md
@@ -410,7 +410,7 @@ INSERT INTO table VALUES ({val1:Int32}, {val2:Array(UInt8)})
 
 ---
 
-## Logging {#logging}
+## Logging and diagnostics {#logging-and-diagnostics}
 
 The ClickHouse .NET client integrates with the `Microsoft.Extensions.Logging` abstractions to offer lightweight, opt-in logging. When enabled, the driver emits structured messages for connection lifecycle events, command execution, transport operations, and bulk copy uploads. Logging is entirely optional—applications that do not configure a logger continue to run without additional overhead.
 


### PR DESCRIPTION
## Summary
Adds info on logging and tracing for the C# client library.

Also removing the section on env vars as they are no longer supported.