### PR TITLE
add a caveat about async insert behavior for insert into .... select

### DIFF
--- a/docs/best-practices/_snippets/_async_inserts.md
+++ b/docs/best-practices/_snippets/_async_inserts.md
@@ -61,3 +61,7 @@ Asynchronous inserts can be enabled for a particular user, or for a specific que
   ```bash
   "jdbc:ch://HOST.clickhouse.cloud:8443/?user=default&password=PASSWORD&ssl=true&custom_http_params=async_insert=1,wait_for_async_insert=1"
   ```
+
+:::note
+Asynchronous inserts do not apply to `INSERT INTO ... SELECT` queries. When the insert contains a `SELECT` clause, the query is always executed synchronously regardless of the `async_insert` setting.
+:::


### PR DESCRIPTION
## Summary
Add a note about async insert does not work for INSERT INTO ... SELECT, which is not mentioned in the doc and would be useful to caveat. 

Code ref: https://github.com/ClickHouse/ClickHouse/blob/e66342dfd554a025dff54bf3a72ab16375cec81f/src/Interpreters/executeQuery.cpp#L1523-L1536

Would be good to have this behavior confirmed by engineers more familiar with this matter. 