### PR TITLE
ClickPipes: Fix import issue with snippets

### DIFF
--- a/docs/_snippets/clickpipes/object-storage/_create_clickpipe.md
+++ b/docs/_snippets/clickpipes/object-storage/_create_clickpipe.md
@@ -15,6 +15,9 @@ import S3DataSource from '@site/docs/_snippets/clickpipes/object-storage/amazon-
 import GCSSDataSource from '@site/docs/_snippets/clickpipes/object-storage/google-cloud-storage/_1-data-source.md';
 import ABSDataSource from '@site/docs/_snippets/clickpipes/object-storage/azure-blob-storage/_1-data-source.md';
 
+import S3Connection from '@site/docs/_snippets/clickpipes/object-storage/amazon-s3/_2-connection.md';
+import GCSConnection from '@site/docs/_snippets/clickpipes/object-storage/google-cloud-storage/_2-connection.md';
+
 <VerticalStepper type="numbered" headerLevel="h2">
 
 ## Select the data source {#1-select-the-data-source}
@@ -31,9 +34,8 @@ import ABSDataSource from '@site/docs/_snippets/clickpipes/object-storage/azure-
 
 **1.** To setup a new ClickPipe, you must provide details on how to connect to and authenticate with your object storage service.
 
-{props.provider === 's3' && <S3DataSource />}
-{props.provider === 'gcs' && <GCSSDataSource />}
-{props.provider === 'abs' && <ABSDataSource />}
+{props.provider === 's3' && <S3Connection />}
+{props.provider === 'gcs' && <GCSConnection />}
 
 **2.** Click **Incoming data**. ClickPipes will fetch metadata from your bucket for the next step.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
https://clickhouse.com/docs/integrations/clickpipes/object-storage/s3/get-started

Step 1 and 2 are the same due to the snippet imports

<img width="909" height="863" alt="image" src="https://github.com/user-attachments/assets/73f70318-395a-48ba-949b-1f7a1741b0d8" />

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
