### PR TITLE
Remove UniForm SQL on Unity Catalog page

### DIFF
--- a/docs/use-cases/data_lake/unity_catalog.md
+++ b/docs/use-cases/data_lake/unity_catalog.md
@@ -55,17 +55,6 @@ SETTINGS warehouse = 'CATALOG_NAME', catalog_credential = '<PAT>', catalog_type 
 
 ### Read Iceberg {#read-iceberg}
 
-To access UniForm Iceberg tables:
-
-```sql
-CREATE DATABASE unity
-ENGINE = DataLakeCatalog('https://<workspace-id>.cloud.databricks.com/api/2.1/unity-catalog/iceberg')
-SETTINGS catalog_type = 'rest', catalog_credential = '<client-id>:<client-secret>', warehouse = 'workspace', 
-oauth_server_uri = 'https://<workspace-id>.cloud.databricks.com/oidc/v1/token', auth_scope = 'all-apis,sql'
-```
-
-To access managed Iceberg tables:
-
 ```sql
 CREATE DATABASE unity
 ENGINE = DataLakeCatalog('https://<workspace-id>.cloud.databricks.com/api/2.1/unity-catalog/iceberg-rest')

--- a/docs/use-cases/data_lake/unity_catalog.md
+++ b/docs/use-cases/data_lake/unity_catalog.md
@@ -55,6 +55,8 @@ SETTINGS warehouse = 'CATALOG_NAME', catalog_credential = '<PAT>', catalog_type 
 
 ### Read Iceberg {#read-iceberg}
 
+To access managed Iceberg tables:
+
 ```sql
 CREATE DATABASE unity
 ENGINE = DataLakeCatalog('https://<workspace-id>.cloud.databricks.com/api/2.1/unity-catalog/iceberg-rest')


### PR DESCRIPTION
Removed instructions for accessing UniForm Iceberg tables Databricks is deprecating this API. 

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
