### PR TITLE
adding not production ready to beta feature warning

### DIFF
--- a/docs/use-cases/observability/clickstack/deployment/_snippets/_json_support.md
+++ b/docs/use-cases/observability/clickstack/deployment/_snippets/_json_support.md
@@ -4,7 +4,7 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 <BetaBadge/>
 
-:::warning Beta Feature
+:::warning Beta Feature - not production ready
 JSON type support in **ClickStack** is a **beta feature**. While the JSON type itself is production-ready in ClickHouse 25.3+, its integration within ClickStack is still under active development and may have limitations, change in the future, or contain bugs.
 :::
 


### PR DESCRIPTION
## Summary
Adding "not production ready" to add clarity.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
