### PR TITLE
Bugfix: fix pagination bug on managed postgres overview page

### DIFF
--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -4,6 +4,8 @@ title: 'Managed Postgres'
 description: 'Fast, scalable, enterprise-grade Postgres backed by NVMe storage with native ClickHouse integration for real-time analytics'
 keywords: ['managed postgres', 'postgresql', 'cloud database', 'postgres service', 'nvme postgres', 'clickhouse integration']
 doc_type: 'guide'
+pagination_next: cloud/managed-postgres/quickstart
+pagination_prev: null
 ---
 
 import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
The navigation on the docs is slightly off—the “Managed Postgres” page is supposed to link to the next page at the bottom (“Quick Start”), but instead it links to itself.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
