### PR TITLE
Chore: set broken link check to warn temporarily

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -57,7 +57,7 @@ const config = {
   // url: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://bookish-disco-5997zvo.pages.github.io',
   baseUrl: "/docs/",
   baseUrlIssueBanner: true,
-  onBrokenLinks: "throw",
+  onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   onDuplicateRoutes: "throw",
   onBrokenAnchors: process.env.ON_BROKEN_ANCHORS ?? "throw",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
We have broken links in the docs check of https://github.com/ClickHouse/ClickHouse/pull/92668 for files in this repo, however if we update them here docs check will fail because the file hasn't been renamed yet until the other PR is merged. For the sake of everyone's sanity turning the link checker to warn temporarily and we can fix the links and turn back on together with the PR that adds the redirect.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
