### PR TITLE
Bug: correct searchPagePath for translations

### DIFF
--- a/docusaurus.config.jp.js
+++ b/docusaurus.config.jp.js
@@ -212,7 +212,7 @@ const config = {
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
         indexName: "clickhouse-jp",
         contextualSearch: false,
-        searchPagePath: "/docs/search",
+        searchPagePath: "/docs/jp/search",
       },
       image: "img/docs_social_share.png",
       icon: "/img/gareth.png",

--- a/docusaurus.config.ru.js
+++ b/docusaurus.config.ru.js
@@ -213,7 +213,7 @@ const config = {
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
         indexName: "clickhouse-ru",
         contextualSearch: false,
-        searchPagePath: "/docs/search",
+        searchPagePath: "/docs/ru/search",
       },
       image: "img/docs_social_share.png",
       icon: "/img/gareth.png",

--- a/docusaurus.config.zh.js
+++ b/docusaurus.config.zh.js
@@ -212,7 +212,7 @@ const config = {
         apiKey: "4a7bf25cf3edbef29d78d5e1eecfdca5",
         indexName: "clickhouse-zh",
         contextualSearch: false,
-        searchPagePath: "/docs/search",
+        searchPagePath: "/docs/zh/search",
       },
       image: "img/docs_social_share.png",
       icon: "/img/gareth.png",


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Bug fix where searchPagePath for translations is wrong
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
