### PR TITLE
Clarify ClickPipes JSON Variant requirements

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kafka/03_reference.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/03_reference.md
@@ -77,8 +77,8 @@ ClickPipes supports the Variant type in the following circumstances:
 - Avro Unions.  If your Avro schema contains a union with multiple non-null types, ClickPipes will infer the
   appropriate variant type.  Variant types are not otherwise supported for Avro data.
 - JSON fields.  You can manually specify a Variant type (such as `Variant(String, Int64, DateTime)`) for any JSON field
-  in the source data stream.  Because of the way ClickPipes determines the correct variant subtype to use, only one integer or datetime
-  type can be used in the Variant definition - for example, `Variant(Int64, UInt32)` is not supported.
+  in the source data stream.  Complex subtypes (arrays/maps/tuples) are not supported.  In addition, because of the way ClickPipes determines
+  the correct variant subtype to use, only one integer or datetime type can be used in the Variant definition - for example, `Variant(Int64, UInt32)` is not supported.
 
 #### JSON type support {#json-type-support}
 ClickPipes support the JSON type in the following circumstances:


### PR DESCRIPTION
## Summary
Tuples/Maps/Arrays are not supported for ClickPipes Variant using a JSONEachRow source

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
