### PR TITLE
ClickPipes: improve recommendation for publication creation

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/alloydb.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/alloydb.md
@@ -69,7 +69,7 @@ Connect to your AlloyDB instance as an admin user and execute the following comm
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Grant the dedicated user permissions on the schema(s) you want to replicate.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
    
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -77,9 +77,7 @@ Connect to your AlloyDB instance as an admin user and execute the following comm
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-   The example above shows permissions for the `public` schema. Repeat the sequence of commands for each schema you want to replicate using ClickPipes.
-
-3. Grant the dedicated user permissions to manage replication:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/aurora.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/aurora.md
@@ -74,7 +74,7 @@ Connect to your Aurora PostgreSQL writer instance as an admin user and execute t
     CREATE USER clickpipes_user PASSWORD 'some-password';
     ```
 
-2. Grant schema permissions. The following example shows permissions for the `public` schema. Repeat these commands for each schema you want to replicate:
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -82,7 +82,7 @@ Connect to your Aurora PostgreSQL writer instance as an admin user and execute t
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-3. Grant replication privileges:
+3. Grant replication privileges to the user:
 
     ```sql
     GRANT rds_replication TO clickpipes_user;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/azure-flexible-server-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/azure-flexible-server-postgres.md
@@ -37,13 +37,13 @@ ClickPipes supports Postgres version 12 and later.
 
 Connect to your Azure Flexible Server Postgres through the admin user and run the below commands:
 
-1. Create a Postgres user for exclusively ClickPipes.
+1. Create a dedicated user for ClickPipes.
 
    ```sql
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Provide read-only access to the schema from which you are replicating tables to the `clickpipes_user`. Below example shows setting up permissions for the `public` schema. If you want to grant access to multiple schemas, you can run these three commands for each schema.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
    ```sql
    GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -51,7 +51,7 @@ Connect to your Azure Flexible Server Postgres through the admin user and run th
    ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
    ```
 
-3. Grant replication access to this user:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/crunchy-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/crunchy-postgres.md
@@ -29,13 +29,13 @@ SHOW max_replication_slots; -- should be 10
 
 Connect to your Crunchy Bridge Postgres through the `postgres` user and run the below commands:
 
-1. Create a Postgres user exclusively for ClickPipes.
+1. Create a dedicated user for ClickPipes:
 
     ```sql
     CREATE USER clickpipes_user PASSWORD 'some-password';
     ```
 
-2. Grant read-only access to the schema from which you are replicating tables to `clickpipes_user`. Below example shows granting permissions for the `public` schema. If you want to grant access to multiple schemas, you can run these three commands for each schema.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -43,7 +43,7 @@ Connect to your Crunchy Bridge Postgres through the `postgres` user and run the 
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-3. Grant replication access to this user:
+3. Grant replication privileges to the user:
 
     ```sql
      ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/generic.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/generic.md
@@ -62,7 +62,7 @@ Connect to your Postgres instance as an admin user and execute the following com
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Grant the dedicated user permissions on the schema(s) you want to replicate.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
    
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -70,9 +70,7 @@ Connect to your Postgres instance as an admin user and execute the following com
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-   The example above shows permissions for the `public` schema. Repeat the sequence of commands for each schema you want to replicate using ClickPipes.
-
-3. Grant the dedicated user permissions to manage replication:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/google-cloudsql.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/google-cloudsql.md
@@ -47,13 +47,13 @@ Anything on or after Postgres 12
 
 Connect to your Cloud SQL Postgres through the admin user and run the below commands:
 
