### PR TITLE
Clean up: remove links to clickhouse.com in favour of relative links

### DIFF
--- a/docs/managing-data/core-concepts/primary-indexes.mdx
+++ b/docs/managing-data/core-concepts/primary-indexes.mdx
@@ -22,13 +22,13 @@ For advanced indexing strategies and deeper technical detail, see the [primary i
 
 <br/>
 
-The sparse primary index in ClickHouse helps efficiently identify [granules](https://clickhouse.com/docs/guides/best-practices/sparse-primary-indexes#data-is-organized-into-granules-for-parallel-data-processing)—blocks of rows—that might contain data matching a query's condition on the table's ^^primary key^^ columns. In the next section, we explain how this index is constructed from the values in those columns.
+The sparse primary index in ClickHouse helps efficiently identify [granules](/guides/best-practices/sparse-primary-indexes#data-is-organized-into-granules-for-parallel-data-processing)—blocks of rows—that might contain data matching a query's condition on the table's ^^primary key^^ columns. In the next section, we explain how this index is constructed from the values in those columns.
 
 ### Sparse primary index creation \{#sparse-primary-index-creation\}
 
-To illustrate how the sparse primary index is built, we use the [uk_price_paid_simple](https://clickhouse.com/docs/parts) table along with some animations.
+To illustrate how the sparse primary index is built, we use the [uk_price_paid_simple](/parts) table along with some animations.
 
-As a [reminder](https://clickhouse.com/docs/parts), in our ① example table with the ^^primary key^^ (town, street), ② inserted data is ③ stored on disk, sorted by the ^^primary key^^ column values, and compressed, in separate files for each column:
+As a [reminder](/parts), in our ① example table with the ^^primary key^^ (town, street), ② inserted data is ③ stored on disk, sorted by the ^^primary key^^ column values, and compressed, in separate files for each column:
 
 <Image img={visual01} size="lg"/>
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
These links shouldn't be to `www.clickhouse.com`, just relative.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
