### PR TITLE
Translations: enable multilingual search

### DIFF
--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -210,7 +210,7 @@ const config = {
       algolia: {
         appId: "5H9UG7CX5W",
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
-        indexName: "clickhouse",
+        indexName: "clickhouse-jp",
         contextualSearch: false,
         searchPagePath: "search",
       },

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -211,7 +211,7 @@ const config = {
       algolia: {
         appId: "5H9UG7CX5W",
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
-        indexName: "clickhouse",
+        indexName: "clickhouse-ru",
         contextualSearch: false,
         searchPagePath: "search",
       },

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -210,7 +210,7 @@ const config = {
       algolia: {
         appId: "5H9UG7CX5W",
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
-        indexName: "clickhouse",
+        indexName: "clickhouse-zh",
         contextualSearch: false,
         searchPagePath: "search",
       },

--- a/scripts/search/README.md
+++ b/scripts/search/README.md
@@ -11,11 +11,24 @@ pip install -r requirements.txt
 ### Running
 
 ```bash
+# Index English (default)
 python index_pages.py --base_directory /opt/clickhouse-docs --algolia_app_id 7AL1W7YVZK --algolia_api_key <write_key>
+
+# Index Japanese
+python index_pages.py --base_directory /opt/clickhouse-docs --algolia_app_id 7AL1W7YVZK --algolia_api_key <write_key> --locale jp
+
+# Index Chinese
+python index_pages.py --base_directory /opt/clickhouse-docs --algolia_app_id 7AL1W7YVZK --algolia_api_key <write_key> --locale zh
+
+# Index Russian
+python index_pages.py --base_directory /opt/clickhouse-docs --algolia_app_id 7AL1W7YVZK --algolia_api_key <write_key> --locale ru
+
+# Using the shell script
+./run_indexer.sh --locale jp
 ```
 
 ```bash
-usage: index_pages.py [-h] [-d BASE_DIRECTORY] [-x] --algolia_app_id ALGOLIA_APP_ID --algolia_api_key ALGOLIA_API_KEY [--algolia_index_name ALGOLIA_INDEX_NAME]
+usage: index_pages.py [-h] [-d BASE_DIRECTORY] [-x] --algolia_app_id ALGOLIA_APP_ID --algolia_api_key ALGOLIA_API_KEY [--algolia_index_name ALGOLIA_INDEX_NAME] [--locale {en,jp,zh,ru}]
 
 Index search pages.
 
@@ -30,9 +43,16 @@ options:
                         Algolia Admin API Key
   --algolia_index_name ALGOLIA_INDEX_NAME
                         Algolia Index Name
+  --locale {en,jp,zh,ru}
+                        Locale to index (default: en)
 ```
 
-[]()## Search scripts
+Before pushing any changes to the production app, please test on the dev app
+and make a backup of the english search index "clickhouse".
+You can do so from the search tab -> manage index -> duplicate.
+Give the duplicate index a name like "clickhouse-backup-DD-MM-YYYY"
+
+## Search scripts
 
 We use these to evaluate search performance. `results.csv` contains a list of authoritative search results for 200 terms.
 
@@ -50,6 +70,7 @@ pip install -r requirements.txt
 
 You need to comment out either Dev or Prod depending on what you want to test.
 The API key is the public search key, don't worry.
+Find the actual key you need in the Algolia app under settings -> API keys
 
 ```python
 # dev details

--- a/scripts/search/run_indexer.sh
+++ b/scripts/search/run_indexer.sh
@@ -39,12 +39,14 @@ fi
 
 BASE_DIRECTORY_ARG="$BASE_DIRECTORY"
 DRY_RUN=false
+LOCALE="en"
 
 # allows us to override params if needed
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -d|--base_directory) BASE_DIRECTORY_ARG="$2"; shift ;;
         -x|--dry_run) DRY_RUN=true ;;
+        -l|--locale) LOCALE="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -56,6 +58,7 @@ python "$PYTHON_SCRIPT" \
     --base_directory "$BASE_DIRECTORY_ARG" \
     $( [ "$DRY_RUN" = true ] && echo "--dry_run" ) \
     --algolia_app_id "$ALGOLIA_APP_ID" \
-    --algolia_api_key "$ALGOLIA_API_KEY"
+    --algolia_api_key "$ALGOLIA_API_KEY" \
+    --locale "$LOCALE"
 
 deactivate


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Some modifications to the indexing script to accept a `locale` parameter which will create an index with `index-name-{locale}`

Modifies the Docusaurus config for translation deployments to use the newly created language specific index.

Also took a backup of the current clickhouse english index (just in case). It is called `clickhouse-backup-27-11-2025`
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