-1. Create a Postgres user for exclusively ClickPipes.
+1. Create a dedicated user for ClickPipes:
 
    ```sql
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Provide read-only access to the schema from which you are replicating tables to the `clickpipes_user`. Below example shows setting up permissions for the `public` schema. If you want to grant access to multiple schemas, you can run these three commands for each schema.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
    ```sql
    GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -61,7 +61,7 @@ Connect to your Cloud SQL Postgres through the admin user and run the below comm
    ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
    ```
 
-3. Grant replication access to this user:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/neon-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/neon-postgres.md
@@ -28,7 +28,7 @@ Connect to your Neon instance as an admin user and execute the following command
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Grant the dedicated user permissions on the schema(s) you want to replicate.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
    
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -36,9 +36,7 @@ Connect to your Neon instance as an admin user and execute the following command
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-   The example above shows permissions for the `public` schema. Repeat the sequence of commands for each schema you want to replicate using ClickPipes.
-
-3. Grant the dedicated user permissions to manage replication:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/planetscale.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/planetscale.md
@@ -47,27 +47,47 @@ Changing this in the PlanetScale console WILL trigger a restart.
 
 ## Creating a user with permissions and publication {#creating-a-user-with-permissions-and-publication}
 
-Let's create a new user for ClickPipes with the necessary permissions suitable for CDC,
-and also create a publication that we'll use for replication.
+Connect to your PlanetScale Postgres instance using the default `postgres.<...>` user and run the following commands:
 
-For this, you can connect to your PlanetScale Postgres instance using the default `postgres.<...>` user and run the following SQL commands:
-```sql
-  CREATE USER clickpipes_user PASSWORD 'clickpipes_password';
-  GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
--- You may need to grant these permissions on more schemas depending on the tables you're moving
-  GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO clickpipes_user;
-  ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
+1. Create a dedicated user for ClickPipes:
 
--- Give replication permission to the USER
-  ALTER USER clickpipes_user REPLICATION;
+    ```sql
+    CREATE USER clickpipes_user PASSWORD 'some-password';
+    ```
 
--- Create a publication. We will use this when creating the pipe
--- When adding new tables to the ClickPipe, you'll need to manually add them to the publication as well. 
-  CREATE PUBLICATION clickpipes_publication FOR TABLE <...>, <...>, <...>;
-```
-:::note
-Make sure to replace `clickpipes_user` and `clickpipes_password` with your desired username and password.
-:::
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
+
+    ```sql
+    GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
+    GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO clickpipes_user;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
+    ```
+
+3. Grant replication privileges to the user:
+
+    ```sql
+    GRANT rds_replication TO clickpipes_user;
+    ```
+
+4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.
+
+   :::warning
+   Any table included in the publication must either have a **primary key** defined _or_ have its **replica identity** configured to `FULL`. See the [Postgres FAQs](../faq.md#how-should-i-scope-my-publications-when-setting-up-replication) for guidance on scoping.
+   :::
+
+   - To create a publication for specific tables:
+
+      ```sql
+      CREATE PUBLICATION clickpipes FOR TABLE table_to_replicate, table_to_replicate2;
+      ```
+
+   - To create a publication for all tables in a specific schema:
+
+      ```sql
+      CREATE PUBLICATION clickpipes FOR TABLES IN SCHEMA "public";
+      ```
+
+   The `clickpipes` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
 
 ## Caveats {#caveats}
 1. To connect to PlanetScale Postgres, the current branch needs to be appended to the username created above. For example, if the created user was named `clickpipes_user`, the actual user provided during the ClickPipe creation needs to be `clickpipes_user`.`branch` where `branch` refers to the "id" of the current PlanetScale Postgres [branch](https://planetscale.com/docs/postgres/branching). To quickly determine this, you can refer to the username of the `postgres` user you used to create the user earlier, the part after the period would be the branch id.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/rds.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/rds.md
@@ -74,7 +74,7 @@ Connect to your RDS Postgres instance as an admin user and execute the following
     CREATE USER clickpipes_user PASSWORD 'some-password';
     ```
 
-2. Grant schema permissions. The following example shows permissions for the `public` schema. Repeat these commands for each schema you want to replicate:
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -82,7 +82,7 @@ Connect to your RDS Postgres instance as an admin user and execute the following
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-3. Grant replication privileges:
+3. Grant replication privileges to the user:
 
     ```sql
     GRANT rds_replication TO clickpipes_user;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
@@ -31,7 +31,7 @@ Connect to your Supabase instance as an admin user and execute the following com
    CREATE USER clickpipes_user PASSWORD 'some-password';
    ```
 
-2. Grant the dedicated user permissions on the schema(s) you want to replicate.
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
    
     ```sql
     GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
@@ -39,9 +39,7 @@ Connect to your Supabase instance as an admin user and execute the following com
     ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
     ```
 
