### PR TITLE
Update 02_release_status.md

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_status.md
+++ b/docs/cloud/reference/01_changelog/02_release_status.md
@@ -41,13 +41,12 @@ The release dates given below are an estimate and may be subject to change.
    {
     changelog_link: 'https://clickhouse.com/docs/changelogs/25.10',
     version: '25.10',
-    fast_date: 'Starting 2025-12-11',
+    fast_date: '2025-12-11 (completed 2025-12-15)',
     regular_date: '2026-01-07',
     slow_date: 'TBD',
     fast_progress: 'green',
     regular_progress: 'green',
     slow_progress: 'green',
-    fast_delay_note: 'Complete',
-    regular_delay_note: 'Services with an upgrade window will receive 25.10 during their scheduled window in the week of Jan 05',
+    fast_delay_note: 'Services with an upgrade window will receive 25.10 during their scheduled window in the week of Jan 05',
   }
 ]} />


### PR DESCRIPTION
**Fast** channel services with upgrade window will receive the upgrade in the week of Jan 5. Not regular channel.

Current state is:
* fast channel without upgrade window: done
* fast channel with upgrade window: will be ugpraded during their window on Jan 5 (after the freeze)
* regular channel without upgrade window: starting Jan 07
* regular channel with upgrade window: once step 3 is done

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
