### PR TITLE
Remove custom webpack configuration to improve initial load time

### DIFF
--- a/docusaurus.config.en.js
+++ b/docusaurus.config.en.js
@@ -322,42 +322,6 @@ const config = {
         },
       };
     },
-    // Webpack optimization plugin for large sites
-    function webpackOptimizationPlugin(context, options) {
-      return {
-        name: 'webpack-optimization-plugin',
-        configureWebpack(config, isServer) {
-
-          const isVercel = process.env.VERCEL === '1';
-
-          if (!isServer && isVercel) {
-            return {
-              optimization: {
-                splitChunks: {
-                  chunks: 'all',
-                  cacheGroups: {
-                    vendor: {
-                      chunks: 'all',
-                      test: /node_modules/,
-                      priority: 20,
-                    },
-                    common: {
-                      minChunks: 2,
-                      chunks: 'all',
-                      priority: 10,
-                      reuseExistingChunk: true,
-                      enforce: true,
-                    },
-                  },
-                  maxSize: 244000,
-                },
-              },
-            };
-          }
-          return {};
-        },
-      };
-    },
     // [
     // N.B - If you need to redirect a page please do so from vercel.json
     // 	'@docusaurus/plugin-client-redirects',


### PR DESCRIPTION
With custom configuration there were 400 http requests. With default configuration there are "only" 100 requests and the initial page load is 1s faster locally (2.5s => 1.5s), the difference should be bigger after the change is deployed to https://clickhouse.com/docs

I see improvements locally, but these changes should be first deployed to a vercel preview env to make sure everything still works correctly and similar improvements are visible when the docs are deployed to vercel

The changes with custom config were introduced in https://github.com/ClickHouse/clickhouse-docs/pull/4770, but I don't see any information why these changes are needed.

### Before (with VERCEL=1)

<img width="654" height="238" alt="master" src="https://github.com/user-attachments/assets/5c3d8148-3766-4d42-bbed-7092c2ecf5c1" />



### After

<img width="700" height="155" alt="default-config" src="https://github.com/user-attachments/assets/3b6be215-771a-47ea-a962-aa377e5d4a5e" />

cc: @Blargian @dhtclk 

