### PR TITLE
Anchor Tag redirect: trying to add / before anchor tag

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3733,8 +3733,8 @@
       "permanent": true
     },
     {
-      "source": "/docs/cloud/security/compliance/hipaa-onboarding#deploy-hippa-services",
-      "destination": "/docs/cloud/security/compliance/hipaa-onboarding#deploy-hipaa-services",
+      "source": "/docs/cloud/security/compliance/hipaa-onboarding/#deploy-hippa-services",
+      "destination": "/docs/cloud/security/compliance/hipaa-onboarding/#deploy-hipaa-services",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary
There's an issue with redirect with anchor tag, trying to add a slash beforehand to see if that can be a work around.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
