### PR TITLE
Remove redirect from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3542,11 +3542,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/cloud/security/audit-logging",
-      "destination": "/docs/cloud/security/audit-logging/console-audit-log",
-      "permanent": true
-    },
-    {
       "source": "/docs/cloud/security/cloud-access-management/overview",
       "destination": "/docs/cloud/security/manage-database-users",
       "permanent": true


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
There is a redirect in place here which redirects from a valid page to another valid page. We only need redirects when a page is deleted.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
