### PR TITLE
adding rule to boost datalakecatalog on catalog search

### DIFF
--- a/scripts/search/settings.json
+++ b/scripts/search/settings.json
@@ -106,6 +106,21 @@
     {
       "conditions": [
         {
+          "anchoring": "is",
+          "pattern": "catalog"
+        }
+      ],
+      "consequence": {
+        "params": {
+          "query": "DataLakeCatalog catalog"
+        }
+      },
+      "enabled": true,
+      "objectID": "catalog-datalake-boost"
+    },
+    {
+      "conditions": [
+        {
           "anchoring": "contains",
           "pattern": "how to scale"
         }


### PR DESCRIPTION
## Summary
adding rule to boost datalakecatalog on catalog search

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