-   The example above shows permissions for the `public` schema. Repeat the sequence of commands for each schema you want to replicate using ClickPipes.
-
-3. Grant the dedicated user permissions to manage replication:
+3. Grant replication privileges to the user:
 
    ```sql
    ALTER ROLE clickpipes_user REPLICATION;

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
@@ -64,40 +64,45 @@ but this requires additional steps.
 If you'd like to only perform a one-time load of your data (`Initial Load Only`), please skip steps 2 onward.
 :::
 
-1. Create a Postgres user for the pipe and grant it permissions to `SELECT` the tables you wish to replicate.
+1. Create a dedicated user for ClickPipes:
 
-```sql
-  CREATE USER clickpipes_user PASSWORD 'clickpipes_password';
-  GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
-  -- If desired, you can refine these GRANTs to individual tables alone, instead of the entire schema
-  -- But when adding new tables to the ClickPipe, you'll need to add them to the user as well.
-  GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO clickpipes_user;
-  ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
-```
+    ```sql
+    CREATE USER clickpipes_user PASSWORD 'some-password';
+    ```
 
-:::note
-Make sure to replace `clickpipes_user` and `clickpipes_password` with your desired username and password.
-:::
+2. Grant schema-level, read-only access to the user you created in the previous step. The following example shows permissions for the `public` schema. Repeat these commands for each schema containing tables you want to replicate:
 
-2. As a Postgres superuser/admin user, create a publication on the source instance that has the tables and hypertables 
-   you want to replicate and **also includes the entire `_timescaledb_internal` schema**. While creating the ClickPipe, you need to select this publication.
+    ```sql
+    GRANT USAGE ON SCHEMA "public" TO clickpipes_user;
+    GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO clickpipes_user;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO clickpipes_user;
+    ```
 
-```sql
--- When adding new tables to the ClickPipe, you'll need to add them to the publication as well manually. 
-  CREATE PUBLICATION clickpipes_publication FOR TABLE <...>, <...>, TABLES IN SCHEMA _timescaledb_internal;
-```
+3. Grant replication privileges to the user:
 
-:::tip
-We don't recommend creating a publication `FOR ALL TABLES`, this leads to more traffic from Postgres to ClickPipes (to sending changes for other tables not in the pipe) and reduces overall efficiency.
+    ```sql
+    GRANT rds_replication TO clickpipes_user;
+    ```
 
-For manually created publications, please add any tables you want to the publication before adding them to the pipe.
-::: 
+4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.
 
-:::info
-Some managed services don't give their admin users the required permissions to create a publication for an entire schema.
-If this is the case, please raise a support ticket with your provider. Alternatively, you can skip this step and the following 
-steps and perform a one-time load of your data.
-:::
+   :::warning
+   Any table included in the publication must either have a **primary key** defined _or_ have its **replica identity** configured to `FULL`. See the [Postgres FAQs](../faq.md#how-should-i-scope-my-publications-when-setting-up-replication) for guidance on scoping.
+   :::
+
+   - To create a publication for specific tables:
+
+      ```sql
+      CREATE PUBLICATION clickpipes FOR TABLE table_to_replicate, table_to_replicate2;
+      ```
+
+   - To create a publication for all tables in a specific schema:
+
+      ```sql
+      CREATE PUBLICATION clickpipes FOR TABLES IN SCHEMA "public";
+      ```
+
+   The `clickpipes` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
 
 3. Grant replication permissions to the user created earlier.
 


### PR DESCRIPTION
## Summary

Most of our service-specific Postgres guides use a publication creation approach that is an anti-pattern for performance reasons (`FOR ALL TABLES`). Patching to guide users towards adding individual tables or tables per schema to the publication, instead.

The Postgres guides currently don't follow a common structure, so for now just copy-pasting the step across all guides. Will work on a common structure for guides + templating in the future. Also mirrored the changes in the PeerDB documentation (see [`PeerDB-io/docs` #239](https://github.com/PeerDB-io/docs/pull/239)).

Closes [DBI-187](https://linear.app/clickhouse/issue/DBI-187/document-create-publication).