### PR TITLE
Improve Managed Postgres quickstart with clearer value prop and structure

### DIFF
--- a/docs/cloud/managed-postgres/quickstart.md
+++ b/docs/cloud/managed-postgres/quickstart.md
@@ -2,8 +2,8 @@
 slug: /cloud/managed-postgres/quickstart
 sidebar_label: 'Quickstart'
 title: 'Quickstart'
-description: 'Create your first Managed Postgres database and explore the instance dashboard'
-keywords: ['managed postgres', 'quickstart', 'getting started', 'create database']
+description: 'Experience NVMe-powered Postgres performance and add real-time analytics with native ClickHouse integration'
+keywords: ['managed postgres', 'quickstart', 'getting started', 'create database', 'nvme', 'performance']
 doc_type: 'guide'
 ---
 
@@ -20,11 +20,26 @@ import analyticsList from '@site/static/images/managed-postgres/analytics-list.p
 import replicatedTables from '@site/static/images/managed-postgres/replicated-tables.png';
 
 # Quickstart for Managed Postgres
-This is a quickstart guide to help you create your first Managed Postgres service and integrate it with ClickHouse. Having an existing ClickHouse instance will help you explore the full capabilities of Managed Postgres.
+
+ClickHouse Managed Postgres is enterprise-grade Postgres backed by NVMe storage, delivering up to 10x faster performance for disk-bound workloads compared to network-attached storage like EBS. This quickstart is divided into two parts:
+
+- **Part 1:** Get started with NVMe Postgres and experience its performance
+- **Part 2:** Unlock real-time analytics by integrating with ClickHouse
+
+Managed Postgres is currently available on AWS in several regions and is free during private preview.
 
 <PrivatePreviewBadge/>
 
-## Create a database {#create-postgres-database}
+**In this quickstart, you will:**
+- Create a Managed Postgres instance with NVMe-powered performance
+- Load 1 million sample events and see NVMe speed in action
+- Run queries and experience low-latency performance
+- Replicate data to ClickHouse for real-time analytics
+- Query ClickHouse directly from Postgres using `pg_clickhouse`
+
+## Part 1: Get Started with NVMe Postgres {#part-1}
+
+### Create a database {#create-postgres-database}
 
 To create a new Managed Postgres service, click on the **New service** button in the service list of the Cloud Console. You should then be able to select Postgres as the database type.
 
@@ -34,16 +49,25 @@ Enter a name for your database instance and click on **Create service**. You wil
 
 <Image img={pgOverview} alt="Managed Postgres overview" size="md" border/>
 
-Your Managed Postgres instance will be provisioned and ready for use in a few minutes.
+Your Managed Postgres instance will be provisioned and ready for use in 3-5 minutes.
 
-## Connect and have some data ready {#connect-and-data}
+### Connect to your database {#connect}
+
 In the sidebar on the left, you will see a [**Connect** button](/cloud/managed-postgres/connection). Click on it to view your connection details and connection strings in multiple formats.
 
 <Image img={connectModal} alt="Managed Postgres connect modal" size="md" border/>
 
-You can copy the connection string in your preferred format and use it to connect to your database using any Postgres-compatible client such as `psql`, DBeaver, or any application  library.
+Copy the `psql` connection string and connect to your database. You can also use any Postgres-compatible client such as DBeaver, or any application library.
 
-To get started quickly, you can use the following SQL commands to create two sample tables and insert some data:
+### Experience NVMe performance {#nvme-performance}
+
+Let's see NVMe-powered performance in action. First, enable timing in psql to measure query execution:
+
+```sql
+\timing
+```
+
+Create two sample tables for events and users:
 
 ```sql
 CREATE TABLE events (
@@ -58,6 +82,7 @@ CREATE TABLE events (
    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
 CREATE TABLE users (
    user_id SERIAL PRIMARY KEY,
    name VARCHAR(100),
@@ -66,17 +91,18 @@ CREATE TABLE users (
 );
 ```
 
