### PR TITLE
Managed Postgres: link and track private preview badges

### DIFF
--- a/docs/cloud/managed-postgres/backup-and-restore.md
+++ b/docs/cloud/managed-postgres/backup-and-restore.md
@@ -11,7 +11,7 @@ import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 import Image from '@theme/IdealImage';
 import backupAndRestore from '@site/static/images/managed-postgres/backup-and-restore.png';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="backup-and-restore" />
 
 Managed Postgres ensures the safety and availability of your data through automated backups and point-in-time recovery. You can view your backup history and initiate restores from the **Backups** view of your instance.
 

--- a/docs/cloud/managed-postgres/clickhouse-integration.md
+++ b/docs/cloud/managed-postgres/clickhouse-integration.md
@@ -14,7 +14,7 @@ import replicationServiceStep from '@site/static/images/managed-postgres/replica
 import selectTablesStep from '@site/static/images/managed-postgres/select-tables-step.png';
 import integrationRunning from '@site/static/images/managed-postgres/integration-running.png';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="clickhouse-integration" />
 
 Every Managed Postgres instance comes with built-in CDC capabilities to any of your ClickHouse services. This allows you to move some or all of the data on your Postgres instance to ClickHouse and have changes in data on Postgres be reflected on ClickHouse continous and nearly real-time. This is powered by [ClickPipes](/integrations/clickpipes) under the hood.
 

--- a/docs/cloud/managed-postgres/connection.md
+++ b/docs/cloud/managed-postgres/connection.md
@@ -13,7 +13,7 @@ import connectButton from '@site/static/images/managed-postgres/connect-button.p
 import connectModal from '@site/static/images/managed-postgres/connect-modal.png';
 import tlsCaBundle from '@site/static/images/managed-postgres/tls-ca-bundle.png';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="connection" />
 
 ## Accessing connection details {#accessing-connection-details}
 

--- a/docs/cloud/managed-postgres/extensions.md
+++ b/docs/cloud/managed-postgres/extensions.md
@@ -9,7 +9,7 @@ doc_type: 'guide'
 
 import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="extensions" />
 
 Managed Postgres includes a curated set of extensions to extend the functionality of your database. Below is the list of available extensions.
 

--- a/docs/cloud/managed-postgres/high-availability.md
+++ b/docs/cloud/managed-postgres/high-availability.md
@@ -10,7 +10,7 @@ doc_type: 'guide'
 import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 import Image from '@theme/IdealImage';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="high-availability" />
 
 Managed Postgres offers different levels of high availability to match your durability and performance requirements. You can add one or two standby replicas when provisioning your database, or adjust this configuration later from the **Settings** page as needed.
 

--- a/docs/cloud/managed-postgres/migrations/pg_dump-pg_restore.md
+++ b/docs/cloud/managed-postgres/migrations/pg_dump-pg_restore.md
@@ -18,7 +18,7 @@ import targetSetup from '@site/static/images/managed-postgres/pg_dump_restore/ta
 # Migrate to Managed Postgres using pg_dump and pg_restore {#pg-dump-pg-restore}
 This guide provides step-by-step instructions on how to migrate your PostgreSQL database to ClickHouse Managed Postgres using the `pg_dump` and `pg_restore` utilities.
 
-<PrivatePreviewBadge />
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="pg_dump-pg_restore" />
 
 ## Prerequisites {#migration-pgdump-pg-restore-prerequisites}
 - Access to your source PostgreSQL database.

--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -9,7 +9,7 @@ doc_type: 'guide'
 import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 import Image from '@theme/IdealImage';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="overview" />
 
 ClickHouse Managed Postgres is an enterprise-grade managed Postgres service built for performance and scale. Backed by NVMe storage that is physically colocated with compute, it delivers up to 10x faster performance for workloads that are disk-bound compared to alternatives using network-attached storage like EBS.
 

--- a/docs/cloud/managed-postgres/quickstart.md
+++ b/docs/cloud/managed-postgres/quickstart.md
@@ -20,9 +20,8 @@ import analyticsList from '@site/static/images/managed-postgres/analytics-list.p
 import replicatedTables from '@site/static/images/managed-postgres/replicated-tables.png';
 
 # Quickstart for Managed Postgres
-:::tip Now available
-Managed Postgres is now available in ClickHouse Cloud in Private Preview! Get started in minutes by clicking [here](https://clickhouse.com/cloud/postgres).
-:::
+
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="quick-start" />
 
 ClickHouse Managed Postgres is enterprise-grade Postgres backed by NVMe storage, delivering up to 10x faster performance for disk-bound workloads compared to network-attached storage like EBS. This quickstart is divided into two parts:
 

--- a/docs/cloud/managed-postgres/read-replicas.md
+++ b/docs/cloud/managed-postgres/read-replicas.md
@@ -12,7 +12,7 @@ import Image from '@theme/IdealImage';
 import warehouseView from '@site/static/images/managed-postgres/warehouse-view.png';
 import readReplicaDialog from '@site/static/images/managed-postgres/read-replica-dialog.png';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="read-replicas" />
 
 Read replicas allow you to create one or more copies of your primary Managed Postgres database. These replicas continuously follow your primary database using PostgreSQL's native replication to stay up to date with changes.
 

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -13,7 +13,7 @@ import postgresParameters from '@site/static/images/managed-postgres/postgres-pa
 import serviceActions from '@site/static/images/managed-postgres/service-actions.png';
 import ipFilters from '@site/static/images/managed-postgres/ip-filters.png';
 
-<PrivatePreviewBadge/>
+<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="settings" />
 
 You can modify configuration parameters and manage instance settings for your Managed Postgres instance through the **Settings** tab in the sidebar.
 

--- a/src/theme/badges/PrivatePreviewBadge/index.js
+++ b/src/theme/badges/PrivatePreviewBadge/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 import styles from "./styles.module.css"
+import { galaxyOnClick } from '../../../lib/galaxy/galaxy'
 
 const Icon = () => {
     return (
@@ -13,10 +14,30 @@ const Icon = () => {
     )
 }
 
-const PrivatePreviewBadge = () => {
+const PrivatePreviewBadge = ({ link, galaxyTrack, slug }) => {
+    const content = (
+        <>
+            <Icon />{'Private preview in ClickHouse Cloud'}
+        </>
+    )
+
+    if (link) {
+        return (
+            <a
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.privatePreviewBadge}
+                onClick={galaxyTrack && slug ? galaxyOnClick(`docs.managed-postgres.${slug}-private-preview`) : undefined}
+            >
+                {content}
+            </a>
+        )
+    }
+
     return (
         <div classes className={styles.privatePreviewBadge}>
-            <Icon />{'Private preview in ClickHouse Cloud'}
+            {content}
         </div>
     )
 }


### PR DESCRIPTION
Private Preview badges on Managed Postgres pages will now link to the signup page and also track click events with Galaxy.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
