### PR TITLE
Add exception for new page

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -22,3 +22,4 @@ interfaces/ssh
 interfaces/grpc
 interfaces/arrowflight
 interfaces/overview
+operations/utilities/clickhouse-keeper-http-api.md


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds an exception for the page added in https://github.com/ClickHouse/ClickHouse/pull/78181 so we can get docs check green.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
