### PR TITLE
GT: add Korean config

### DIFF
--- a/gt.config.json
+++ b/gt.config.json
@@ -52,7 +52,8 @@
     "en",
     "zh",
     "ru",
-    "jp"
+    "jp",
+    "ko"
   ],
   "customMapping": {
     "jp": {


### PR DESCRIPTION
## Summary
Adding Korean (`ko`) to `gt.config.json`

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
