### PR TITLE
Fix typo in clickhouse-local.md session initialization

### DIFF
--- a/docs/chdb/guides/clickhouse-local.md
+++ b/docs/chdb/guides/clickhouse-local.md
@@ -97,7 +97,7 @@ Go back to the `ipython` shell and import the `session` module from chDB:
 from chdb import session as chs
 ```
 
-Initialize a session pointing to `demo..chdb`:
+Initialize a session pointing to `demo.chdb`:
 
 ```python
 sess = chs.Session("demo.chdb")


### PR DESCRIPTION
## Summary
Fixed a typo in the chdb clickhouse-local documentation referencing an incorrect file name. 

Sorry for the very small PR, but I just noticed this typo and wanted to fix it. :)

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
