### PR TITLE
Bug fix: take into account anchor tag in search results

### DIFF
--- a/src/theme/SearchBar/utils/searchConfig.js
+++ b/src/theme/SearchBar/utils/searchConfig.js
@@ -96,9 +96,10 @@ export function transformSearchItems(items, options) {
     // For English, baseUrl is /docs/, so we want /tutorial
 
     try {
-      // Parse the URL to safely extract the pathname
+      // Parse the URL to safely extract the pathname and hash
       const urlObj = new URL(url);
       const pathname = urlObj.pathname;
+      const hash = urlObj.hash;
 
       if (currentLocale !== 'en') {
         // Remove /docs/{locale} prefix, keeping the leading slash
@@ -119,6 +120,9 @@ export function transformSearchItems(items, options) {
           url = pathname;
         }
       }
+
+      // Append the hash back to the URL
+      url += hash;
     } catch (e) {
       // If URL parsing fails, assume it's already a relative path
       // and use the original transformation logic as fallback

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -215,11 +215,12 @@ function SearchPageContent() {
                     // For non-English locales, the baseUrl is /docs/{locale}/
                     // Algolia returns URLs like /docs/{locale}/path
                     // We need to make them relative: path (without leading slash)
-                    // Parse the URL to safely extract the pathname
+                    // Parse the URL to safely extract the pathname and hash
                     let processedUrl = url;
                     try {
                         const urlObj = new URL(url);
                         const pathname = urlObj.pathname;
+                        const hash = urlObj.hash;
 
                         if (currentLocale !== 'en') {
                             const prefix = `/docs/${currentLocale}`;
@@ -236,6 +237,9 @@ function SearchPageContent() {
                                 processedUrl = pathname;
                             }
                         }
+
+                        // Append the hash back to the URL
+                        processedUrl += hash;
                     } catch (e) {
                         // Fallback to original logic if parsing fails
                         if (currentLocale !== 'en') {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Anchors are not being taken into account after changes to implement multilingual search. Fixes this.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
