### PR TITLE
Fix TPC-DS schema types and simplify DDL

### DIFF
--- a/docs/getting-started/example-datasets/tpcds.md
+++ b/docs/getting-started/example-datasets/tpcds.md
@@ -604,7 +604,7 @@ Then run the generated queries.
 The following settings should be enabled to produce correct results according to SQL standard:
 
 ```sql
-SET data_type_default_nullable: 1;
+SET data_type_default_nullable = 1;
 SET group_by_use_nulls = 1;
 SET intersect_default_mode = 'DISTINCT';
 SET joined_subquery_requires_alias = 0;


### PR DESCRIPTION
## Summary
1. Fixed the definition of integer from `Int32` to `Int64`, as the spec requires.
2. Clarified which columns of type identifier use `UInt32`.
3. Removed `LowCardinality()` wrappers from all `[var]char(N)` type mappings, and from all column definitions throughout the schema.
4. Added `SET data_type_default_nullable: 1;` so all columns are nullable by default, allowing the schema to use bare types with explicit NOT NULL where needed. 
5. Removed the three workaround query blocks for Q5, Q27, and Q80 as the closer-to-spec schema removed the need for workarounds there.

## Checklist
- [x] Delete items not relevant to your PR