### PR TITLE
Fixing broken anchors in ClickStack docs

### DIFF
--- a/docs/use-cases/observability/clickstack/deployment/_snippets/_setup_managed_ingestion.md
+++ b/docs/use-cases/observability/clickstack/deployment/_snippets/_setup_managed_ingestion.md
@@ -38,7 +38,7 @@ To get started quickly, copy and run the Docker command shown.
 This command should include your connection credentials pre-populated.
 
 :::note[Deploying to production]
-While this command uses the `default` user to connect Managed ClickStack, you should create a dedicated user when [going to production](/use-cases/observability/clickstack/production#create-a-user) and modifying your configuration.
+While this command uses the `default` user to connect Managed ClickStack, you should create a dedicated user when [going to production](/use-cases/observability/clickstack/production#create-a-database-ingestion-user-managed) and modifying your configuration.
 :::
 
 Running this single command starts the ClickStack collector with OTLP endpoints exposed on ports 4317 (gRPC) and 4318 (HTTP). If you already have OpenTelemetry instrumentation and agents, you can immediately begin sending telemetry data to these endpoints. 

--- a/docs/use-cases/observability/clickstack/deployment/managed.md
+++ b/docs/use-cases/observability/clickstack/deployment/managed.md
@@ -167,7 +167,7 @@ To get started quickly, copy and run the Docker command shown.
 **Modify this command with your service credentials, recorded when you created your service.**
 
 :::note[Deploying to production]
-While this command uses the `default` user to connect Managed ClickStack, you should create a dedicated user when [going to production](/use-cases/observability/clickstack/production#create-a-user) and modifying your configuration.
+While this command uses the `default` user to connect Managed ClickStack, you should create a dedicated user when [going to production](/use-cases/observability/clickstack/production#create-a-database-ingestion-user-managed) and modifying your configuration.
 :::
 
 Running this single command starts the ClickStack collector with OTLP endpoints exposed on ports 4317 (gRPC) and 4318 (HTTP). If you already have OpenTelemetry instrumentation and agents, you can immediately begin sending telemetry data to these endpoints. 

--- a/docs/use-cases/observability/clickstack/deployment/oss/all-in-one.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/all-in-one.md
@@ -55,7 +55,7 @@ On clicking `Create` data sources will be created for the integrated ClickHouse 
 
 <Image img={hyperdx_login} alt="HyperDX UI" size="lg"/>
 
-For an example of using an alternative ClickHouse instance, see ["Create a ClickHouse Cloud connection"](/use-cases/observability/clickstack/getting-started/oss#create-a-cloud-connection).
+For an example of using an alternative ClickHouse instance, see ["Using ClickHouse Cloud"](#using-clickhouse-cloud).
 
 ### Ingest data {#ingest-data}
 
@@ -114,7 +114,7 @@ docker run -e CLICKHOUSE_ENDPOINT=${CLICKHOUSE_ENDPOINT} -e CLICKHOUSE_USER=defa
 
 The `CLICKHOUSE_ENDPOINT` should be the ClickHouse Cloud HTTPS endpoint, including the port `8443` e.g. `https://mxl4k3ul6a.us-east-2.aws.clickhouse.com:8443`
 
-On connecting to the HyperDX UI, navigate to [`Team Settings`](http://localhost:8080/team) and create a connection to your ClickHouse Cloud service - followed by the required sources. For an example flow, see [here](/use-cases/observability/clickstack/getting-started/oss#create-a-cloud-connection).
+On connecting to the HyperDX UI, navigate to [`Team Settings`](http://localhost:8080/team) and create a connection to your ClickHouse Cloud service - followed by the required sources.
 
 ## Configuring the OpenTelemetry collector {#configuring-collector}
 

--- a/docs/use-cases/observability/clickstack/deployment/oss/docker-compose.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/docker-compose.md
@@ -68,7 +68,7 @@ You can override the default connection to the integrated ClickHouse instance. F
 
 <Image img={hyperdx_login} alt="HyperDX UI" size="lg"/>
 
-For an example of using an alternative ClickHouse instance, see ["Create a ClickHouse Cloud connection"](/use-cases/observability/clickstack/getting-started/oss#create-a-cloud-connection).
+For an example of using an alternative ClickHouse instance, see ["Using ClickHouse Cloud"](#using-clickhouse-cloud).
 
 ### Complete connection details {#complete-connection-details}
 

--- a/docs/use-cases/observability/clickstack/deployment/oss/helm/helm-deployment-options.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/helm/helm-deployment-options.md
@@ -167,8 +167,6 @@ hyperdx:
   existingConfigSourcesKey: "sources.json"
 ```
 
-For a complete example of connecting to ClickHouse Cloud, see ["Create a ClickHouse Cloud connection"](/docs/use-cases/observability/clickstack/getting-started/oss#create-a-cloud-connection).
-
 ## External OTEL Collector {#external-otel-collector}
 
 If you have an existing OTEL collector infrastructure:

--- a/docs/use-cases/observability/clickstack/deployment/oss/helm/helm.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/helm/helm.md
@@ -103,8 +103,6 @@ On clicking `Create`, data sources will be created for the ClickHouse instance d
 You can override the default connection to the integrated ClickHouse instance. For details, see ["Using ClickHouse Cloud"](#using-clickhouse-cloud).
 :::
 
-For an example of using an alternative ClickHouse instance, see ["Create a ClickHouse Cloud connection"](/docs/use-cases/observability/clickstack/getting-started/oss#create-a-cloud-connection).
-
 ### Customizing values (optional) {#customizing-values}
 
 You can customize settings by using `--set` flags. For example:


### PR DESCRIPTION
## Summary
Fixing broken anchors in ClickStack docs. Redirecting or removing ones that don't exist anymore.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
