### PR TITLE
Sync pg_clickhouse docs to the v0.1.4 release

### DIFF
--- a/docs/integrations/tools/data-integration/pg_clickhouse/introduction.md
+++ b/docs/integrations/tools/data-integration/pg_clickhouse/introduction.md
@@ -44,8 +44,6 @@ factor 1; ✔︎ indicates full pushdown, while a dash indicates a query
 cancellation after 1m. All tests run on a MacBook Pro M4 Max with 36 GB of
 memory.
 
-<!-- cd dev/tpch && make ch && make pg && make run -->
-
 |    Query   | PostgreSQL | pg_clickhouse | Pushdown |
 | ----------:| ----------:| -------------:|:--------:|
 |  [Query 1] |    4693 ms |        268 ms |     ✔︎    |
@@ -58,7 +56,7 @@ memory.
 |  [Query 8] |     342 ms |        156 ms |     ✔︎    |
 |  [Query 9] |    3094 ms |        298 ms |     ✔︎    |
 | [Query 10] |     581 ms |        197 ms |     ✔︎    |
-| [Query 11] |     212 ms |         24 ms |     ✔︎    |
+| [Query 11] |     212 ms |         24 ms |          |
 | [Query 12] |    1116 ms |         84 ms |     ✔︎    |
 | [Query 13] |     958 ms |       1368 ms |          |
 | [Query 14] |     181 ms |         73 ms |     ✔︎    |

--- a/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
+++ b/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
@@ -357,7 +357,7 @@ DROP FOREIGN TABLE uact CASCADE;
 ## DML SQL Reference {#dml-sql-reference}
 
 The SQL [DML] expressions below may use pg_clickhouse. Examples depend on
-these ClickHouse tables, created by [make-logs.sql]:
+these ClickHouse tables:
 
 ```sql
 CREATE TABLE logs (
@@ -574,6 +574,15 @@ try=# EXECUTE avg_durations_between_dates('2025-12-09', '2025-12-13');
 (5 rows)
 ```
 
