### PR TITLE
Bug fix: menu styling for firefox

### DIFF
--- a/src/components/DocsCategoryDropdown/styles.module.css
+++ b/src/components/DocsCategoryDropdown/styles.module.css
@@ -6,7 +6,8 @@
   display: inline-block;
   color: var(--ch-nav-v2-link-color);
   width: fit-content;
-  padding: 8px; /* Keep original padding for non-dropdown items */
+  padding: 8px;
+  /* Keep original padding for non-dropdown items */
 }
 
 /* Only remove padding for dropdown containers */
@@ -38,11 +39,6 @@
   color: black;
   /* Ensure the span covers the full width including caret */
   width: 100%;
-  /* Handle long translations */
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 200px;
 }
 
 .docsNavDropdownToolbarLink:hover {
@@ -65,9 +61,11 @@
   content: "";
   position: absolute;
   left: 0;
-  bottom: -20px; /* Increased to bridge the gap better */
+  bottom: -20px;
+  /* Increased to bridge the gap better */
   width: 100%;
-  height: 20px; /* Increased to cover more area */
+  height: 20px;
+  /* Increased to cover more area */
   pointer-events: auto;
 }
 
@@ -88,15 +86,18 @@
   cursor: pointer;
 }
 
-.docsNavDropdownToolbarLink:hover, .docsNavDropdownToolbarTopLevelLink:hover {
+.docsNavDropdownToolbarLink:hover,
+.docsNavDropdownToolbarTopLevelLink:hover {
   color: black;
 }
 
-[data-theme="dark"] .docsNavDropdownToolbarLink, [data-theme="dark"] .docsNavDropdownToolbarTopLevelLink {
+[data-theme="dark"] .docsNavDropdownToolbarLink,
+[data-theme="dark"] .docsNavDropdownToolbarTopLevelLink {
   color: #C0C0C0;
 }
 
-[data-theme="dark"] .docsNavDropdownToolbarLink:hover, [data-theme="dark"] .docsNavDropdownToolbarTopLevelLink:hover {
+[data-theme="dark"] .docsNavDropdownToolbarLink:hover,
+[data-theme="dark"] .docsNavDropdownToolbarTopLevelLink:hover {
   color: #FAFF69;
 }
 
@@ -118,7 +119,8 @@
 
 .docsNavDropdownMenu {
   position: absolute;
-  top: calc(100% + 4px); /* Reduced from + 8px to + 4px */
+  top: calc(100% + 4px);
+  /* Reduced from + 8px to + 4px */
   left: 0;
   z-index: 9999 !important;
   min-width: 320px;


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fix menu styling for firefox
<img width="720" height="378" alt="image" src="https://github.com/user-attachments/assets/1c65fdae-c950-4175-af58-9b114b250872" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
