### PR TITLE
Clarify init script execution order for Docker images

### DIFF
--- a/docs/getting-started/install/_snippets/_docker.md
+++ b/docs/getting-started/install/_snippets/_docker.md
@@ -180,7 +180,9 @@ docker run --rm -e CLICKHOUSE_SKIP_USER_SETUP=1 -p 9000:9000/tcp clickhouse/clic
 
 To perform additional initialization in an image derived from this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under `/docker-entrypoint-initdb.d`. After the entrypoint calls `initdb`, it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further initialization before starting the service.
 
-Note: Scripts under `/docker-entrypoint-initdb.d` are executed in **alphabetical order** by filename. If your scripts have dependencies on each other (for example, a script that creates views must run after the script that creates the referenced tables), ensure your filenames sort in the correct order.
+:::note
+Scripts under `/docker-entrypoint-initdb.d` are executed in **alphabetical order** by filename. If your scripts have dependencies on each other (for example, a script that creates views must run after the script that creates the referenced tables), ensure your filenames sort in the correct order.
+:::
 
 Also, you can provide environment variables `CLICKHOUSE_USER` & `CLICKHOUSE_PASSWORD` that will be used for clickhouse-client during initialization.
 


### PR DESCRIPTION
## Summary
Adds a note clarifying that init scripts in `/docker-entrypoint-initdb.d/` execute in alphabetical order.

## Motivation
When using multiple init scripts with dependencies (e.g., creating materialized views that reference tables), users encounter "Unknown table" errors if scripts aren't named correctly. 

This behavior comes from shell glob expansion in `entrypoint.sh` (`for f in /docker-entrypoint-initdb.d/*`) but wasn't documented.

## Changes
Added note about script execution order in Docker initialization.
