### PR TITLE
Managed Postgres: Add private preview link to top of quickstart

### DIFF
--- a/docs/cloud/managed-postgres/quickstart.md
+++ b/docs/cloud/managed-postgres/quickstart.md
@@ -20,7 +20,7 @@ import analyticsList from '@site/static/images/managed-postgres/analytics-list.p
 import replicatedTables from '@site/static/images/managed-postgres/replicated-tables.png';
 
 # Quickstart for Managed Postgres
-:::tip Now available!
+:::tip Now available
 Managed Postgres is now available in ClickHouse Cloud in Private Preview! Get started in minutes by clicking [here](https://clickhouse.com/cloud/postgres).
 :::
 


### PR DESCRIPTION
## Summary
Adds a link pointing to https://clickhouse.com/cloud/postgres at the top of Managed Postgres quickstart.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
