### PR TITLE
Redirects: remove unneeded redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3419,10 +3419,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/whats-new/changelog/2025",
-      "destination": "/docs/category/changelog"
-    },
-    {
       "source": "/docs/development/adding_test_queries",
       "destination": "/docs/development/tests#adding-a-new-test"
     },


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
A fix for:
> There is something odd going on with changelog links. When I go to https://clickhouse.com/docs/whats-new/changelog/2025 it redirects me to https://clickhouse.com/docs/category/changelog, then I click to 2025 and I go to the exact link I was trying to access in the first place
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
