### PR TITLE
Docs: add back upload-a-csv-file

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/04_upload-a-csv-file.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/04_upload-a-csv-file.md
@@ -2,6 +2,7 @@
 title: 'Uploading files'
 slug: /cloud/migrate/upload-a-csv-file
 description: 'Learn how to upload files to Cloud'
+doc_type: 'guide'
 ---
 
 import Image from '@theme/IdealImage';


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Saw we are getting 404 hits on `/docs/knowledge-base/upload-a-file`. Somehow this file got lost. Adding it back.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
