### PR TITLE
Gt/config update

### DIFF
--- a/gt.config.json
+++ b/gt.config.json
@@ -66,8 +66,14 @@
     }
   },
   "options": {
-    "experimentalLocalizeStaticUrls": true,
-    "experimentalAddHeaderAnchorIds": "mintlify",
+    "experimentalLocalizeStaticImports": true,
+    "docsImportRewrites": [
+      {
+        "match": "@site/docs",
+        "replace": "@site/i18n/[locale]/docusaurus-plugin-content-docs/current"
+      }
+    ],
+    "experimentalAddHeaderAnchorIds": "default",
     "experimentalClearLocaleDirs": true
   }
 }


### PR DESCRIPTION
## Summary
Updating the Clickhouse docs `gt.config.json` to handle static imports and improve fragment anchor ID handling on Locadex runs.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