-Let's insert into the events table:
+Now, insert 1 million events and watch the NVMe speed:
+
 ```sql
 INSERT INTO events (event_name, event_type, event_timestamp, event_data, user_id, user_ip)
 SELECT
    'Event ' || gs::text AS event_name,
    CASE
-       WHEN random() < 0.5 THEN 'click'          -- 50% chance
-       WHEN random() < 0.75 THEN 'view'          -- 25% chance
-       WHEN random() < 0.9 THEN 'purchase'       -- 15% chance
-       WHEN random() < 0.98 THEN 'signup'        -- 8% chance
-       ELSE 'logout'                             -- 2% chance
+       WHEN random() < 0.5 THEN 'click'
+       WHEN random() < 0.75 THEN 'view'
+       WHEN random() < 0.9 THEN 'purchase'
+       WHEN random() < 0.98 THEN 'signup'
+       ELSE 'logout'
    END AS event_type,
    NOW() - INTERVAL '1 day' * (gs % 365) AS event_timestamp,
    jsonb_build_object('key', 'value' || gs::text, 'additional_info', 'info_' || (gs % 100)::text) AS event_data,
@@ -86,16 +112,23 @@ FROM
    generate_series(1, 1000000) gs;
 ```
 
-And then insert into the users table:
+```text
+INSERT 0 1000000
+Time: 3596.542 ms (00:03.597)
+```
+
+:::tip NVMe Performance
+1 million rows with JSONB data inserted in under 4 seconds. On traditional cloud databases using network-attached storage like EBS, this same operation typically takes 2-3x longer due to network round-trip latency and IOPS throttling. NVMe storage eliminates these bottlenecks by keeping storage physically attached to the compute.
+
+Performance varies based on instance size, current load, and data characteristics.
+:::
+
+Insert 1,000 users:
+
 ```sql
-INSERT INTO
-    users (
-        NAME,
-        country,
-        platform
-    )
+INSERT INTO users (name, country, platform)
 SELECT
-    first_names [first_idx] || ' ' || last_names [last_idx] AS NAME,
+    first_names[first_idx] || ' ' || last_names[last_idx] AS name,
     CASE
         WHEN random() < 0.25 THEN 'India'
         WHEN random() < 0.5 THEN 'USA'
@@ -113,19 +146,103 @@ SELECT
     END AS platform
 FROM
     generate_series(1, 1000) AS seq
-    CROSS JOIN lateral (
+    CROSS JOIN LATERAL (
         SELECT
-            array ['Alice', 'Bob', 'Charlie', 'Diana', 'Eve', 'Frank', 'Grace', 'Hank', 'Ivy', 'Jack',                 'Liam', 'Olivia', 'Noah', 'Emma', 'Sophia', 'Benjamin', 'Isabella', 'Lucas', 'Mia', 'Amelia',                 'Aarav', 'Riya', 'Arjun', 'Ananya', 'Wei', 'Li', 'Huan', 'Mei', 'Hans', 'Klaus', 'Greta', 'Sofia'] AS first_names,
-            array ['Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Garcia', 'Miller', 'Davis', 'Martinez', 'Taylor',                 'Anderson', 'Thomas', 'Jackson', 'White', 'Harris', 'Martin', 'Thompson', 'Moore', 'Lee', 'Perez',                 'Sharma', 'Patel', 'Gupta', 'Reddy', 'Zhang', 'Wang', 'Chen', 'Liu', 'Schmidt', 'Müller', 'Weber', 'Fischer'] AS last_names,
+            array['Alice', 'Bob', 'Charlie', 'Diana', 'Eve', 'Frank', 'Grace', 'Hank', 'Ivy', 'Jack', 'Liam', 'Olivia', 'Noah', 'Emma', 'Sophia', 'Benjamin', 'Isabella', 'Lucas', 'Mia', 'Amelia', 'Aarav', 'Riya', 'Arjun', 'Ananya', 'Wei', 'Li', 'Huan', 'Mei', 'Hans', 'Klaus', 'Greta', 'Sofia'] AS first_names,
+            array['Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Garcia', 'Miller', 'Davis', 'Martinez', 'Taylor', 'Anderson', 'Thomas', 'Jackson', 'White', 'Harris', 'Martin', 'Thompson', 'Moore', 'Lee', 'Perez', 'Sharma', 'Patel', 'Gupta', 'Reddy', 'Zhang', 'Wang', 'Chen', 'Liu', 'Schmidt', 'Müller', 'Weber', 'Fischer'] AS last_names,
             1 + (seq % 32) AS first_idx,
-            1 + ((seq / 32) :: int % 32) AS last_idx
+            1 + ((seq / 32)::int % 32) AS last_idx
     ) AS names;
 ```
 
