### PR TITLE
fix: update nav css to handle longer localized strings

### DIFF
--- a/src/components/DocsCategoryDropdown/styles.module.css
+++ b/src/components/DocsCategoryDropdown/styles.module.css
@@ -3,10 +3,13 @@
 .docsNavDropdownContainer {
   border-radius: 10px;
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   color: var(--ch-nav-v2-link-color);
   width: fit-content;
   padding: 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
   /* Keep original padding for non-dropdown items */
 }
 


### PR DESCRIPTION
## Summary
Updating`docsNavDropdownContainer` CSS to handle oversized translations.

Example:
<img width="718" height="137" alt="image" src="https://github.com/user-attachments/assets/b58f8262-039e-4e7b-8a74-c3f89f300920" />


## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
