### PR TITLE
Fix formatting in clickhouse-cpp examples

### DIFF
--- a/docs/integrations/language-clients/cpp.md
+++ b/docs/integrations/language-clients/cpp.md
@@ -78,11 +78,11 @@ connecting to a ClickHouse Cloud instance using several additional parameters:
 
 clickhouse::Client client{
     clickhouse::ClientOptions{}
-        .SetHost("your.instance.clickhouse.cloud")
-         .SetUser("default")
-        .SetPassword("your-password")
+      .SetHost("your.instance.clickhouse.cloud")
+      .SetUser("default")
+      .SetPassword("your-password")
       .SetSSLOptions({})   // Enable SSL
-      .SetPort(9440)       // for connections over SS ClickHouse Cloud uses 9440
+      .SetPort(9440)       // for connections over SSL ClickHouse Cloud uses port 9440
     };
 ```
 


### PR DESCRIPTION
## Summary
There was a slight issue with the code formatting in one of the examples (offsets were not aligned) and a typo. Fixing it in this PR.

## Checklist
~- Not applicable. Delete items not relevant to your PR~
~- Not applicable. URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js~
~- Not applicable. If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx~
