### PR TITLE
Change WHERE clause to exclude initial query ID

### DIFF
--- a/knowledgebase/find-expensive-queries.mdx
+++ b/knowledgebase/find-expensive-queries.mdx
@@ -158,7 +158,7 @@ SELECT
     ProfileEvents.Values[indexOf(ProfileEvents.Names, 'SystemTimeMicroseconds')] AS systemCPU,
     normalizedQueryHash(query) AS normalized_query_hash
 FROM clusterAllReplicas(default, system.query_log)
-WHERE (query_id = initial_query_id) AND (initial_query_id = 'a7262fa2-bd8b-4b51-a359-621ccf282417')
+WHERE (query_id != initial_query_id) AND (initial_query_id = 'a7262fa2-bd8b-4b51-a359-621ccf282417')
 ORDER BY memory_usage DESC
 LIMIT 10 FORMAT Pretty;
 ```


### PR DESCRIPTION
The query description says that query_id != initial_query_id should be used to return child queries, but the SQL example uses query_id = initial_query_id. The explanation and the query do not match. Changing the condition to query_id != initial_query_id fixes this inconsistency.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
