### PR TITLE
Fix `hyperdx_ingest` user grants when creating an ingestion user

### DIFF
--- a/docs/use-cases/observability/clickstack/ingesting-data/collector.md
+++ b/docs/use-cases/observability/clickstack/ingesting-data/collector.md
@@ -216,7 +216,7 @@ We recommend creating a dedicated database and user for the OTel collector for i
 ```sql
 CREATE DATABASE otel;
 CREATE USER hyperdx_ingest IDENTIFIED WITH sha256_password BY 'ClickH0u3eRocks123!';
-GRANT SELECT, INSERT, CREATE TABLE, CREATE VIEW ON otel.* TO hyperdx_ingest;
+GRANT SELECT, INSERT, CREATE DATABASE, CREATE TABLE, CREATE VIEW ON otel.* TO hyperdx_ingest;
 ```
 
 This assumes the collector has been configured to use the database `otel`. This can be controlled through the environment variable `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`. Pass this to the image hosting the collector [similar to other environment variables](#modifying-otel-collector-configuration).


### PR DESCRIPTION
## Summary
ClickHouse ingestion user needs `CREATE DATABASE` permissions, because on startup collector tries to execute `CREATE DATABASE IF NOT EXISTS`. Not having `CREATE DATABASE` permissions will cause the collector to fail on startup.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
