### PR TITLE
Bug fix: logo overlays menu text on mobile

### DIFF
--- a/src/components/MobileSideBarMenu/index.jsx
+++ b/src/components/MobileSideBarMenu/index.jsx
@@ -1,10 +1,11 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import Hamburger from "./Hamburger";
 import MobileSideBarMenuContents from './Content';
 import styles from './styles.module.scss';
 import { useLocation, useHistory } from '@docusaurus/router';
 
-const MobileSideBarMenu = ({sidebar, menu}) => {
+const MobileSideBarMenu = ({ sidebar, menu }) => {
     const [currentMenuState, setMenuState] = useState(() => {
         // Only access sessionStorage if we're in the browser
         if (typeof window !== 'undefined' && window.sessionStorage) {
@@ -197,27 +198,32 @@ const MobileSideBarMenu = ({sidebar, menu}) => {
         }
     };
 
-    return(
+    return (
         <>
             <Hamburger
                 onClick={() => setMenuState(!currentMenuState)}
             />
-            <div className={currentMenuState ? styles.docsMobileMenuBackdropActive : styles.docsMobileMenuBackdropInactive}/>
-            <MobileSideBarMenuContents
-                onClick={(item) => {
-                    if (!item.collapsible) {
-                        setMenuState(!currentMenuState)
-                    }
-                }}
-                onClose={handleMenuClose}
-                onLanguageChange={handleLanguageChange}
-                sidebar={sidebar} // Left sidebar items
-                menu={menu} // Top level menu items
-                isVisible={currentMenuState} // Pass menu visibility state
-                className={currentMenuState
-                    ? styles.docsMobileMenuActive
-                    : styles.docsMobileMenuHidden}
-            />
+            {typeof window !== 'undefined' && ReactDOM.createPortal(
+                <>
+                    <div className={currentMenuState ? styles.docsMobileMenuBackdropActive : styles.docsMobileMenuBackdropInactive} />
+                    <MobileSideBarMenuContents
+                        onClick={(item) => {
+                            if (!item.collapsible) {
+                                setMenuState(!currentMenuState)
+                            }
+                        }}
+                        onClose={handleMenuClose}
+                        onLanguageChange={handleLanguageChange}
+                        sidebar={sidebar} // Left sidebar items
+                        menu={menu} // Top level menu items
+                        isVisible={currentMenuState} // Pass menu visibility state
+                        className={currentMenuState
+                            ? styles.docsMobileMenuActive
+                            : styles.docsMobileMenuHidden}
+                    />
+                </>,
+                document.body
+            )}
         </>
     );
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
On mobile the logo overlays the menu text when scrolling down: 
<img width="472" height="176" alt="image" src="https://github.com/user-attachments/assets/e1b89907-3e08-4d4b-af6c-94c4b79f9900" />
Fixes this.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
