### PR TITLE
Bug fix: "edit this page" directs to wrong repo for files which were previously in ClickHouse/ClickHouse

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -136,11 +136,11 @@ const config = {
           editUrl: ({ docPath }) => {
             if (docPath === "index.md") return false;
             if (
-              docPath.includes("development") ||
-              docPath.includes("engines") ||
-              docPath.includes("interfaces") ||
-              docPath.includes("operations") ||
-              docPath.includes("sql-reference")
+              docPath.startsWith("development/") ||
+              docPath.startsWith("engines/") ||
+              docPath.startsWith("interfaces/") ||
+              docPath.startsWith("operations/") ||
+              docPath.startsWith("sql-reference/")
             ) {
               return (
                 "https://github.com/ClickHouse/ClickHouse/tree/master/docs/en/" +


### PR DESCRIPTION
Files which were previously in ClickHouse/ClickHouse but which got moved across to ClickHouse/clickhouse-docs direct to the wrong repo when using the "edit this page" button. Fixes this.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
