### PR TITLE
Update ClickHouse version in chDB documentation (v25.8.2.1)

### DIFF
--- a/docs/chdb/index.md
+++ b/docs/chdb/index.md
@@ -12,7 +12,7 @@ import dfBench from '@site/static/images/chdb/df_bench.png';
 
 # chDB
 
-chDB is a fast in-process SQL OLAP Engine powered by [ClickHouse](https://github.com/clickhouse/clickhouse).
+chDB is a fast in-process SQL OLAP Engine powered by [ClickHouse](https://github.com/clickhouse/clickhouse) v25.8.2.1.
 You can use it when you want to get the power of ClickHouse in a programming language without needing to connect to a ClickHouse server.
 
 ## Key features {#key-features}

--- a/i18n/jp/docusaurus-plugin-content-docs/current/chdb/index.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/chdb/index.md
@@ -12,7 +12,7 @@ import dfBench from '@site/static/images/chdb/df_bench.png';
 
 # chDB {#chdb}
 
-chDB は、[ClickHouse](https://github.com/clickhouse/clickhouse) を基盤とした、高速なインプロセス SQL OLAP エンジンです。
+chDB は、[ClickHouse](https://github.com/clickhouse/clickhouse) v25.8.2.1 を基盤とした、高速なインプロセス SQL OLAP エンジンです。
 ClickHouse サーバーに接続することなく、任意のプログラミング言語から ClickHouse のパワーを利用したい場合に使用できます。
 
 ## 主な機能 {#key-features}

--- a/i18n/ru/docusaurus-plugin-content-docs/current/chdb/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/chdb/index.md
@@ -12,7 +12,7 @@ import dfBench from '@site/static/images/chdb/df_bench.png';
 
 # chDB {#chdb}
 
-chDB — это быстрый встроенный SQL OLAP-движок на базе [ClickHouse](https://github.com/clickhouse/clickhouse).
+chDB — это быстрый встроенный SQL OLAP-движок на базе [ClickHouse](https://github.com/clickhouse/clickhouse) v25.8.2.1.
 Вы можете использовать его, когда вам нужна мощь ClickHouse в вашем коде, без необходимости подключаться к серверу ClickHouse.
 
 ## Ключевые возможности {#key-features}

--- a/i18n/zh/docusaurus-plugin-content-docs/current/chdb/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/chdb/index.md
@@ -12,7 +12,7 @@ import dfBench from '@site/static/images/chdb/df_bench.png';
 
 # chDB {#chdb}
 
-chDB 是一款由 [ClickHouse](https://github.com/clickhouse/clickhouse) 驱动的快速进程内 SQL OLAP 引擎。
+chDB 是一款由 [ClickHouse](https://github.com/clickhouse/clickhouse) v25.8.2.1 驱动的快速进程内 SQL OLAP 引擎。
 当你希望在程序中使用 ClickHouse 的强大功能，但又不想连接到 ClickHouse 服务器时，就可以使用 chDB。
 
 ## 关键特性 {#key-features}


### PR DESCRIPTION
## Summary
Update ClickHouse version in chDB documentation (v25.8.2.1).
Resolved https://github.com/chdb-io/chdb/issues/474

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
