### PR TITLE
Add `LIMIT`s to TPC-H queries 2, 3, 10, 18 and 21

### DIFF
--- a/docs/getting-started/example-datasets/tpch.md
+++ b/docs/getting-started/example-datasets/tpch.md
@@ -676,33 +676,33 @@ WHERE
 **Q15**
 
 ```sql
-with revenue_view as (
-    select
-        l_suppkey as supplier_no,
-        sum(l_extendedprice * (1 - l_discount)) as total_revenue
-    from
+WITH revenue_view AS (
+    SELECT
+        l_suppkey AS supplier_no,
+        sum(l_extendedprice * (1 - l_discount)) AS total_revenue
+    FROM
         lineitem
-    where
+    WHERE
         l_shipdate >= '1996-01-01'
-      and l_shipdate < '1996-04-01'
-    group by
+      AND l_shipdate < '1996-04-01'
+    GROUP BY
         l_suppkey)
-select
+SELECT
     s_suppkey,
     s_name,
     total_revenue
-from
+FROM
     supplier,
     revenue_view
-where
+WHERE
     s_suppkey = supplier_no
-    and total_revenue = (
-        select
+    AND total_revenue = (
+        SELECT
             max(total_revenue)
-        from
+        FROM
             revenue_view
     )
-order by
+ORDER BY
     s_suppkey;
 ```
 


### PR DESCRIPTION
## Summary
[The document](https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf) that defines TPC-H benchmark does not have `LIMIT` statements in some of the queries. But in paragraph 2.1.2.9, they ask to add them for queries 2, 3, 10, 18 and 21, which we do in this PR. 

Also, a cosmetic improvement for Q15.