### PR TITLE
ClickPipes: add new ClickPipes EU region (`eu-west-1`)

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/index.md
@@ -63,17 +63,19 @@ More connectors will get added to ClickPipes, you can find out more by [contacti
 The following are the static NAT IPs (separated by region) that ClickPipes uses to connect to your external services. Add your related instance region IPs to your IP allow list to allow traffic. In the case of object storage pipes you should also add the [ClickHouse cluster IPs](/manage/data-sources/cloud-endpoints-api) to your IP allow list.
 
 For all services, ClickPipes traffic will originate from a default region based on your service's location:
-- **eu-central-1**: For all services in EU regions. (this includes GCP and Azure EU regions)
+- **eu-central-1**: For all EU regions not explicitly listed (including GCP and Azure EU regions).
+- **eu-west-1**: For all services in AWS `eu-west-1` created on or after 20 Jan 2026 (services created before this date use `eu-central-1` IPs).
 - **us-east-1**: For all services in AWS `us-east-1`.
 - **ap-south-1**: For services in AWS `ap-south-1` created on or after 25 Jun 2025 (services created before this date use `us-east-2` IPs).
 - **ap-northeast-2**: For services in AWS `ap-northeast-2` created on or after 14 Nov 2025 (services created before this date use `us-east-2` IPs).
 - **ap-southeast-2**: For services in AWS `ap-southeast-2` created on or after 25 Jun 2025 (services created before this date use `us-east-2` IPs).
 - **us-west-2**: For services in AWS `us-west-2` created on or after 24 Jun 2025 (services created before this date use `us-east-2` IPs).
-- **us-east-2**: For all other regions not explicitly listed. (this includes GCP and Azure US regions)
+- **us-east-2**: For all other regions not explicitly listed (including GCP and Azure regions).
 
 | AWS region                            | IP Addresses                                                                                                                                     |
 |---------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **eu-central-1**                      | `18.195.233.217`, `3.127.86.90`, `35.157.23.2`, `18.197.167.47`, `3.122.25.29`, `52.28.148.40`                                                       |
+| **eu-west-1** (from 20 Jan 2026)      | `54.228.1.92` , `54.72.101.254`, `54.228.16.208`, `54.76.200.104`, `52.211.2.177`, `54.77.10.134`                                                      |
 | **us-east-1**                         | `54.82.38.199`, `3.90.133.29`, `52.5.177.8`, `3.227.227.145`, `3.216.6.184`, `54.84.202.92`, `3.131.130.196`, `3.23.172.68`, `3.20.208.150`      |
 | **us-east-2**                         | `3.131.130.196`, `3.23.172.68`, `3.20.208.150`, `3.132.20.192`, `18.119.76.110`, `3.134.185.180`                                                     |
 | **ap-south-1** (from 25 Jun 2025)     | `13.203.140.189`, `13.232.213.12`, `13.235.145.208`, `35.154.167.40`, `65.0.39.245`, `65.1.225.89`                                                   |


### PR DESCRIPTION
## Summary
New region available as of Jan. 20th 2026.
