### PR TITLE
style: adjust DocSearch-Button-Keys layout to use flexbox, update padding, and remove the key separator.

### DIFF
--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -7,8 +7,7 @@
 
 .DocSearch-Button {
   margin: 0;
-  transition: all var(--ifm-transition-fast)
-    var(--ifm-transition-timing-default);
+  transition: all var(--ifm-transition-fast) var(--ifm-transition-timing-default);
   font-size: inherit;
   outline: transparent !important;
   border-radius: 4px;
@@ -20,6 +19,7 @@
   background-color: rgb(250, 250, 250);
   color: black;
 }
+
 .DocSearch-Button-Placeholder {
   font-size: inherit;
 }
@@ -45,30 +45,27 @@
 }
 
 .DocSearch-Button-Keys {
-  gap: 1rem;
-  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
   border-radius: 4px;
   background: var(--click-color-background-muted);
   border: 1px solid var(--click-color-stroke);
-}
-
-.DocSearch-Button-Key:first-of-type::after {
-  content: "+";
-  position: absolute;
-  left: 100%;
+  height: 20px;
 }
 
 .DocSearch-Logo {
   display: none !important;
 }
 
-.DocSearch-Dropdown { 
-  max-height: calc(min(90vh) - 180px) !important; 
+.DocSearch-Dropdown {
+  max-height: calc(min(90vh) - 180px) !important;
 }
 
 /* Mobile styles */
 @media (max-width: 768px) {
-  .DocSearch-Dropdown { 
+  .DocSearch-Dropdown {
     max-height: calc(100vh - 120px) !important;
     width: calc(100vw - 20px) !important;
     left: 10px !important;
@@ -76,7 +73,7 @@
     position: fixed !important;
     z-index: 9999 !important;
   }
-  
+
   .DocSearch-SearchBar {
     position: sticky !important;
     top: 0 !important;


### PR DESCRIPTION
i just basically made it look a lot better, i've read a lot of docs and this just triggered my ocd

https://github.com/ClickHouse/clickhouse-docs/blob/main/src/theme/SearchBar/styles.css

<img width="267" height="277" alt="Screenshot 2025-12-03 at 13 44 53" src="https://github.com/user-attachments/assets/8bd36673-f2d3-4ee4-a7d1-cf396aa5c2a9" />
<img width="267" height="277" alt="Screenshot 2025-12-03 at 13 44 58" src="https://github.com/user-attachments/assets/43859f88-9a24-47f3-9352-0694831c1bba" />
