### PR TITLE
docs(cloud): editorial fixes and wording improvements across features docs

### DIFF
--- a/docs/cloud/features/03_sql_console_features/01_sql-console.md
+++ b/docs/cloud/features/03_sql_console_features/01_sql-console.md
@@ -303,6 +303,6 @@ Our chart will be updated accordingly:
 
 <Image img={update_subtitle_etc} size="md" alt='Update subtitle etc.' />
 
-In some scenarios, it may be necessary to adjust the axis scales for each field independently. This can also be accomplished in the 'Advanced' section of the chart configuration pane by specifying min and max values for an axis range. As an example, the above chart looks good, but in order to demonstrate the correlation between our `trip_total` and `fare_total` fields, the axis ranges need some adjustment:
+In some scenarios, it may be necessary to adjust the axis scales for each field independently. This can be done in the 'Advanced' section of the chart configuration pane by specifying min and max values for an axis range. As an example, the above chart looks good, but to demonstrate the correlation between our `trip_total` and `fare_total` fields, the axis ranges need some adjustment:
 
 <Image img={adjust_axis_scale} size="md" alt='Adjust axis scale' />

--- a/docs/cloud/features/03_sql_console_features/02_query-insights.md
+++ b/docs/cloud/features/03_sql_console_features/02_query-insights.md
@@ -16,7 +16,7 @@ import insights_query_info from '@site/static/images/cloud/sqlconsole/insights_q
 
 # Query Insights
 
-The **Query Insights** feature makes ClickHouse's built-in query log easier to use through various visualizations and tables. ClickHouse's `system.query_log` table is a key source of information for query optimization, debugging, and monitoring overall cluster health and performance.
+The **Query Insights** feature makes ClickHouse's built-in query log easier to use through visualizations and tables. ClickHouse's `system.query_log` table is a key source of information for query optimization, debugging, and monitoring overall cluster health and performance.
 
 ## Query overview {#query-overview}
 

--- a/docs/cloud/features/03_sql_console_features/hyperdx.md
+++ b/docs/cloud/features/03_sql_console_features/hyperdx.md
@@ -13,7 +13,7 @@ import hyperdx_cloud from '@site/static/images/use-cases/observability/hyperdx_c
 
 <PrivatePreviewBadge/>
 
-HyperDX is the user interface for [**ClickStack**](/use-cases/observability/clickstack) - a production-grade observability platform built on ClickHouse and OpenTelemetry (OTel), unifying logs, traces, metrics and session in a single high-performance solution. Designed for monitoring and debugging complex systems, ClickStack enables developers and SREs to trace issues end-to-end without switching between tools or manually stitching together data using timestamps or correlation IDs.
+HyperDX is the user interface for [**ClickStack**](/use-cases/observability/clickstack) - a production-grade observability platform built on ClickHouse and OpenTelemetry (OTel), unifying logs, traces, metrics, and session data in a single high-performance solution. Designed for monitoring and debugging complex systems, ClickStack enables developers and SREs to trace issues end-to-end without switching between tools or manually stitching together data using timestamps or correlation IDs.
 
 HyperDX is a purpose-built frontend for exploring and visualizing observability data, supporting both Lucene-style and SQL queries, interactive dashboards, alerting, trace exploration, and more—all optimized for ClickHouse as the backend.
 

--- a/docs/cloud/features/04_infrastructure/automatic_scaling/01_auto_scaling.md
+++ b/docs/cloud/features/04_infrastructure/automatic_scaling/01_auto_scaling.md
@@ -106,7 +106,7 @@ To horizontally scale a cluster, issue a `PATCH` request via the API to adjust t
 
 *Response from `PATCH` request*
 
-If you issue a new scaling request or multiple requests in succession, while one is already in progress, the scaling service will ignore the intermediate states and converge on the final replica count.
+If you issue a new scaling request (or multiple requests in succession) while one is already in progress, the scaling service ignores intermediate states and converges on the final replica count.
 
 ### Horizontal scaling via UI {#horizontal-scaling-via-ui}
 

--- a/docs/cloud/features/04_infrastructure/automatic_scaling/02_make_before_break.md
+++ b/docs/cloud/features/04_infrastructure/automatic_scaling/02_make_before_break.md
@@ -24,7 +24,7 @@ The image below shows how this might happen for a cluster with 3 replicas where 
 
 <Image img={mbb_diagram} size="lg" alt="Example diagram for a cluster with 3 replicas which gets vertically scaled" />
 
-Overall, MBB leads to a seamless, less disruptive scaling and upgrade experience compared to the break-first approach previously utilized.
+Overall, MBB provides a seamless and less disruptive scaling and upgrade experience compared to the previously used break-first approach.
 
 With MBB, there are some key behaviors that you need to be aware of:
 

