### PR TITLE
Bug fix: mobile menu crashing

### DIFF
--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -84,7 +84,7 @@ export default function NavbarContent() {
               <button className="click-button primary-btn">Get started</button>
             </a>
           </div>
-          <MobileSideBarMenu sidebar={items} menu={{ ...sidebars, dropdownCategories }} />
+          <MobileSideBarMenu sidebar={items} menu={{ dropdownCategories }} />
         </div>
       </div>
       <div className={clsx("secondary-nav--items", styles.secondaryMenu)}>

--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    useNavbarMobileSidebar,
+  useNavbarMobileSidebar,
 } from '@docusaurus/theme-common/internal';
 import Translate from '@docusaurus/Translate';
 import SearchBar from "@theme/SearchBar";
@@ -9,18 +9,18 @@ import { ThemeClassNames } from '@docusaurus/theme-common'
 import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
 import styles from './styles.module.scss'
 import DocSidebarItems from '@theme/DocSidebarItems'
-import sidebars from '../../../../../sidebars';
+import { dropdownCategories } from '../../../Navbar/Content/MenuData';
 
 function SecondaryMenuBackButton(props) {
-    return (
-        <button {...props} type="button" className="clean-btn navbar-sidebar__back">
-            <Translate
-                id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
-                description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
-                ← Back to main menu
-            </Translate>
-        </button>
-    );
+  return (
+    <button {...props} type="button" className="clean-btn navbar-sidebar__back">
+      <Translate
+        id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
+        description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
+        ← Back to main menu
+      </Translate>
+    </button>
+  );
 }
 
 // The secondary menu slides from the right and shows the top nav items. This is a little unusual - we use this to show the drop down items
@@ -37,16 +37,16 @@ export default function NavbarMobileSidebarSecondaryMenu() {
         </div>
       </div>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list', styles.docsMobileMenuItems)}>
-        <DocSidebarItems items={sidebars.dropdownCategories.map(item => ({
+        <DocSidebarItems items={dropdownCategories.map(item => ({
           ...item,
-          label: (
+          label: React.isValidElement(item.label) ? item.label : (
             <Translate id={`sidebar.dropdownCategories.category.${item.label}`}>
               {item.label}
             </Translate>
           ),
           items: item.items?.map(subItem => ({
             ...subItem,
-            label: (
+            label: React.isValidElement(subItem.label) ? subItem.label : (
               <Translate id={`sidebar.dropdownCategories.category.${item.label}.${subItem.label}`}>
                 {subItem.label}
               </Translate>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes a bug where the mobile menu is crashing following refactor for i18n setup: 
<img width="331" height="719" alt="image" src="https://github.com/user-attachments/assets/a17cfc0d-bdb0-47ed-824b-f94366de8ec0" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
