### PR TITLE
Feedback: link to the wrong page

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/01_overview.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/01_overview.md
@@ -46,7 +46,7 @@ All **public regions** listed in our [supported regions](https://clickhouse.com/
 - **Zero Trust Network via Tailscale.**
 - **Monitoring**:
   - The Cloud console includes built-in health dashboards for monitoring service health.
-  - Prometheus scraping for centralized monitoring with Prometheus, Grafana, and Datadog. See the [Prometheus documentation](/integrations/prometheus) for setup instructions.
+  - Prometheus scraping for centralized monitoring with Prometheus, Grafana, and Datadog. See the [Prometheus documentation](/cloud/reference/byoc/observability#prometheus-access) for setup instructions.
 - **VPC Peering**
 - **Integrations**: See the full list on [this page](/integrations).
 - **Secure S3**


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Addresses the feedback: 

> ["The Monitoring for Prometheus is not accurate. The right link should be https://clickhouse.com/docs/cloud/reference/byoc/observability#prometheus-access"]
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
