### PR TITLE
Improvement: show insert progress on dbpedia.md

### DIFF
--- a/docs/getting-started/example-datasets/dbpedia.md
+++ b/docs/getting-started/example-datasets/dbpedia.md
@@ -35,7 +35,11 @@ CREATE TABLE dbpedia
 To load the dataset from all Parquet files, run the following shell command:
 
 ```shell
-$ seq 0 25 | xargs -P1 -I{} clickhouse client -q "INSERT INTO dbpedia SELECT _id, title, text, \"text-embedding-3-large-1536-embedding\" FROM url('https://huggingface.co/api/datasets/Qdrant/dbpedia-entities-openai3-text-embedding-3-large-1536-1M/parquet/default/train/{}.parquet') SETTINGS max_http_get_redirects=5,enable_url_encoding=0;"
+for i in $(seq 0 25); do
+  echo "Processing file ${i}..."
+  clickhouse client -q "INSERT INTO dbpedia SELECT _id, title, text, \"text-embedding-3-large-1536-embedding\" FROM url('https://huggingface.co/api/datasets/Qdrant/dbpedia-entities-openai3-text-embedding-3-large-1536-1M/parquet/default/train/${i}.parquet') SETTINGS max_http_get_redirects=5,enable_url_encoding=0;"
+  echo "File ${i} complete."
+done
 ```
 
 Alternatively, individual SQL statements can be run as shown below to load each of the 25 Parquet files:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Currently, when inserting the data with the first command there is no feedback on the progress.
Updates the insert statement to show some progress while the data gets inserted, as it takes a while.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
