### PR TITLE
fix the mixup of <k+v> with <v+k>

### DIFF
--- a/docs/cloud/features/04_infrastructure/shared-merge-tree.md
+++ b/docs/cloud/features/04_infrastructure/shared-merge-tree.md
@@ -13,7 +13,7 @@ import Image from '@theme/IdealImage';
 
 # SharedMergeTree table engine
 
-The SharedMergeTree table engine family is a cloud-native replacement of the ReplicatedMergeTree engines that is optimized to work on top of shared storage (e.g. Amazon S3, Google Cloud Storage, MinIO, Azure Blob Storage). There is a SharedMergeTree analog for every specific MergeTree engine type, i.e. ReplacingSharedMergeTree replaces ReplacingReplicatedMergeTree.
+The SharedMergeTree table engine family is a cloud-native replacement of the ReplicatedMergeTree engines that is optimized to work on top of shared storage (e.g. Amazon S3, Google Cloud Storage, MinIO, Azure Blob Storage). There is a SharedMergeTree analog for every specific MergeTree engine type, i.e. SharedReplacingMergeTree replaces ReplicatedReplacingMergeTree.
 
 The SharedMergeTree table engine family powers ClickHouse Cloud. For an end-user, nothing needs to be changed to start using the SharedMergeTree engine family instead of the ReplicatedMergeTree based engines. It provides the following additional benefits:
 


### PR DESCRIPTION
## Summary
Fix the mixup of engine naming for shared/replicated variations within the shared doc page

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

closes #4922 