### PR TITLE
Update ClickHouse JS client Node.js version support table

### DIFF
--- a/docs/integrations/language-clients/js.md
+++ b/docs/integrations/language-clients/js.md
@@ -41,10 +41,10 @@ Current Node.js versions support:
 
 | Node.js version | Supported?  |
 |-----------------|-------------|
+| 24.x            | ✔           |
 | 22.x            | ✔           |
 | 20.x            | ✔           |
-| 18.x            | ✔           |
-| 16.x            | Best effort |
+| 18.x            | Best effort |
 
 ## Environment requirements (web) {#environment-requirements-web}
 


### PR DESCRIPTION
## Summary

According to the [test workflow matrix](https://github.com/ClickHouse/clickhouse-js/blob/c8e1d05dcc68e5958e893fa9b8c77ad935900bc9/.github/workflows/tests.yml#L30) the current supported versions are 20, 22 and 24. Updating the docs accordingly.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
