### PR TITLE
Chore: add floating exception for datalakes.md

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -11,3 +11,4 @@ integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 integrations/data-ingestion/clickpipes/postgres/maintenance.md
 operations/backup.md
+sql-reference/datalakes.md


### PR DESCRIPTION
## Summary
Docs check on https://github.com/ClickHouse/ClickHouse/pull/91393 fails because of our lovely two repo problem. Adding this page as an exception so that we can merge that PR in and then update the sidebar in a follow up PR on this repo.
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