--- a/docs/cloud/features/04_infrastructure/deployment-options.md
+++ b/docs/cloud/features/04_infrastructure/deployment-options.md
@@ -15,14 +15,14 @@ This document outlines the distinct deployment types available, enabling you to 
 
 ClickHouse Cloud is a fully managed, cloud-native service that delivers the power and speed of ClickHouse without the operational complexities of self-management.
 This option is ideal if you prioritize rapid deployment, scalability, and minimal administrative overhead.
-ClickHouse Cloud handles all aspects of infrastructure provisioning, scaling, maintenance, and updates, allowing users to focus entirely on data analysis and application development.
-It offers consumption-based pricing, and automatic scaling, ensuring reliable and cost-effective performance for analytical workloads. It is available across AWS, GCP and Azure, with direct marketplace billing options.
+ClickHouse Cloud handles provisioning, scaling, maintenance, and updates so users can focus entirely on data analysis and application development.
+It offers consumption-based pricing and automatic scaling to ensure reliable, cost-effective performance for analytical workloads. It is available across AWS, GCP, and Azure, with direct marketplace billing options.
 
 Learn more about [ClickHouse Cloud](/getting-started/quick-start/cloud).
 
 ## Bring Your Own Cloud {#byoc}
 
-ClickHouse Bring Your Own Cloud (BYOC) allows organizations to deploy and manage ClickHouse within their own cloud environment while leveraging a managed service layer. This option bridges the gap between the fully managed experience of ClickHouse Cloud and the complete control of self-managed deployments. With ClickHouse BYOC, users retain control over their data, infrastructure, and security policies, meeting specific compliance and regulatory requirements, while offloading operational tasks like patching, monitoring, and scaling to the ClickHouse. This model offers the flexibility of a private cloud deployment with the benefits of a managed service, making it suitable for large-scale deployments at enterprises with stringent security, governance, and data residency needs.
+ClickHouse Bring Your Own Cloud (BYOC) allows organizations to deploy and manage ClickHouse within their own cloud environment while leveraging a managed service layer. This option bridges the gap between the fully managed experience of ClickHouse Cloud and the complete control of self-managed deployments. With ClickHouse BYOC, users retain control over data, infrastructure, and security policies to meet specific compliance and regulatory requirements, while offloading operational tasks like patching, monitoring, and scaling to ClickHouse. This model offers the flexibility of a private cloud deployment with the benefits of a managed service, making it suitable for large-scale deployments at enterprises with stringent security, governance, and data residency needs.
 
 Learn more about [Bring Your Own Cloud](/cloud/reference/byoc/overview).
 

--- a/docs/cloud/features/04_infrastructure/shared-merge-tree.md
+++ b/docs/cloud/features/04_infrastructure/shared-merge-tree.md
@@ -31,7 +31,7 @@ As you can see, even though the data stored in the ReplicatedMergeTree are in ob
 
 <Image img={shared_merge_tree_2} alt="ReplicatedMergeTree Diagram with Metadata" size="md"  />
 
-Unlike ReplicatedMergeTree, SharedMergeTree doesn't require replicas to communicate with each other. Instead, all communication happens through shared storage and clickhouse-keeper. SharedMergeTree implements asynchronous leaderless replication and uses clickhouse-keeper for coordination and metadata storage. This means that metadata doesn't need to be replicated as your service scales up and down. This leads to faster replication, mutation, merges and scale-up operations. SharedMergeTree allows for hundreds of replicas for each table, making it possible to dynamically scale without shards. A distributed query execution approach is used in ClickHouse Cloud to utilize more compute resources for a query.
+Unlike ReplicatedMergeTree, SharedMergeTree doesn't require replicas to communicate with each other. Instead, all communication happens through shared storage and clickhouse-keeper. SharedMergeTree implements asynchronous leaderless replication and uses clickhouse-keeper for coordination and metadata storage. This means that metadata doesn't need to be replicated as your service scales up and down. This leads to faster replication, mutation, merges, and scale-up operations. SharedMergeTree allows for hundreds of replicas for each table, making it possible to dynamically scale without shards. A distributed query execution approach is used in ClickHouse Cloud to utilize more compute resources for a query.
 
 ## Introspection {#introspection}
 

