### PR TITLE
Integrations grid: Fix integrations grid caching to allow revalidation

### DIFF
--- a/src/components/IntegrationGrid/IntegrationGrid.tsx
+++ b/src/components/IntegrationGrid/IntegrationGrid.tsx
@@ -192,7 +192,7 @@ function useCMSIntegrations() {
       // Step 1: Load fallback data first for immediate display
       try {
         const fallbackResponse = await fetch(fallbackPath, {
-          cache: 'force-cache' // Use cached version if available
+          cache: 'no-cache' // Always revalidate with server to get fresh data
         });
 
         if (fallbackResponse.ok) {


### PR DESCRIPTION
Change fetch cache policy from 'force-cache' to 'no-cache' so browsers revalidate with the server instead of serving stale cached data.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
