### PR TITLE
DynamoDB integration is not experimental

### DIFF
--- a/docs/integrations/data-ingestion/dbms/dynamodb/index.md
+++ b/docs/integrations/data-ingestion/dbms/dynamodb/index.md
@@ -10,15 +10,12 @@ doc_type: 'guide'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
-import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import dynamodb_kinesis_stream from '@site/static/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-kinesis-stream.png';
 import dynamodb_s3_export from '@site/static/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-s3-export.png';
 import dynamodb_map_columns from '@site/static/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-map-columns.png';
 import Image from '@theme/IdealImage';
 
 # CDC from DynamoDB to ClickHouse
-
-<ExperimentalBadge/>
 
 This page covers how set up CDC from DynamoDB to ClickHouse using ClickPipes. There are 2 components to this integration:
 1. The initial snapshot via S3 ClickPipes


### PR DESCRIPTION
We just forgot to remove the badge.

The only building block is Kinesis, and it is battle-tested and runs in production.

## Summary
DynamoDB integration is not experimental.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