--- a/docs/cloud/features/05_admin_features/api/api-overview.md
+++ b/docs/cloud/features/05_admin_features/api/api-overview.md
@@ -14,7 +14,7 @@ keywords: ['ClickHouse Cloud', 'API overview', 'cloud API', 'REST API', 'program
 
 The ClickHouse Cloud API is a REST API designed for developers to easily manage 
 organizations and services on ClickHouse Cloud. Using our Cloud API, you can 
-create and manage services, provision API keys, add or remove members in your 
+create and manage services, provision API keys, and add or remove members in your 
 organization, and more.
 
 [Learn how to create your first API key and start using the ClickHouse Cloud API.](/cloud/manage/openapi)

--- a/docs/cloud/features/05_admin_features/upgrades.md
+++ b/docs/cloud/features/05_admin_features/upgrades.md
@@ -22,7 +22,7 @@ With ClickHouse Cloud you never have to worry about patching and upgrades. We ro
 :::note
 We're introducing a new upgrade mechanism, a concept we call "make before break" (or MBB). With this new approach, we add updated replicas before removing the old ones during the upgrade operation. This results in more seamless upgrades that are less disruptive to running workloads.
 
-As part of this change, historical system table data will be retained for up to a maximum of 30 days as part of upgrade events. In addition, any system table data older than December 19, 2024, for services on AWS or GCP and older than January 14, 2025, for services on Azure won't be retained as part of the migration to the new organization tiers.
+As part of this change, historical system table data will be retained for up to a maximum of 30 days as part of upgrade events. In addition, any system table data older than December 19, 2024, for services on AWS or GCP, and older than January 14, 2025, for services on Azure won't be retained as part of the migration to the new organization tiers.
 :::
 
 ## Version compatibility {#version-compatibility}
@@ -35,7 +35,7 @@ You can't manage the service-level default `compatibility` setting for your serv
 
 ## Maintenance mode {#maintenance-mode}
 
-At times, it may be necessary for us to update your service, which could require us to disable certain features such as scaling or idling. In rare cases, we may need to take action on a service that is experiencing issues and bring it back to a healthy state. During such maintenance, you will see a banner on the service page that says _"Maintenance in progress"_. You may still be able to use the service for queries during this time.
+At times, we may need to update your service, which could require disabling certain features such as scaling or idling. In rare cases, we may need to take action on a service that is experiencing issues and bring it back to a healthy state. During such maintenance, you will see a banner on the service page that says _"Maintenance in progress"_. You may still be able to use the service for queries during this time.
 
 You won't be charged for the time that the service is under maintenance. _Maintenance mode_ is a rare occurrence and shouldn't be confused with regular service upgrades.
 

--- a/docs/cloud/features/08_backups.md
+++ b/docs/cloud/features/08_backups.md
@@ -23,13 +23,13 @@ ClickHouse Cloud backups are a combination of "full" and "incremental" backups t
 
 In the screenshot below, the solid line squares show full backups and the dotted line squares show incremental backups. The solid line rectangle around the squares denotes the retention period and the backups that are visible to the end user, which can be used for a backup restore. In the scenario below, backups are being taken every 24 hours and are retained for 2 days.
 
-On Day 1, a full backup is taken to start the backup chain. On Day 2, an incremental backup is taken, and we now have a full and incremental backup available to restore from. By Day 7, we have one full backup and six incremental backups in the chain, with the most recent two incremental backups visible to the user. On Day 8, we take a new full backup, and on Day 9, once we have two backups in the new chain, the previous chain is discarded.
+On Day 1, a full backup is taken to start the backup chain. On Day 2, an incremental backup is taken, and both full and incremental backups are available to restore from. By Day 7, we have one full backup and six incremental backups in the chain, with the most recent two incremental backups visible to the user. On Day 8, we take a new full backup, and on Day 9, once we have two backups in the new chain, the previous chain is discarded.
 
 <Image img={backup_chain} size="lg" alt="Backup chain example in ClickHouse Cloud" />
 
 ### Default backup policy {#default-backup-policy}
 
-In the Basic, Scale, and Enterprise tiers, backups are metered and billed separately from storage.
+Backups are metered and billed separately from storage in the Basic, Scale, and Enterprise tiers.
 All services will default to one daily backup with the ability to configure more, starting with the Scale tier, via the Settings tab of the Cloud console.
 Each backup will be retained for at least 24 hours.
 

--- a/docs/cloud/features/09_AI_ML/AI_chat_overview.md
+++ b/docs/cloud/features/09_AI_ML/AI_chat_overview.md
@@ -11,7 +11,7 @@ doc_type: 'reference'
 The “ClickHouse Assistant” agent is a turn-key experience that allows users to trigger complex analysis tasks on top of the data hosted in their ClickHouse Cloud service.
 Instead of writing SQL or navigating dashboards, users can describe what they're looking for in natural language.
 The assistant responds with generated queries, visualizations, or summaries, and can incorporate context like active tabs, saved queries, schema details, and dashboards to improve accuracy.
-It’s designed to work as an embedded assistant, helping users move quickly from questions to insights, and from prompts to working dashboards or APIs.
+It’s designed to work as an embedded assistant, helping users move quickly from questions to insights and from prompts to working dashboards or APIs.
 
 The experience also embeds a "Docs AI" sub-agent that can be used to ask specific questions about the ClickHouse documentation straight from the console.
 Instead of searching through hundreds of pages, users can ask direct questions like "How do I configure materialized views?" or "What's the difference between ReplacingMergeTree and AggregatingMergeTree?" and receive precise answers with relevant code examples and links to source documentation.

--- a/docs/cloud/features/09_AI_ML/langfuse.md
+++ b/docs/cloud/features/09_AI_ML/langfuse.md
@@ -74,7 +74,7 @@ flowchart TB
 
 ### Observability {#observability}
 
-[Observability](/docs/observability/overview) is essential for understanding and debugging LLM applications. Unlike traditional software, LLM applications involve complex, non-deterministic interactions that can be challenging to monitor and debug. Langfuse provides comprehensive tracing capabilities that help you understand exactly what's happening in your application.
+[Observability](/docs/observability/overview) is essential for understanding and debugging LLM applications. Unlike traditional software, LLM applications involve complex and non-deterministic interactions that can be challenging to monitor and debug. Langfuse provides comprehensive tracing capabilities that help you understand exactly what's happening in your application.
 
 _📹 Want to learn more? [**Watch end-to-end walkthrough**](https://langfuse.com/watch-demo?tab=observability) of Langfuse Observability and how to integrate it with your application._
 
@@ -224,7 +224,7 @@ Baseline your evaluation workflow with human annotations via Annotation Queues.
 </TabItem>
 <TabItem value="custom-evals" label="Custom Evals">
 
-Add custom evaluation results, supports numeric, boolean and categorical values.
+Add custom evaluation results; supports numeric, boolean, and categorical values.
 
 ```bash
 POST /api/public/scores

--- a/docs/cloud/features/09_AI_ML/remote_mcp_overview.md
+++ b/docs/cloud/features/09_AI_ML/remote_mcp_overview.md
@@ -10,12 +10,12 @@ doc_type: 'reference'
 
 Not all users interact with ClickHouse through the Cloud console.
 For example, many developers work directly from their preferred code editors, CLI agents, or connect to the database via custom setups, while others rely on general-purpose AI assistants such as Anthropic Claude for most of their explorations.
-These users, and the agentic workloads acting on their behalf, need a way to securely access and query ClickHouse Cloud without complex setups or custom infrastructure.
+These users and the agentic workloads acting on their behalf need a way to securely access and query ClickHouse Cloud without complex setups or custom infrastructure.
 
 The remote MCP server capability in ClickHouse Cloud addresses this by exposing a standard interface that external agents can use to retrieve analytical context.
 MCP, or Model Context Protocol, is a standard for structured data access by AI applications powered by LLMs.
 With this integration, external agents can list databases and tables, inspect schemas, and run scoped, read-only SELECT queries.
-Authentication is handled via OAuth, and the server is fully managed on ClickHouse Cloud, so no setup or maintenance is required.
+Authentication is handled via OAuth. The server is fully managed on ClickHouse Cloud, so no setup or maintenance is required.
 
 This makes it easier for agentic tools to plug into ClickHouse and retrieve the data they need, whether for analysis, summarization, code generation, or exploration.
 


### PR DESCRIPTION
### Motivation

- Improve clarity, grammar, punctuation, and consistency across ClickHouse Cloud feature documentation. 
- Make several sentences more concise and readable and apply consistent phrasing (including Oxford-comma consistency). 
- Ensure descriptions accurately convey product behavior and UI elements without changing technical meaning.

### Description

- Applied minor copy edits and rephrasing across multiple Cloud feature pages including SQL Console, Query Insights, HyperDX, Automatic Scaling, Make Before Break (MBB), Deployment Options, SharedMergeTree, API overview, Upgrades, Backups, ClickHouse Assistant, Langfuse, and Remote MCP to improve readability and consistency. 
- Adjusted a number of sentences to be more concise (for example removing "in order to" and splitting or joining clauses for clarity) and fixed punctuation and list formatting issues. 
- Standardized wording around feature descriptions such as adding "session data" to HyperDX, clarifying backup/retention explanations, and reflowing a few long lines into clearer statements. 
- Corrected small grammatical issues (commas, conjunctions, semicolons) and improved UI/UX wording where screenshots and flows are described.

### Testing

- No automated tests were run for these editorial changes as they are documentation-only modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aea918b494832caf391e3d3db7dd45)