### PR TITLE
Update docs to reflect that IP addresses are allow all by default

### DIFF
--- a/docs/cloud/guides/security/02_connectivity/01_setting-ip-filters.md
+++ b/docs/cloud/guides/security/02_connectivity/01_setting-ip-filters.md
@@ -15,8 +15,8 @@ import ip_filter_add_single_ip from '@site/static/images/cloud/security/ip-filte
 
 IP access lists filter traffic to ClickHouse services or API keys by specifying which source addresses are permitted to connect.  These lists are configurable for each service and each API key.  Lists can be configured during service or API key creation, or afterward.
 
-:::warning[Don't skip creation of the IP access list]
-If you skip the creation of the IP access list for a ClickHouse Cloud service then no traffic will be permitted to the service. If IP access lists for ClickHouse services are set to `Allow from anywhere` your service may be periodically moved from an idle to an active state by internet crawlers and scanners that look for public IPs, which may result in nominal unexpected cost.
+:::warning[Configure the IP access list for your service]
+When you create a ClickHouse Cloud service, the default setting for the IP allow list is 'Allow from anywhere.' We strongly recommend restricting access to specific IP addresses or ranges as soon as possible. Services set to `Allow from anywhere` may be periodically moved from an idle to an active state by internet crawlers and scanners that look for public IPs, which may result in unexpected costs.
 :::
 
 ## Prepare {#prepare}
@@ -35,7 +35,7 @@ If you only want traffic from PrivateLink, set `DenyAll` in IP Allow list.
 <details>
   <summary>IP access list for ClickHouse services</summary>
 
-  When you create a ClickHouse service, the default setting for the IP allow list is 'Allow from nowhere.' 
+  When you create a ClickHouse service, the default setting for the IP allow list is 'Allow from anywhere.'
   
   From your ClickHouse Cloud services list select the service and then select **Settings**.  Under the **Security** section, you will find the IP access list. Click on the Add IPs button.
   


### PR DESCRIPTION
Closes DOC-564
Docs currently say IP filtering defaults to deny-all and requires changing it, but a newly created service defaults to allowing all traffic. Update the IP filtering docs page and/or any guides that claim deny-by-default (noted in a 2022 guide).

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
