### PR TITLE
chore(docs): remove outdated note

### DIFF
--- a/docs/cloud/guides/production-readiness.md
+++ b/docs/cloud/guides/production-readiness.md
@@ -119,7 +119,7 @@ provider "clickhouse" {
 }
 ```
 
-The Terraform provider supports service provisioning, IP access lists, and user management. Note that the provider does not currently support importing existing services or explicit backup configuration. For features not covered by the provider, manage them through the console or contact ClickHouse support.
+The Terraform provider supports service provisioning, IP access lists, and user management. For features not covered by the provider, manage them through the console or contact ClickHouse support.
 
 For comprehensive examples including service configuration and network access controls, see [Terraform example on how to use Cloud API](/knowledgebase/terraform_example).
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Remove outdated note. Terraform provider supports service imports, including backup configurations: https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/service#import

## Checklist
- [x] Delete items not relevant to your PR
