### PR TITLE
Fix links and exmaple in operator docs

### DIFF
--- a/docs/kubernetes-operator/02_install/kubectl.mdx
+++ b/docs/kubernetes-operator/02_install/kubectl.mdx
@@ -24,7 +24,7 @@ Requires cert-manager to issue webhook certificates.
 Install the operator and CRDs from the latest release:
 
 ```bash
-kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/download/latest/clickhouse-operator.yaml
+kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator.yaml
 ```
 
 This will:

--- a/docs/kubernetes-operator/02_install/olm.mdx
+++ b/docs/kubernetes-operator/02_install/olm.mdx
@@ -70,7 +70,7 @@ metadata:
   name: clickhouse-operator
   namespace: clickhouse-operator-system
 spec:
-  channel: stable
+  channel: stable-v0
   name: clickhouse-operator
   source: clickhouse-operator-catalog
   sourceNamespace: clickhouse-operator-system
@@ -97,3 +97,4 @@ More info about uninstalling can be found in the [OLM documentation](https://olm
 ## Additional Resources {#additional-resources}
 
 - [Operator Lifecycle Manager Documentation](https://olm.operatorframework.io/docs)
+


### PR DESCRIPTION
## Summary

Fix the release bundle link for operator kubectl install.
Fix the olm subscription channel.

## Checklist
- [x] Delete items not relevant to your PR
