### PR TITLE
docs(golang-client): Enforce `rows.Err()` check in examples

### DIFF
--- a/docs/integrations/language-clients/go/index.md
+++ b/docs/integrations/language-clients/go/index.md
@@ -39,81 +39,81 @@ Copy this code into the `clickhouse-golang-example` directory as `main.go`.
 package main
 
 import (
-	"context"
-	"crypto/tls"
-	"fmt"
-	"log"
+    "context"
+    "crypto/tls"
+    "fmt"
+    "log"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+    "github.com/ClickHouse/clickhouse-go/v2"
+    "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func main() {
-	conn, err := connect()
-	if err != nil {
-		panic(err)
-	}
+    conn, err := connect()
+    if err != nil {
+        panic(err)
+    }
 
-	ctx := context.Background()
-	rows, err := conn.Query(ctx, "SELECT name, toString(uuid) as uuid_str FROM system.tables LIMIT 5")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
+    ctx := context.Background()
+    rows, err := conn.Query(ctx, "SELECT name, toString(uuid) as uuid_str FROM system.tables LIMIT 5")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer rows.Close()
 
-	for rows.Next() {
-		var name, uuid string
-		if err := rows.Scan(&name, &uuid); err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("name: %s, uuid: %s", name, uuid)
-	}
+    for rows.Next() {
+        var name, uuid string
+        if err := rows.Scan(&name, &uuid); err != nil {
+            log.Fatal(err)
+        }
+        log.Printf("name: %s, uuid: %s", name, uuid)
+    }
 
-	// NOTE: Do not skip rows.Err() check
-	if err := rows.Err(); err != nil {
-		log.Fatal(err)
-	}
+    // NOTE: Do not skip rows.Err() check
+    if err := rows.Err(); err != nil {
+        log.Fatal(err)
+    }
 
 }
 
 func connect() (driver.Conn, error) {
-	var (
-		ctx       = context.Background()
-		conn, err = clickhouse.Open(&clickhouse.Options{
-			Addr: []string{"<CLICKHOUSE_SECURE_NATIVE_HOSTNAME>:9440"},
-			Auth: clickhouse.Auth{
-				Database: "default",
-				Username: "default",
-				Password: "<DEFAULT_USER_PASSWORD>",
-			},
-			ClientInfo: clickhouse.ClientInfo{
-				Products: []struct {
-					Name    string
-					Version string
-				}{
-					{Name: "an-example-go-client", Version: "0.1"},
-				},
-			},
-			Debugf: func(format string, v ...interface{}) {
-				fmt.Printf(format, v)
-			},
-			TLS: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		})
-	)
+    var (
+        ctx       = context.Background()
+        conn, err = clickhouse.Open(&clickhouse.Options{
+            Addr: []string{"<CLICKHOUSE_SECURE_NATIVE_HOSTNAME>:9440"},
+            Auth: clickhouse.Auth{
+                Database: "default",
+                Username: "default",
+                Password: "<DEFAULT_USER_PASSWORD>",
+            },
+            ClientInfo: clickhouse.ClientInfo{
+                Products: []struct {
+                    Name    string
+                    Version string
+                }{
+                    {Name: "an-example-go-client", Version: "0.1"},
+                },
+            },
+            Debugf: func(format string, v ...interface{}) {
+                fmt.Printf(format, v)
+            },
+            TLS: &tls.Config{
+                InsecureSkipVerify: true,
+            },
+        })
+    )
 
-	if err != nil {
-		return nil, err
-	}
+    if err != nil {
+        return nil, err
+    }
 
-	if err := conn.Ping(ctx); err != nil {
-		if exception, ok := err.(*clickhouse.Exception); ok {
-			fmt.Printf("Exception [%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
-		}
-		return nil, err
-	}
-	return conn, nil
+    if err := conn.Ping(ctx); err != nil {
+        if exception, ok := err.(*clickhouse.Exception); ok {
+            fmt.Printf("Exception [%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
+        }
+        return nil, err
+    }
+    return conn, nil
 }
 ```
 


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->

1. Enforce `rows.Err()` check in examples. This check is needed to extract the exceptions form the server properly.
2. Also fixes `defer rows.Close()` wherever it was missed.
3. Also did `gofmt` fixes on Go code blocks in index.md

Related discussions:
1. https://github.com/ClickHouse/clickhouse-go/issues/1468#issuecomment-3669435811
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
