### PR TITLE
GT: Updating gt config to handle relative paths of image assets

### DIFF
--- a/gt.config.json
+++ b/gt.config.json
@@ -48,6 +48,13 @@
       "output": "i18n/locales/[locale].json"
     }
   },
+  "sharedStaticAssets": {
+    "include": [
+      "docs/**/images/*.png",
+      "knowledgebase/**/images/*.png"
+    ],
+    "mirrorToLocales": true
+  },
   "locales": [
     "en",
     "zh",


### PR DESCRIPTION
## Summary
Updating `gt.config.json` to handle relative image asset paths

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
