### PR TITLE
Remove Houseplant from migration tools list

### DIFF
--- a/knowledgebase/schema_migration_tools.mdx
+++ b/knowledgebase/schema_migration_tools.mdx
@@ -23,4 +23,3 @@ There is no standard schema migration tool for ClickHouse, but we have compiled 
 - [Liquibase](https://www.liquibase.com/)
 - A [simple community tool](https://github.com/VVVi/clickhouse-migrations) named `clickhouse-migrations`
 - Another [community tool](https://github.com/golang-migrate/migrate/tree/master/database/clickhouse) written in Go
-- [Houseplant](https://houseplant.readthedocs.io)


### PR DESCRIPTION
Removed Houseplant from the list of schema migration tools.

## Summary
I tested out Houseplant and it was broken. It doesn't look like it's getting maintained (last commit was from Feb 2025 and the company that did create it was acquired and doesn't seem to be actively contributing to it anymore given the PR/issue history). Given the lack of support and how there are better options on this page, I would like to remove this from our documentation so users choose the more time tested offerings. 

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
