### PR TITLE
Fix inaccuracy: add caveat to KB article

### DIFF
--- a/knowledgebase/configure-a-user-setting.mdx
+++ b/knowledgebase/configure-a-user-setting.mdx
@@ -49,3 +49,9 @@ You can verify it worked by logging out of your client, logging back in, then us
 ```sql
 SELECT getSetting('max_threads');
 ```
+
+:::note
+Specifying the settings this way will overwrite the current settings of the user i.e if you had other settings applied to the user but did not specify them in the `ALTER USER` statement, they will be lost.
+
+If you want to retain your settings use the `ALTER USER ... MODIFY SETTING ...` instead
+:::


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Closes https://github.com/ClickHouse/clickhouse-docs/issues/4599. I've tested and `ALTER USER ... SETTINGS` does indeed overwrite all the settings. Added note to highlight this caveat with suggestion to use `MODIFY SETTINGS`
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
