### PR TITLE
Docs: add version note on `memory_usage`

### DIFF
--- a/docs/integrations/interfaces/http.md
+++ b/docs/integrations/interfaces/http.md
@@ -448,7 +448,7 @@ The possible header fields are:
 | `written_rows`       | Number of rows written.         |
 | `written_bytes`      | Volume of data written in bytes.|
 | `elapsed_ns`         | Query runtime in nanoseconds.|
-| `memory_usage`       | Memory in bytes used by the query. |
+| `memory_usage`       | Memory in bytes used by the query. (**Available from v25.11**) |
 
 Running requests do not stop automatically if the HTTP connection is lost. Parsing and data formatting are performed on the server-side, and using the network might be ineffective.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
`memory_usage ` only works in v25.11+, so we should make this clear.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
