### PR TITLE
Missing: add docs for `_request_body` param

### DIFF
--- a/docs/integrations/interfaces/http.md
+++ b/docs/integrations/interfaces/http.md
@@ -815,7 +815,7 @@ max_final_threads    2
 max_threads    1
 ```
 
-#### Virtual parameter `_request_body`
+#### Virtual parameter `_request_body` {#virtual-param-request-body}
 
 In addition to URL parameters, headers, and query parameters, `predefined_query_handler` supports a special virtual parameter `_request_body`.
 It contains the raw HTTP request body as a string.


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Add missing docs for functionality introduced in https://github.com/ClickHouse/ClickHouse/pull/47086
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
