### PR TITLE
Docs: update links for interfaces docs

### DIFF
--- a/docs/faq/integration/json-import.md
+++ b/docs/faq/integration/json-import.md
@@ -14,7 +14,7 @@ ClickHouse supports a wide range of [data formats for input and output](/interfa
 
 ## Examples {#examples}
 
-Using [HTTP interface](../../interfaces/http.md):
+Using [HTTP interface](/interfaces/http):
 
 ``` bash
 $ echo '{"foo":"bar"}' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test%20FORMAT%20JSONEachRow' --data-binary @-

--- a/docs/getting-started/playground.md
+++ b/docs/getting-started/playground.md
@@ -13,7 +13,7 @@ doc_type: 'guide'
 [ClickHouse Playground](https://sql.clickhouse.com) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
 Several example datasets are available in Playground.
 
-You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](../interfaces/jdbc.md) or [ODBC](../interfaces/odbc.md) drivers. More information about software products that support ClickHouse is available [here](../integrations/index.mdx).
+You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](/interfaces/jdbc) or [ODBC](/interfaces/odbc) drivers. More information about software products that support ClickHouse is available [here](../integrations/index.mdx).
 
 ## Credentials {#credentials}
 

--- a/docs/integrations/data-ingestion/dbms/jdbc-with-clickhouse.md
+++ b/docs/integrations/data-ingestion/dbms/jdbc-with-clickhouse.md
@@ -103,7 +103,7 @@ We started the ClickHouse JDBC Bridge in foreground mode. In order to stop the B
 
 ClickHouse can now access MySQL data by either using the [jdbc table function](/sql-reference/table-functions/jdbc.md) or the [JDBC table engine](/engines/table-engines/integrations/jdbc.md).
 
-The easiest way to execute the following examples is to copy and paste them into the [`clickhouse-client`](/interfaces/cli.md) or into the [Play UI](/interfaces/http.md).
+The easiest way to execute the following examples is to copy and paste them into the [`clickhouse-client`](/interfaces/cli.md) or into the [Play UI](/interfaces/http).
 
 - jdbc Table Function:
 

--- a/docs/integrations/data-ingestion/kafka/confluent/kafka-connect-http.md
+++ b/docs/integrations/data-ingestion/kafka/confluent/kafka-connect-http.md
@@ -128,7 +128,7 @@ Note that this example preserves the Array fields of the Github dataset. We assu
 
 Follow [these instructions](https://docs.confluent.io/cloud/current/cp-component/connect-cloud-config.html#set-up-a-local-connect-worker-with-cp-install) for setting up Connect relevant to your installation type, noting the differences between a standalone and distributed cluster. If using Confluent Cloud, the distributed setup is relevant.
 
-The most important parameter is the `http.api.url`. The [HTTP interface](../../../../interfaces/http.md) for ClickHouse requires you to encode the INSERT statement as a parameter in the URL. This must include the format (`JSONEachRow` in this case) and target database. The format must be consistent with the Kafka data, which will be converted to a string in the HTTP payload. These parameters must be URL escaped. An example of this format for the Github dataset (assuming you are running ClickHouse locally) is shown below:
+The most important parameter is the `http.api.url`. The [HTTP interface](/interfaces/http) for ClickHouse requires you to encode the INSERT statement as a parameter in the URL. This must include the format (`JSONEachRow` in this case) and target database. The format must be consistent with the Kafka data, which will be converted to a string in the HTTP payload. These parameters must be URL escaped. An example of this format for the Github dataset (assuming you are running ClickHouse locally) is shown below:
 
 ```response
 <protocol>://<clickhouse_host>:<clickhouse_port>?query=INSERT%20INTO%20<database>.<table>%20FORMAT%20JSONEachRow


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Interfaces docs were moved to this repo. Updates some links needed for docs check on https://github.com/ClickHouse/ClickHouse/pull/92405 to pass.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
