### PR TITLE
getting started: Fix `docker run` command

### DIFF
--- a/docs/use-cases/observability/clickstack/getting-started/oss.md
+++ b/docs/use-cases/observability/clickstack/getting-started/oss.md
@@ -58,7 +58,7 @@ For example:
 ```shell
 # modify command to mount paths
 docker run \
-  --name clickstack
+  --name clickstack \
   -p 8123:8123 \
   -p 8080:8080 \
   -p 4317:4317 \


### PR DESCRIPTION
This change fixes the newline escaping on the `docker run` command so that it is easy to copy/paste and run.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
