### PR TITLE
docs: remove beta label from MSK IAM Authentication ClickPipe feature

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kafka/04_best_practices.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/04_best_practices.md
@@ -36,10 +36,6 @@ to 8MB (or lower) when configuring your WarpStream agent to prevent ClickPipes f
 
 ### IAM {#iam}
 
-:::info
-IAM Authentication for the MSK ClickPipe is a beta feature.
-:::
-
 ClickPipes supports the following AWS MSK authentication
 
 - [SASL/SCRAM-SHA-512](https://docs.aws.amazon.com/msk/latest/developerguide/msk-password.html) authentication


### PR DESCRIPTION
## Summary

- Removes the beta/experimental info admonition from the MSK IAM Authentication section in the Kafka ClickPipes best practices documentation.
- IAM Authentication for MSK ClickPipes is no longer considered a beta feature.