-## Setup integration with ClickHouse {#setup-integrate-clickhouse}
+### Run queries on your data {#run-queries}
+
+Now let's run some queries to see how fast Postgres responds with NVMe storage.
+
+**Aggregate 1 million events by type:**
+
+```sql
+SELECT event_type, COUNT(*) as count 
+FROM events 
+GROUP BY event_type 
+ORDER BY count DESC;
+```
+
+```text
+ event_type | count  
+------------+--------
+ click      | 499523
+ view       | 375644
+ purchase   | 112473
+ signup     |  12117
+ logout     |    243
+(5 rows)
+
+Time: 114.883 ms
+```
+
+**Query with JSONB filtering and date range:**
+
+```sql
+SELECT COUNT(*) 
+FROM events 
+WHERE event_timestamp > NOW() - INTERVAL '30 days'
+  AND event_data->>'additional_info' LIKE 'info_5%';
+```
+
+```text
+ count 
+-------
+  9042
+(1 row)
+
+Time: 109.294 ms
+```
+
+**Join events with users:**
+
+```sql
+SELECT u.country, COUNT(*) as events, AVG(LENGTH(e.event_data::text))::int as avg_json_size
+FROM events e
+JOIN users u ON e.user_id = u.user_id
+GROUP BY u.country
+ORDER BY events DESC;
+```
+
+```text
+ country | events | avg_json_size 
+---------+--------+---------------
+ USA     | 383748 |            52
+ India   | 255990 |            52
+ Germany | 223781 |            52
+ China   | 127754 |            52
+ Other   |   8727 |            52
+(5 rows)
+
+Time: 224.670 ms
+```
+
+:::note Your Postgres is ready
+At this point, you have a fully functional, high-performance Postgres database ready for your transactional workloads.
+
+Continue to Part 2 to see how native ClickHouse integration can supercharge your analytics.
+:::
+
+---
+
+## Part 2: Add Real-Time Analytics with ClickHouse {#part-2}
+
+While Postgres excels at transactional workloads (OLTP), ClickHouse is purpose-built for analytical queries (OLAP) on large datasets. By integrating the two, you get the best of both worlds:
+
+- **Postgres** for your application's transactional data (inserts, updates, point lookups)
+- **ClickHouse** for sub-second analytics on billions of rows
+
+This section shows you how to replicate your Postgres data to ClickHouse and query it seamlessly.
+
+### Setup ClickHouse integration {#setup-integrate-clickhouse}
 Now that we have tables and data in Postgres, let's replicate the tables to ClickHouse for analytics. We start by clicking on **ClickHouse integration** in the sidebar. Then you can click on **Replicate data in ClickHouse**.
 <Image img={integrationLanding} alt="Managed Postgres integration empty" size="md" border/>
-In the form that follows, you can enter a name for your integration and select an existing ClickHouse instance to replicate to. If you don't have a ClickHouse instance yet, you can create one by following the [Quickstart for ClickHouse Cloud](/cloud/clickhouse-cloud/quickstart) guide.
+In the form that follows, you can enter a name for your integration and select an existing ClickHouse instance to replicate to. If you don't have a ClickHouse instance yet, you can create one directly from this form.
 :::warning Important
 Make sure the ClickHouse service you select is Running before proceeding.
 :::
