### PR TITLE
fix(too_many_parts): updating error code for too many parts from 600 to 252

### DIFF
--- a/knowledgebase/exception-too-many-parts.mdx
+++ b/knowledgebase/exception-too-many-parts.mdx
@@ -9,7 +9,7 @@ keywords: ['Too many parts']
 {frontMatter.description}
 {/* truncate */}
 
-## DB::Exception: Too many parts (600). Merges are processing significantly slower than inserts {#dbexception-too-many-parts-600-merges-are-processing-significantly-slower-than-inserts}
+## DB::Exception: Too many parts (Error: 252). Merges are processing significantly slower than inserts {#dbexception-too-many-parts-252-merges-are-processing-significantly-slower-than-inserts}
 
 You reached the `parts_to_throw_insert` setting on a MergeTree table.
 


### PR DESCRIPTION
## Summary
We have error code 600 for `too_many_parts` when it looks like it should be `252`
- [source](https://github.com/ClickHouse/clickhouse-private/blob/a5c7e0b9165186a32443308bbb7e2750478250b3/src/Common/ErrorCodes.cpp#L216)
- [doc](https://clickhouse.com/docs/knowledgebase/exception-too-many-parts)
- [discussion](https://clickhouse-inc.slack.com/archives/C0751CX2X99/p1763649705569099?thread_ts=1763627567.235259&cid=C0751CX2X99)


## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
