### PR TITLE
Enhance max_execution_time documentation with link

### DIFF
--- a/knowledgebase/query_max_execution_time.mdx
+++ b/knowledgebase/query_max_execution_time.mdx
@@ -14,7 +14,7 @@ How do I enforce a time limit on my queries?
 
 ## Answer \{#answer\}
 
-You can use [`max_execution_time`](https://clickhouse.com/docs/operations/settings/settings#max_execution_time) setting (expressed in seconds):
+You can use [`max_execution_time`](/docs/operations/settings/settings#max_execution_time) setting (expressed in seconds):
 
 ```sql
 clickhouse-cloud :) SELECT 1 SETTINGS max_execution_time=0.0001


### PR DESCRIPTION
Updated the explanation of the max_execution_time setting to include a link to the documentation. Also clarify it's in seconds.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