@@ -140,20 +257,24 @@ Click on **Next**, to be taken to the table picker. Here all you need to do is:
 
 The replication process will start, and you will be taken to the integration overview page. Being the first integration, it can take 2-3 minutes to setup the initial infrastructure. In the meantime let's check out the new **pg_clickhouse** extension.
 
-## pg_clickhouse extension {#pg-clickhouse-extension}
-**pg_clickhouse** is a Postgres extension we built which enables you to query ClickHouse data from a Postgres interface. A full introduction can be found [here](integrations/pg_clickhouse#introduction). To use the extension, connect to your Managed Postgres instance using any Postgres-compatible client and run the following SQL commands:
+### Query ClickHouse from Postgres {#pg-clickhouse-extension}
+
+The `pg_clickhouse` extension lets you query ClickHouse data directly from Postgres using standard SQL. This means your application can use Postgres as a unified query layer for both transactional and analytical data. See the [full documentation](/integrations/pg_clickhouse) for details.
+
+Enable the extension:
 
 ```sql
 CREATE EXTENSION pg_clickhouse;
 ```
 
-Then, we create what is known as a foreign data wrapper (FDW) to connect to ClickHouse:
+Then, create a foreign server connection to ClickHouse. Use the `http` driver with port `8443` for secure connections:
 
 ```sql
 CREATE SERVER ch FOREIGN DATA WRAPPER clickhouse_fdw
-       OPTIONS(driver 'binary', host '<clickhouse_cloud_host>', dbname 'default');
+       OPTIONS(driver 'http', host '<clickhouse_cloud_host>', dbname '<database_name>', port '8443');
 ```
-You can get the host for the above by going to your ClickHouse service, clicking on Connect in the sidebar, and choosing Native.
+
+Replace `<clickhouse_cloud_host>` with your ClickHouse hostname and `<database_name>` with the database you selected during replication setup. You can find the hostname in your ClickHouse service by clicking **Connect** in the sidebar.
 
 <Image img={getClickHouseHost} alt="Get ClickHouse host" size="md" border/>
 
@@ -162,18 +283,117 @@ Now, we map the Postgres user to the ClickHouse service's credentials:
 CREATE USER MAPPING FOR CURRENT_USER SERVER ch 
 OPTIONS (user 'default', password '<clickhouse_password>');
 ```
-It's time to import data! Add the `organization` schema, just import it all of the tables from the remote ClickHouse database into a Postgres schema:
+Now import the ClickHouse tables into a Postgres schema:
+
 ```sql
 CREATE SCHEMA organization;
-IMPORT FOREIGN SCHEMA "default" FROM SERVER ch INTO organization;
+IMPORT FOREIGN SCHEMA "<database_name>" FROM SERVER ch INTO organization;
 ```
-Done! You can now see all the ClickHouse tables in your Postgres client:
+
+Replace `<database_name>` with the same database name you used when creating the server.
+
+You can now see all the ClickHouse tables in your Postgres client:
+
 ```sql
-postgres=# \det+ organization.*
+\det+ organization.*
 ```
-## Analytics after integration {#analytics-after-integration}
-Let's check back in on the integration page. You should see that the initial replication is complete. You can click on the name of the integration to view more details on it.
+
+### See your analytics in action {#analytics-after-integration}
+
+Let's check back on the integration page. You should see that the initial replication is complete. Click on the integration name to view details.
+
 <Image img={analyticsList} alt="Managed Postgres analytics list" size="md" border/>
 
-If you click on the service name, you will be taken to the ClickHouse console where you can see the two tables we replicated.
+Click on the service name to open the ClickHouse console and see your replicated tables.
+
 <Image img={replicatedTables} alt="Managed Postgres replicated tables in ClickHouse" size="md" border/>
+
+### Compare Postgres vs ClickHouse performance {#performance-comparison}
+
+Now let's run some analytical queries and compare performance between Postgres and ClickHouse. Note that replicated tables use the naming convention `public_<table_name>`.
+
+**Query 1: Top users by activity**
+
+This query finds the most active users with multiple aggregations:
+
+```sql
+-- Via ClickHouse
+SELECT 
+    user_id,
+    COUNT(*) as total_events,
+    COUNT(DISTINCT event_type) as unique_event_types,
+    SUM(CASE WHEN event_type = 'purchase' THEN 1 ELSE 0 END) as purchases,
+    MIN(event_timestamp) as first_event,
+    MAX(event_timestamp) as last_event
+FROM organization.public_events
+GROUP BY user_id
+ORDER BY total_events DESC
+LIMIT 10;
+```
+
+```text
+ user_id | total_events | unique_event_types | purchases |        first_event         |         last_event         
+---------+--------------+--------------------+-----------+----------------------------+----------------------------
+       1 |        31439 |                  5 |      3551 | 2025-01-22 22:40:45.612281 | 2026-01-21 22:40:45.612281
+       2 |        13235 |                  4 |      1492 | 2025-01-22 22:40:45.612281 | 2026-01-21 22:40:45.612281
+...
+(10 rows)
+
+Time: 163.898 ms   -- ClickHouse
+Time: 554.621 ms   -- Same query on Postgres
+```
+
+**Query 2: User engagement by country and platform**
+
+This query joins events with users and computes engagement metrics:
+
+```sql
+-- Via ClickHouse
+SELECT 
+    u.country,
+    u.platform,
+    COUNT(DISTINCT e.user_id) as users,
+    COUNT(*) as total_events,
+    ROUND(COUNT(*)::numeric / COUNT(DISTINCT e.user_id), 2) as events_per_user,
+    SUM(CASE WHEN e.event_type = 'purchase' THEN 1 ELSE 0 END) as purchases
+FROM organization.public_events e
+JOIN organization.public_users u ON e.user_id = u.user_id
+GROUP BY u.country, u.platform
+ORDER BY total_events DESC
+LIMIT 10;
+```
+
+```text
+ country | platform | users | total_events | events_per_user | purchases 
+---------+----------+-------+--------------+-----------------+-----------
+ USA     | Android  |   115 |       109977 |             956 |     12388
+ USA     | Web      |   108 |       105057 |             972 |     11847
+ USA     | iOS      |    83 |        84594 |            1019 |      9565
+ Germany | Android  |    85 |        77966 |             917 |      8852
+ India   | Android  |    80 |        68095 |             851 |      7724
+...
+(10 rows)
+
+Time: 170.353 ms   -- ClickHouse
+Time: 1245.560 ms  -- Same query on Postgres
+```
+
+**Performance comparison:**
+
+| Query | Postgres (NVMe) | ClickHouse (via pg_clickhouse) | Speedup |
+|-------|-----------------|-------------------------------|---------|
+| Top users (5 aggregations) | 555 ms | 164 ms | 3.4x |
+| User engagement (JOIN + aggregations) | 1,246 ms | 170 ms | 7.3x |
+
+:::tip When to use ClickHouse
+Even on this 1M row dataset, ClickHouse delivers 3-7x faster performance on complex analytical queries with JOINs and multiple aggregations. The difference becomes even more dramatic at larger scales (100M+ rows), where ClickHouse's columnar storage and vectorized execution can deliver 10-100x speedups.
+
+Query times vary based on instance size, network latency between services, data characteristics, and current load.
+:::
+
+## Cleanup {#cleanup}
+
+To delete the resources created in this quickstart:
+
+1. First, delete the ClickPipe integration from the ClickHouse service
+2. Then, delete the Managed Postgres instance from the Cloud Console


### PR DESCRIPTION
- Add "What You'll Learn" section with clear objectives
- Update intro with value proposition (NVMe performance, native ClickHouse integration)
- Mention free during private preview and AWS availability
- Change provisioning time from vague "few minutes" to "3-5 minutes"
- Simplify ClickHouse instance creation note (can create inline)
- Add cleanup instructions section
