### PR TITLE
Improvement: fix weird formatting

### DIFF
--- a/docs/native-protocol/columns.md
+++ b/docs/native-protocol/columns.md
@@ -6,6 +6,7 @@ description: 'Column types for the native protocol'
 keywords: ['native protocol columns', 'column types', 'data types', 'protocol data types', 'binary encoding']
 doc_type: 'reference'
 ---
+
 # Native protocol column types
 
 See [Data Types](/sql-reference/data-types/) for general reference.


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Improves weird formatting on this page.

Good example of a page which contributes to a worse search experience. The title is just "Column types" when the page is specifically about native protocol column types. A search for "Native protocol types" is unlikely to rank this page first for that reason.

Each data type is a header, which means that this page will show as a result whenever someone searches "Integer", "Float" etc, which is probably not what they want.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
