### PR TITLE
Release channels: add 25.12 and update fast channel start date

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_status.md
+++ b/docs/cloud/reference/01_changelog/02_release_status.md
@@ -49,7 +49,7 @@ For advance testing before production upgrades, use the Fast or Regular channel 
     {
      changelog_link: 'https://clickhouse.com/docs/changelogs/25.12',
      version: '25.12',
-     fast_start_date: '2026-02-10',
+     fast_start_date: '2026-02-12',
      fast_end_date: 'TBD',
      regular_start_date: 'TBD',
      regular_end_date: 'TBD',


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
