### PR TITLE
Remove JDBC bridge (no longer supported) migration example

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/01_clickhouse-local-etl.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/01_clickhouse-local-etl.md
@@ -87,7 +87,7 @@ In order for the `remoteSecure` function to connect to your ClickHouse Cloud ser
 
   <AddARemoteSystem />
 
-## Example 1: Migrating from MySQL to ClickHouse Cloud with an Integration engine {#example-1-migrating-from-mysql-to-clickhouse-cloud-with-an-integration-engine}
+## Example: Migrating from MySQL to ClickHouse Cloud with an Integration engine {#example-1-migrating-from-mysql-to-clickhouse-cloud-with-an-integration-engine}
 
 We will use the [integration table engine](/engines/table-engines/integrations/mysql/) (created on-the-fly by the [mysql table function](/sql-reference/table-functions/mysql/)) for reading data from the source MySQL database and we will use the [remoteSecure table function](/sql-reference/table-functions/remote/)
 for writing the data into a destination table on your ClickHouse cloud service.
@@ -127,17 +127,3 @@ SELECT * FROM mysql('host:port', 'database', 'table', 'user', 'password');"
 No data is stored locally on the `clickhouse-local` host machine. Instead, the data is read from the source MySQL table
   and then immediately written to the destination table on the ClickHouse Cloud service.
 :::
-
-## Example 2: Migrating from MySQL to ClickHouse Cloud with the JDBC bridge {#example-2-migrating-from-mysql-to-clickhouse-cloud-with-the-jdbc-bridge}
-
-We will use the [JDBC integration table engine](/engines/table-engines/integrations/jdbc.md) (created on-the-fly by the [jdbc table function](/sql-reference/table-functions/jdbc.md)) together with the [ClickHouse JDBC Bridge](https://github.com/ClickHouse/clickhouse-jdbc-bridge) and the MySQL JDBC driver for reading data from the source MySQL database and we will use the [remoteSecure table function](/sql-reference/table-functions/remote.md)
-for writing the data into a destination table on your ClickHouse cloud service.
-
-<Image img={ch_local_04} size='lg' alt='Migrating Self-managed ClickHouse'  />
-
-### On the destination ClickHouse Cloud service: {#on-the-destination-clickhouse-cloud-service-1}
-
-#### Create the destination database: {#create-the-destination-database-1}
-  ```sql
-  CREATE DATABASE db
-  ```


### PR DESCRIPTION
Removed the second example section about migrating with the JDBC bridge, which is archived and no longer supported:

> clickhouse-jdbc-bridge contains experimental codes and is no longer supported. It may contain reliability and security vulnerabilities. Use it at your own risk.

https://github.com/ClickHouse/clickhouse-jdbc-bridge

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
