### PR TITLE
Enhance S3 permissions validation and checks

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_notes/25_08.md
+++ b/docs/cloud/reference/01_changelog/02_release_notes/25_08.md
@@ -47,7 +47,7 @@ doc_type: 'changelog'
 ### Security and permissions {#security-and-permissions}
 
 * `SYSTEM RESTART REPLICAS` will only restart replicas in the databases where you have permission to `SHOW TABLES`. Previously the query led to the wakeup of tables in the Lazy database, even without access to that database, while these tables were being concurrently dropped. [#83321](https://github.com/ClickHouse/ClickHouse/pull/83321) ([Alexey Milovidov](https://github.com/alexey-milovidov)).
-* Functions `azureBlobStorage`, `deltaLakeAzure`, and `icebergAzure` have been updated to properly validate `AZURE` permissions. All cluster-variant functions (`-Cluster` functions) now verify permissions against their corresponding non-clustered counterparts. Additionally, the `icebergLocal` and `deltaLakeLocal` functions now enforce `FILE` permission checks. [#84938](https://github.com/ClickHouse/ClickHouse/pull/84938) ([Nikita Mikhaylov](https://github.com/nikitamikhaylov
+* Functions `azureBlobStorage`, `deltaLakeAzure`, and `icebergAzure` have been updated to properly validate `AZURE` permissions. All cluster-variant functions (`-Cluster` functions) now verify permissions against their corresponding non-clustered counterparts. To prevent permission errors, make sure users invoking the `-Cluster` functions have the appropriate privileges (e.g., `GRANT S3 ON *.* TO user`). Additionally, the `icebergLocal` and `deltaLakeLocal` functions now enforce `FILE` permission checks. [#84938](https://github.com/ClickHouse/ClickHouse/pull/84938) ([Nikita Mikhaylov](https://github.com/nikitamikhaylov
 
 ## New features {#new-feature}
 


### PR DESCRIPTION
Added instructions to avoid s3 permission errors due to  backward incompatible changes

- [v25.8 Changelog](https://clickhouse.com/docs/changelogs/25.8#security-and-permissions)
- [Discussion](https://clickhouse-inc.slack.com/archives/C097SHZM99Q/p1763738043606549?thread_ts=1761921466.303009&cid=C097SHZM99Q)

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
