### PR TITLE
Adding snippet for when to use json

### DIFF
--- a/docs/best-practices/_snippets/_when-to-use-json.md
+++ b/docs/best-practices/_snippets/_when-to-use-json.md
@@ -1,0 +1,28 @@
+## When to use the `JSON` Type {#when-to-use-json-type}
+
+The `JSON` type is designed for querying, filtering, and aggregating specific fields within JSON objects that have dynamic or unpredictable structures. It achieves this by splitting JSON objects into separate sub-columns, which dramatically reduces data read and speeds up queries on selected fields compared to alternatives like `Map` or parsing strings.
+
+**However, this comes with important trade-offs:**
+
+- Slower `INSERT`s - Splitting JSON into sub-columns, performing type inference, and managing flexible storage structures makes inserts slower compared to storing JSON as a simple `String` column.
+- Slower when reading entire objects - If you need to retrieve complete JSON documents (rather than specific fields), the `JSON` type is slower than reading from a `String` column. The overhead of reconstructing objects from separate sub-columns provides no benefit when you're not doing field-level queries.
+- Storage overhead - Maintaining separate sub-columns adds structural overhead compared to storing JSON as a single string value.
+
+### Use the `JSON` type when: {#use-json-type}
+
+- Your data has a dynamic or unpredictable structure with varying keys across documents
+- Field types or schemas change over time or vary between records
+- You need to query, filter, or aggregate on specific paths within JSON objects whose structure you cannot predict upfront
+- Your use case involves semi-structured data like logs, events, or user-generated content with inconsistent schemas
+
+### Use a `String` column (or structured types) when: {#use-string-type}
+- Your data structure is known and consistent - in this case, use normal columns, `Nested`, `Tuple`, `Array`, `Dynamic`, or `Variant` types instead
+- `JSON` documents are treated as opaque blobs that are only stored and retrieved in their entirety without field-level analysis
+- You don't need to query or filter on individual JSON fields within the database
+- The `JSON` is simply a transport/storage format, not analyzed within ClickHouse
+
+:::tip
+If `JSON` is an opaque document that is not analyzed inside the database, and only stored and retrieved back, it should be stored as a `String` field. The `JSON` type's benefits only materialize when you need to efficiently query, filter, or aggregate on specific fields within dynamic `JSON` structures.
+
+You can also mix approaches—use standard columns for predictable top-level fields and a `JSON` column for dynamic sections of the payload.
+:::

--- a/docs/best-practices/json_type.md
+++ b/docs/best-practices/json_type.md
@@ -9,23 +9,11 @@ show_related_blogs: true
 doc_type: 'reference'
 ---
 
+import WhenToUseJson from '@site/docs/best-practices/_snippets/_when-to-use-json.md';
+
 ClickHouse now offers a native JSON column type designed for semi-structured and dynamic data. It's important to clarify that **this is a column type, not a data format**—you can insert JSON into ClickHouse as a string or via supported formats like [JSONEachRow](/interfaces/formats/JSONEachRow), but that doesn't imply using the JSON column type. You should only use the JSON type when the structure of your data is dynamic, not when you simply happen to store JSON.
 
-## When to use the JSON type {#when-to-use-the-json-type}
-
-Use the JSON type when your data:
-
-* Has **unpredictable keys** that can change over time.
-* Contains **values with varying types** (e.g., a path might sometimes contain a string, sometimes a number).
-* Requires schema flexibility where strict typing isn't viable.
-
-If your data structure is known and consistent, there is rarely a need for the JSON type, even if your data is in JSON format. Specifically, if your data has:
-
-* **A flat structure with known keys**: use standard column types e.g. String.
-* **Predictable nesting**: use Tuple, Array, or Nested types for these structures.
-* **Predictable structure with varying types**: consider Dynamic or Variant types instead.
-
-You can also mix approaches—for example, use static columns for predictable top-level fields and a single JSON column for a dynamic section of the payload.
+<WhenToUseJson />
 
 ## Considerations and tips for using JSON {#considerations-and-tips-for-using-json}
 


### PR DESCRIPTION
## Summary
Documentation was added for when to use JSON in the newJson datatype documentation, it was pointed out that there is overlap with what's already mentioned in our best practices doc, so a snippet has been created.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
