### PR TITLE
updating main and search readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ClickHouse is blazing fast, but understanding ClickHouse and using it effectivel
 - [About this repo](#about-this-repo)
 - [Run locally](#run-locally)
 - [Contributing](#contributing)
+- [Search](#search)
 - [Issues](#issues)
 - [License](#license)
 
@@ -199,6 +200,10 @@ Have you noticed a typo or found some wonky formatting? For small contributions 
 1. Click **Create pull request**.
 
 At this point, your pull request will be handed over to the docs team, who will review it and suggest or make changes where necessary.
+
+## Search
+
+This site uses Algolia for search functionality. The search index is automatically updated daily at 4 AM UTC and immediately when PRs with the `update search` label are merged. For details on how search indexing works, manual indexing, and troubleshooting, see the [Search README](./scripts/search/README.md).
 
 ## Issues
 

--- a/scripts/search/README.md
+++ b/scripts/search/README.md
@@ -132,3 +132,21 @@ Note: exact scores may vary due to constant content changes.
 1. Better chunking - using a markdown chunker which respects code and table boundaries
 2. Skip pages
 3. Segment on case on h3s, h2s on numerics e.g. toInt8 -> to Int 8
+
+## Automated Indexing
+
+The search index is automatically updated through a GitHub Actions workflow (`.github/workflows/build-search.yml`) in three scenarios:
+
+### Daily Scheduled Updates
+- **When**: Every day at 4:00 AM UTC (11 PM CST / 12 AM EST)
+- **What**: Automatically re-indexes all documentation to keep search results fresh
+
+### PR-Triggered Updates  
+- **When**: A PR is merged to `main` with the `update search` label
+- **How to use**: Add the `update search` label to your PR before merging to trigger an immediate index update
+- **Use case**: Important for major documentation restructures or when search needs to reflect changes immediately
+
+### Manual Trigger
+- **When**: Via GitHub Actions UI (workflow_dispatch)
+- **How**: Go to Actions → Update Algolia Search → Run workflow
+- **Use case**: Emergency updates or testing


### PR DESCRIPTION
## Summary
Forgot some info on updating the search index, figured I'd update our readmes.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
