### PR TITLE
Fix grant commands in Postgres guides

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/alloydb.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/alloydb.md
@@ -80,7 +80,7 @@ Connect to your AlloyDB instance as an admin user and execute the following comm
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/azure-flexible-server-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/azure-flexible-server-postgres.md
@@ -57,7 +57,7 @@ Connect to your Azure Flexible Server Postgres through the admin user and run th
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/crunchy-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/crunchy-postgres.md
@@ -49,7 +49,7 @@ Connect to your Crunchy Bridge Postgres through the `postgres` user and run the 
 3. Grant replication privileges to the user:
 
     ```sql
-     ALTER ROLE clickpipes_user REPLICATION;
+     ALTER USER clickpipes_user WITH REPLICATION;
     ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/generic.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/generic.md
@@ -76,7 +76,7 @@ Connect to your Postgres instance as an admin user and execute the following com
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/google-cloudsql.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/google-cloudsql.md
@@ -67,7 +67,7 @@ Connect to your Cloud SQL Postgres through the admin user and run the below comm
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/neon-postgres.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/neon-postgres.md
@@ -42,7 +42,7 @@ Connect to your Neon instance as an admin user and execute the following command
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/planetscale.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/planetscale.md
@@ -69,7 +69,7 @@ Connect to your PlanetScale Postgres instance using the default `postgres.<...>`
 3. Grant replication privileges to the user:
 
     ```sql
-    GRANT rds_replication TO clickpipes_user;
+    ALTER USER clickpipes_user WITH REPLICATION;
     ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/supabase.md
@@ -45,7 +45,7 @@ Connect to your Supabase instance as an admin user and execute the following com
 3. Grant replication privileges to the user:
 
    ```sql
-   ALTER ROLE clickpipes_user REPLICATION;
+   ALTER USER clickpipes_user WITH REPLICATION;
    ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/source/timescale.md
@@ -84,7 +84,7 @@ If you'd like to only perform a one-time load of your data (`Initial Load Only`)
 3. Grant replication privileges to the user:
 
     ```sql
-    GRANT rds_replication TO clickpipes_user;
+    ALTER USER clickpipes_user WITH REPLICATION;
     ```
 
 4. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate. We strongly recommend only including the tables you need in the publication to avoid performance overhead.
@@ -106,13 +106,6 @@ If you'd like to only perform a one-time load of your data (`Initial Load Only`)
       ```
 
    The `clickpipes` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
-
-3. Grant replication permissions to the user created earlier.
-
-```sql
--- Give replication permission to the USER
-  ALTER USER clickpipes_user REPLICATION;
-```
 
 After these steps, you should be able to proceed with [creating a ClickPipe](../index.md).
 


### PR DESCRIPTION
## Summary
Fixing some copypasta from bulk-updating Postgres guides in #5127, and standardizing on `ALTER USER` instead of a mix of `ALTER USER` and `ALTER ROLE` across all guides.