### PR TITLE
Update 25.8 status in 02_release_status.md

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_status.md
+++ b/docs/cloud/reference/01_changelog/02_release_status.md
@@ -39,6 +39,17 @@ The release dates given below are an estimate and may be subject to change.
 
 <ReleaseSchedule releases={[
    {
+     changelog_link: 'https://clickhouse.com/docs/changelogs/25.10',
+     version: '25.10',
+     fast_date: '2025-12-11 (completed 2025-12-15)',
+     regular_date: '2026-01-07',
+     slow_date: 'TBD',
+     fast_progress: 'green',
+     regular_progress: 'green',
+     slow_progress: 'green',
+     fast_delay_note: 'Services with an upgrade window will receive 25.10 during their scheduled window in the week of Jan 05',
+   },
+   {
     changelog_link: 'https://clickhouse.com/docs/changelogs/25.8',
     version: '25.8',
     fast_date: 'Completed',
@@ -48,16 +59,5 @@ The release dates given below are an estimate and may be subject to change.
     regular_progress: 'green',
     slow_progress: 'green',
     regular_delay_note: 'Services with upgrade window will be upgraded starting Jan 07.',
-  },
-  {
-    changelog_link: 'https://clickhouse.com/docs/changelogs/25.10',
-    version: '25.10',
-    fast_date: '2025-12-11 (completed 2025-12-15)',
-    regular_date: '2026-01-07',
-    slow_date: 'TBD',
-    fast_progress: 'green',
-    regular_progress: 'green',
-    slow_progress: 'green',
-    fast_delay_note: 'Services with an upgrade window will receive 25.10 during their scheduled window in the week of Jan 05',
   }
 ]} />


### PR DESCRIPTION
## Summary
Updates 25.8 release status

  Current state:
  - fast channel upgrade: completed
  - regular channel without upgrade window: completed (2025-12-19)
  - Services with upgrade window (fast and regular): starting Jan 07
  - slow channel services: starting Jan 15

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
