### PR TITLE
Chore: temporarily set onBrokenAnchors to warn

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -60,7 +60,7 @@ const config = {
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   onDuplicateRoutes: "throw",
-  onBrokenAnchors: process.env.ON_BROKEN_ANCHORS ?? "throw",
+  onBrokenAnchors: process.env.ON_BROKEN_ANCHORS ?? "warn",
   favicon: "img/docs_favicon.ico",
   organizationName: "ClickHouse",
   trailingSlash: false,


### PR DESCRIPTION
Needed to merge [PR 92916](https://github.com/ClickHouse/ClickHouse/pull/92916) without circular dependency breaking docs check

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
