### PR TITLE
Translations: modification to account for running script in General Translation ag…

### DIFF
--- a/scripts/autogenerate-table-of-contents.sh
+++ b/scripts/autogenerate-table-of-contents.sh
@@ -46,9 +46,9 @@ fi
 # Define all TOC generation commands
 COMMANDS=(
     '--dir="knowledgebase" --single-toc --out="static" --ignore images'
-    '--verbose --single-toc --dir="docs/operations/system-tables" --md="docs/operations/system-tables/index.md"'
-    '--verbose --single-toc --dir="docs/operations/settings" --md="docs/operations/settings/index.md"'
-    '--verbose --single-toc --dir="docs/engines/database-engines" --md="docs/engines/database-engines/index.md"'
+    '--single-toc --dir="docs/operations/system-tables" --md="docs/operations/system-tables/index.md"'
+    '--single-toc --dir="docs/operations/settings" --md="docs/operations/settings/index.md"'
+    '--single-toc --dir="docs/engines/database-engines" --md="docs/engines/database-engines/index.md"'
     '--single-toc --dir="docs/engines/table-engines/mergetree-family" --md="docs/engines/table-engines/mergetree-family/index.md"'
     '--single-toc --dir="docs/engines/table-engines/integrations" --md="docs/engines/table-engines/integrations/index.md"'
     '--single-toc --dir="docs/engines/table-engines/special" --md="docs/engines/table-engines/special/index.md"'


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Add a fallback to avoid using venv when it doesn’t exist in the agent sandbox
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