+:::warning
+Parameterized execution prevents the [http driver](#create-server) from
+properly converting DateTime time zones on ClickHouse versions prior to 25.8,
+when the [underlying bug] was [fixed]. Note that sometimes PostgreSQL will use
+a parameterized query plan even without using `PREPARE`. For any queries on
+that require accurate time zone conversion, and where upgrading to 25.8 or
+later is not an option, use the [binary driver](#create-server), instead.
+:::
+
 pg_clickhouse pushes down the aggregations, as usual, as seen in the
 [EXPLAIN](#explain) verbose output:
 
@@ -714,8 +723,16 @@ SET pg_clickhouse.session_settings TO $$
 $$;
 ```
 
-pg_clickhouse doesn't validate the settings, but passes them on to ClickHouse
-for every query. It thus supports all settings for each ClickHouse version.
+Some settings will be ignored in cases where they would interfere with the
+operation of pg_clickhouse itself. These include:
+
+* `date_time_output_format`: the http driver requires it to be "iso"
+* `format_tsv_null_representation`: the http driver requires the default
+* `output_format_tsv_crlf_end_of_line` the http driver requires the default
+
+Otherwise, pg_clickhouse does not validate the settings, but passes them on to
+ClickHouse for every query. It thus supports all settings for each ClickHouse
+version.
 
 Note that pg_clickhouse must be loaded before setting
 `pg_clickhouse.session_settings`; either use [shared library preloading] or
@@ -773,19 +790,19 @@ shared_preload_libraries = pg_clickhouse
 Useful to save memory and load overhead for every session, but requires the
 cluster to be restart when the library is updated.
 
-## Function and Operator Reference {#function-and-operator-reference}
-
-### Data Types {#data-types}
+## Data Types {#data-types}
 
 pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
-types:
+types. [IMPORT FOREIGN SCHEMA](#import-foreign-schema) use the first type in
+the PostgreSQL column when importing columns; additional types may be used in
+[CREATE FOREIGN TABLE](#create-foreign-table) statements:
 
 | ClickHouse |    PostgreSQL    |             Notes             |
-| -----------|------------------|-------------------------------|
+|------------|------------------|-------------------------------|
 | Bool       | boolean          |                               |
 | Date       | date             |                               |
 | Date32     | date             |                               |
-| DateTime   | timestamp        |                               |
+| DateTime   | timestamptz      |                               |
 | Decimal    | numeric          |                               |
 | Float32    | real             |                               |
 | Float64    | double precision |                               |
@@ -796,12 +813,135 @@ types:
 | Int64      | bigint           |                               |
 | Int8       | smallint         |                               |
 | JSON       | jsonb            | HTTP engine only              |
-| String     | text             |                               |
+| String     | text, bytea      |                               |
 | UInt16     | integer          |                               |
 | UInt32     | bigint           |                               |
 | UInt64     | bigint           | Errors on values > BIGINT max |
 | UInt8      | smallint         |                               |
 | UUID       | uuid             |                               |
+
+Additional notes and details follow.
+
+### BYTEA {#bytea}
+
+ClickHouse does not provide the equivalent of the PostgreSQL [BYTEA] type, but
+allows any bytes to be stored in [String] type. In general ClickHouse strings
+should be mapped to the PostgreSQL [TEXT], but when using binary data, map it
+to [BYTEA]. Example:
+
+```sql
+-- Create clickHouse table with String columns.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE bytes (
+        c1 Int8, c2 String, c3 String
+    ) ENGINE = MergeTree ORDER BY (c1);
+$$);
+
+-- Create foreign table with BYTEA columns.
+CREATE FOREIGN TABLE bytes (
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER ch_srv OPTIONS( table_name 'bytes' );
+
+-- Insert binary data into the foreign table.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- View the results.
+SELECT * FROM bytes;
+```
+
+That final `SELECT` query will output:
+
+```pgsql
+ c1 |                             c2                             |                 c3
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+Note that if there are any nul bytes in the ClickHouse columns, a foreign
+table using [TEXT] columns will not output the proper values:
+
+```sql
+-- Create foreign table with TEXT columns.
+CREATE FOREIGN TABLE texts (
+    c1 int,
+    c2 TEXT,
+    c3 TEXT
+) SERVER ch_srv OPTIONS( table_name 'bytes' );
+
+-- Encode binary data as hex.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM texts ORDER BY c1;
+```
+
+Will output:
+
+```pgsql
+ c1 |                          encode                          |              encode
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+Note that rows two and three contain truncated values. This is because
+PostgreSQL relies on nul-terminated strings and does not support nuls in its
+strings.
+
+Attempting to insert binary values into [TEXT] columns will succeed and work
+as expected:
+
+```sql
+-- Insert via text columns:
+TRUNCATE texts;
+INSERT INTO texts
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- View the data.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM texts ORDER BY c1;
+```
+
+The text columns will be correct:
+
+```pgdsql
+
+ c1 |                          encode                          |              encode
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+But reading them as [BYTEA] will not:
+
+```pgsql
+# SELECT * FROM bytes;
+ c1 |                                                           c2                                                           |                                   c3
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+```
+
+:::tip
+As a rule, only use [TEXT] columns for encoded strings and use [BYTEA] columns
+only for binary data, and never switch between them.
+:::
+
+## Function and Operator Reference {#function-and-operator-reference}
 
 ### Functions {#functions}
 
@@ -883,6 +1023,7 @@ maps the following functions:
 * `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 * `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
 * `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
 
 ### Custom Functions {#custom-functions}
 
@@ -1040,8 +1181,18 @@ Copyright (c) 2025-2026, ClickHouse
   [dollar quoting]: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
     "PostgreSQL Docs: Dollar-Quoted String Constants"
   [library preloading]: https://www.postgresql.org/docs/18/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD
-    "PostgreSQL Docs: Shared Library Preloading
+    "PostgreSQL Docs: Shared Library Preloading"
   [PREPARE notes]: https://www.postgresql.org/docs/current/sql-prepare.html#SQL-PREPARE-NOTES
     "PostgreSQL Docs: PREPARE notes"
   [query parameters]: https://clickhouse.com/docs/guides/developer/stored-procedures-and-prepared-statements#alternatives-to-prepared-statements-in-clickhouse
     "ClickHouse Docs: Alternatives to prepared statements in ClickHouse"
+  [underlying bug]: https://github.com/ClickHouse/ClickHouse/issues/85847
+    "ClickHouse/ClickHouse#85847 Some queries in a multipart forms don't read settings"
+  [fixed]: https://github.com/ClickHouse/ClickHouse/pull/85570
+    "ClickHouse/ClickHouse#85570 fix HTTP with multipart"
+  [BYTEA]: https://www.postgresql.org/docs/current/datatype-binary.html
+    "PostgreSQL Docs: Binary Data Types"
+  [String]: https://clickhouse.com/docs/sql-reference/data-types/string
+    "ClickHouse Docs: String"
+  [TEXT]: https://www.postgresql.org/docs/current/datatype-character.html
+    "PostgreSQL Docs: Character Types"

--- a/docs/integrations/tools/data-integration/pg_clickhouse/tutorial.md
+++ b/docs/integrations/tools/data-integration/pg_clickhouse/tutorial.md
@@ -228,54 +228,54 @@ Success! Use `\d` to show all the columns:
 
 ```pgsql
 taxi=# \d taxi.trips
-                                     Foreign table "taxi.trips"
-        Column         |            Type             | Collation | Nullable | Default | FDW options
------------------------+-----------------------------+-----------+----------+---------+-------------
- trip_id               | bigint                      |           | not null |         |
- vendor_id             | text                        |           | not null |         |
- pickup_date           | date                        |           | not null |         |
- pickup_datetime       | timestamp without time zone |           | not null |         |
- dropoff_date          | date                        |           | not null |         |
- dropoff_datetime      | timestamp without time zone |           | not null |         |
- store_and_fwd_flag    | smallint                    |           | not null |         |
- rate_code_id          | smallint                    |           | not null |         |
- pickup_longitude      | double precision            |           | not null |         |
- pickup_latitude       | double precision            |           | not null |         |
- dropoff_longitude     | double precision            |           | not null |         |
- dropoff_latitude      | double precision            |           | not null |         |
- passenger_count       | smallint                    |           | not null |         |
- trip_distance         | double precision            |           | not null |         |
- fare_amount           | numeric(10,2)               |           | not null |         |
- extra                 | numeric(10,2)               |           | not null |         |
- mta_tax               | numeric(10,2)               |           | not null |         |
- tip_amount            | numeric(10,2)               |           | not null |         |
- tolls_amount          | numeric(10,2)               |           | not null |         |
- ehail_fee             | numeric(10,2)               |           | not null |         |
- improvement_surcharge | numeric(10,2)               |           | not null |         |
- total_amount          | numeric(10,2)               |           | not null |         |
- payment_type          | text                        |           | not null |         |
- trip_type             | smallint                    |           | not null |         |
- pickup                | character varying(25)       |           | not null |         |
- dropoff               | character varying(25)       |           | not null |         |
- cab_type              | text                        |           | not null |         |
- pickup_nyct2010_gid   | smallint                    |           | not null |         |
- pickup_ctlabel        | real                        |           | not null |         |
- pickup_borocode       | smallint                    |           | not null |         |
- pickup_ct2010         | text                        |           | not null |         |
- pickup_boroct2010     | text                        |           | not null |         |
- pickup_cdeligibil     | text                        |           | not null |         |
- pickup_ntacode        | character varying(4)        |           | not null |         |
- pickup_ntaname        | text                        |           | not null |         |
- pickup_puma           | integer                     |           | not null |         |
- dropoff_nyct2010_gid  | smallint                    |           | not null |         |
- dropoff_ctlabel       | real                        |           | not null |         |
- dropoff_borocode      | smallint                    |           | not null |         |
- dropoff_ct2010        | text                        |           | not null |         |
- dropoff_boroct2010    | text                        |           | not null |         |
- dropoff_cdeligibil    | text                        |           | not null |         |
- dropoff_ntacode       | character varying(4)        |           | not null |         |
- dropoff_ntaname       | text                        |           | not null |         |
- dropoff_puma          | integer                     |           | not null |         |
+                                   Foreign table "taxi.trips"
+        Column         |           Type           | Collation | Nullable | Default | FDW options
+-----------------------+--------------------------+-----------+----------+---------+-------------
+ trip_id               | bigint                   |           | not null |         |
+ vendor_id             | text                     |           | not null |         |
+ pickup_date           | date                     |           | not null |         |
+ pickup_datetime       | timestamp with time zone |           | not null |         |
+ dropoff_date          | date                     |           | not null |         |
+ dropoff_datetime      | timestamp with time zone |           | not null |         |
+ store_and_fwd_flag    | smallint                 |           | not null |         |
+ rate_code_id          | smallint                 |           | not null |         |
+ pickup_longitude      | double precision         |           | not null |         |
+ pickup_latitude       | double precision         |           | not null |         |
+ dropoff_longitude     | double precision         |           | not null |         |
+ dropoff_latitude      | double precision         |           | not null |         |
+ passenger_count       | smallint                 |           | not null |         |
+ trip_distance         | double precision         |           | not null |         |
+ fare_amount           | numeric(10,2)            |           | not null |         |
+ extra                 | numeric(10,2)            |           | not null |         |
+ mta_tax               | numeric(10,2)            |           | not null |         |
+ tip_amount            | numeric(10,2)            |           | not null |         |
+ tolls_amount          | numeric(10,2)            |           | not null |         |
+ ehail_fee             | numeric(10,2)            |           | not null |         |
+ improvement_surcharge | numeric(10,2)            |           | not null |         |
+ total_amount          | numeric(10,2)            |           | not null |         |
+ payment_type          | text                     |           | not null |         |
+ trip_type             | smallint                 |           | not null |         |
+ pickup                | character varying(25)    |           | not null |         |
+ dropoff               | character varying(25)    |           | not null |         |
+ cab_type              | text                     |           | not null |         |
+ pickup_nyct2010_gid   | smallint                 |           | not null |         |
+ pickup_ctlabel        | real                     |           | not null |         |
+ pickup_borocode       | smallint                 |           | not null |         |
+ pickup_ct2010         | text                     |           | not null |         |
+ pickup_boroct2010     | text                     |           | not null |         |
+ pickup_cdeligibil     | text                     |           | not null |         |
+ pickup_ntacode        | character varying(4)     |           | not null |         |
+ pickup_ntaname        | text                     |           | not null |         |
+ pickup_puma           | integer                  |           | not null |         |
+ dropoff_nyct2010_gid  | smallint                 |           | not null |         |
+ dropoff_ctlabel       | real                     |           | not null |         |
+ dropoff_borocode      | smallint                 |           | not null |         |
+ dropoff_ct2010        | text                     |           | not null |         |
+ dropoff_boroct2010    | text                     |           | not null |         |
+ dropoff_cdeligibil    | text                     |           | not null |         |
+ dropoff_ntacode       | character varying(4)     |           | not null |         |
+ dropoff_ntaname       | text                     |           | not null |         |
+ dropoff_puma          | integer                  |           | not null |         |
 Server: taxi_srv
 FDW options: (database 'taxi', table_name 'trips', engine 'MergeTree')
 ```
@@ -428,9 +428,12 @@ your own SQL query.
     Time: 36.895 ms
     ```
 
-*   Retrieve rides to LaGuardia or JFK airports:
+*   Set display time zone for New York and retrieve rides to LaGuardia or JFK
+    airports:
 
     ```pgsql
+    taxi=# SET timezone = 'America/New_York';
+    SET
     taxi=# SELECT
         pickup_datetime,
         dropoff_datetime,
@@ -448,13 +451,13 @@ your own SQL query.
     WHERE dropoff_nyct2010_gid IN (132, 138)
     ORDER BY pickup_datetime
     LIMIT 5;
-       pickup_datetime   |  dropoff_datetime   | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour
-    ---------------------+---------------------+--------------+---------------------+----------------------+--------------+------+-----+------
-     2015-07-01 00:04:14 | 2015-07-01 00:15:29 |        13.30 |                 -34 |                  132 | JFK          | 2015 |   1 |    0
-     2015-07-01 00:09:42 | 2015-07-01 00:12:55 |         6.80 |                  50 |                  138 | LGA          | 2015 |   1 |    0
-     2015-07-01 00:23:04 | 2015-07-01 00:24:39 |         4.80 |                -125 |                  132 | JFK          | 2015 |   1 |    0
-     2015-07-01 00:27:51 | 2015-07-01 00:39:02 |        14.72 |                -101 |                  138 | LGA          | 2015 |   1 |    0
-     2015-07-01 00:32:03 | 2015-07-01 00:55:39 |        39.34 |                  48 |                  138 | LGA          | 2015 |   1 |    0
+        pickup_datetime     |    dropoff_datetime    | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour
+    ------------------------+------------------------+--------------+---------------------+----------------------+--------------+------+-----+------
+     2015-06-30 20:04:14-04 | 2015-06-30 20:15:29-04 |        13.30 |                 -34 |                  132 | JFK          | 2015 |  30 |   20
+     2015-06-30 20:09:42-04 | 2015-06-30 20:12:55-04 |         6.80 |                  50 |                  138 | LGA          | 2015 |  30 |   20
+     2015-06-30 20:23:04-04 | 2015-06-30 20:24:39-04 |         4.80 |                -125 |                  132 | JFK          | 2015 |  30 |   20
+     2015-06-30 20:27:51-04 | 2015-06-30 20:39:02-04 |        14.72 |                -101 |                  138 | LGA          | 2015 |  30 |   20
+     2015-06-30 20:32:03-04 | 2015-06-30 20:55:39-04 |        39.34 |                  48 |                  138 | LGA          | 2015 |  30 |   20
     (5 rows)
 
     Time: 17.450 ms

--- a/scripts/aspell-ignore/en/aspell-dict.txt
+++ b/scripts/aspell-ignore/en/aspell-dict.txt
@@ -84,6 +84,7 @@ BSON
 BSONEachRow
 BUZZHOUSE
 BYOC
+BYTEA
 BZIP
 Backblaze
 BackgroundBufferFlushSchedulePool
@@ -149,6 +150,7 @@ Bugfix
 BuildID
 BuilderBinAarch
 BuilderBinAmd
+bytea
 Bytebase
 CCPA
 CCTOOLS
@@ -3015,6 +3017,7 @@ nullability
 nullable
 nullables
 nullptr
+nuls
 num
 numerics
 nypd
@@ -3690,6 +3693,7 @@ timeZoneOffset
 timeslot
 timeslots
 timespan
+timestamptz
 timezones
 tinylog
 tmp


### PR DESCRIPTION
## Summary

Update the pg_clickhouse docs to sync with the [0.1.4 release](https://pgxn.org/dist/pg_clickhouse/0.1.4/).

## Checklist

All items N/A.

- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
