### PR TITLE
Clarify upgrade process in Cloud overview page

### DIFF
--- a/docs/about-us/cloud.md
+++ b/docs/about-us/cloud.md
@@ -47,8 +47,8 @@ Some of the benefits of using ClickHouse Cloud are described below:
 
 ## What version of ClickHouse does ClickHouse Cloud use? {#what-version-of-clickhouse-does-clickhouse-cloud-use}
 
-Clickhouse Cloud continuously upgrades your service to a newer version. After publishing a core database version in the open source, we do additional validation in our cloud staging environment, which typically takes 6-8 weeks before rolling out to production. The rollout is phased out by cloud service provider, service type, and region.
+Clickhouse Cloud periodically upgrades your service to newer versions that include fixes, new features and performance improvements. After publishing a core database version in the open source, we do additional validation in our cloud staging environment, which typically takes 6-8 weeks before rolling out to production. The rollout is phased out by cloud service provider, service type, and region.
 
-We offer a "Fast" Release Channel for subscribing to updates ahead of the regular release schedule. For more details, see ["Fast Release Channel"](/manage/updates#fast-release-channel-early-upgrades).
+You can specify the upgrade schedule for your ClickHouse Cloud service by subscribing to a specific release channel. For example, we offer a ["Fast" Release Channel](/manage/updates#fast-release-channel-early-upgrades) for subscribing to updates ahead of the regular release schedule, as well as a ["Slow" Release Channel](/manage/updates#slow-release-channel-deferred-upgrades) and other more granular scheduling options for deferred upgrades.
 
-If you rely on functionality in the earlier version, you can, in some cases, revert to the previous behavior using your service's compatibility setting.
+For an overview of ClickHouse Cloud's upgrade process, including backwards compatibility guarantees, see the reference documentation for [Upgrades](/manage/updates).


### PR DESCRIPTION
## Summary

The current information about upgrades in the Cloud overview has some misleading points. Proposing a rephrase that better aligns with the language used in the reference documentation for upgrades.