### PR TITLE
Fix MSK multi-VPC cluster policy actions in ClickPipes PrivateLink guide

### DIFF
--- a/knowledgebase/aws-privatelink-setup-for-msk-clickpipes.mdx
+++ b/knowledgebase/aws-privatelink-setup-for-msk-clickpipes.mdx
@@ -43,9 +43,10 @@ Your MSK cluster VPC must be located in one of our ClickPipes regions. See [Clic
                         ]
                     },
                     "Action": [
-                        "kafka-cluster:Connect",
-                        "kafka-cluster:DescribeCluster",
-                        "kafka-cluster:ListClusters"
+                        "kafka:CreateVpcConnection",
+                        "kafka:GetBootstrapBrokers",
+                        "kafka:DescribeCluster",
+                        "kafka:DescribeClusterV2"
                     ]
                 }
             ]


### PR DESCRIPTION
## Summary

- The cluster policy example in the MSK PrivateLink KB article used incorrect `kafka-cluster:*` actions (`Connect`, `DescribeCluster`, `ListClusters`) that do not apply to MSK multi-VPC connectivity
- Replaced with the correct `kafka:*` actions required for ClickPipes RPE creation, matching the Terraform source of truth in the ClickPipes platform:
  - `kafka:CreateVpcConnection`
  - `kafka:GetBootstrapBrokers`
  - `kafka:DescribeCluster`
  - `kafka:DescribeClusterV2`
