### PR TITLE
Revert "Add agent skills link to readme and docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,3 @@ Found a problem with the Clickhouse docs site? [Please raise an issue](https://g
 ## License
 
 This work is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
-
-## Resources
-
-- [ClickHouse Agent Skills](https://github.com/ClickHouse/agent-skills)

--- a/docs/use-cases/AI_ML/MCP/index.md
+++ b/docs/use-cases/AI_ML/MCP/index.md
@@ -45,10 +45,6 @@ The [ClickHouse MCP Server](https://github.com/ClickHouse/mcp-clickhouse) offers
 
 If you're looking for a remote MCP server in ClickHouse Cloud, see page ["Remote MCP server in Cloud"](/cloud/features/ai-ml/remote-mcp)
 
-:::tip[Agent Skills]
-The [ClickHouse Agent Skills repo](https://github.com/ClickHouse/agent-skills) provides packaged instructions that extend AI coding agents (Claude Code, Cursor, Copilot, etc.) with domain-specific expertise. This repository provides skills for ClickHouse databases—covering schema design, query optimization, and data ingestion patterns.
-:::
-
 ## Guides for using the ClickHouse MCP Server {#clickhouse-mcp-server-guides}
 
 Below are some guides showing how to use the ClickHouse MCP Server.


### PR DESCRIPTION
Reverts ClickHouse/clickhouse-docs#5360 (jumped the gun, repo is still public)