### PR TITLE
Don't minify bundle, generate source map

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,13 +44,13 @@ main() {
 
   if [[ -z "$locale" ]]; then
     echo "Building default Docusaurus (English)"
-    build_command="GENERATE_SOURCEMAP=false docusaurus build --locale en"
+    build_command="GENERATE_SOURCEMAP=true docusaurus build --locale en --no-minify"
   else
     echo "Setting locale to: $locale"
     export DOCUSUARUS_LOCALE="$locale"
 
     echo "Building Docusaurus en before $locale (currently required)"
-    build_command="GENERATE_SOURCEMAP=false docusaurus build --locale en"
+    build_command="GENERATE_SOURCEMAP=true docusaurus build --locale en --no-minify"
   fi
 
   # Append output directory if provided
@@ -68,7 +68,7 @@ main() {
 
   if [[ -n "$locale" ]]; then
     echo "Building Docusaurus with locale: $locale"
-    build_command="GENERATE_SOURCEMAP=false docusaurus build --locale $locale"
+    build_command="GENERATE_SOURCEMAP=true docusaurus build --locale $locale --no-minify"
 
     if [[ -n "$out_dir" ]]; then
       build_command+=" --out-dir $out_dir"


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Add flag to build to instruct it not to minify the bundle and to generate source map. Maybe we get more information about the issue in build logs.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
