### PR TITLE
Refine Wordy-rule phrasing and add Vale skill runbook

### DIFF
--- a/contribute/style-guide.md
+++ b/contribute/style-guide.md
@@ -1,6 +1,6 @@
 # ClickHouse docs style guide
 
-In this document, you will find a number of style guidelines for writing ClickHouse
+In this document, you will find style guidelines for writing ClickHouse
 documentation. As documentation is a collective effort, these guidelines are 
 intended to help all of us ensure we maintain quality and consistency across our
 documentation.
@@ -81,7 +81,7 @@ import clickhouse-local-3 from '@site/static/images/chdb/guides/clickhouse-local
 import Image from '@theme/IdealImage';
 ```
 
-To render images we use a fork of the IdealImage plugin. This generates multiple variants of an image, [asynchronously loading them as well as selecting the most appropriate based on the network connection](https://github.com/stereobooster/react-ideal-image/blob/master/introduction.md).
+To render images we use a fork of the IdealImage plugin. This generates multiple variants of an image, [asynchronously loading them and selecting the most appropriate based on the network connection](https://github.com/stereobooster/react-ideal-image/blob/master/introduction.md).
 
 Ensure you import the `Image` component as shown above.
 
@@ -95,7 +95,7 @@ Here is some example text which refers to the image below:
 Here is another paragraph...
 ```
 
-This component takes a number of props:
+This component takes several props:
 
 1. `img` - the imported image
 2. `alt` - mandatory alternate text specified
@@ -180,7 +180,7 @@ Code will be inserted here
 \```
 ```
 
-You will then use `docs-start-1`, `docs-end-1` comments for the first snippet, `docs-start-2`, `docs-end-2` for the second snippet and so on.
+You will then use `docs-start-1`, `docs-end-1` comments for the first snippet, `docs-start-2`, `docs-end-2` for the second snippet, and so forth.
 
 ### Highlighting
 
@@ -283,7 +283,7 @@ export function Anchor(props) {
 
 ### Floating pages
 
-In order to prevent pages from becoming 'floating' or 'orphaned' it is
+To prevent pages from becoming 'floating' or 'orphaned' it is
 necessary that you add a newly created page to `sidebars.js`. We have a [custom
 docusaurus plugin](plugins/checkFloatingPages.js) to catch dangling pages.
 
@@ -377,7 +377,7 @@ Your v0.7.x content here...
 
 #### API 2: External Snippets (Legacy)
 
-This approach uses separate snippet files for each version. Note that this method has limitations with TOC generation.
+This approach uses separate snippet files for each version. This method has limitations with TOC generation.
 
 Versioned folders are structured as follows:
 
@@ -507,7 +507,7 @@ match then it remains hidden.
 ## Vale
 
 Vale is a command-line tool that brings code-like linting to prose.
-We have a number of rules set up to ensure that our documentation is
+We have rules set up to ensure that our documentation is
 consistent in style.
 
 The style rules are located at `/styles/ClickHouse`, and largely based

--- a/skills/vale/SKILL.md
+++ b/skills/vale/SKILL.md
@@ -1,0 +1,39 @@
+# Vale rule runner skill
+
+Use this workflow to run Vale checks in `clickhouse-docs`, especially for one rule such as `Wordy.yml`.
+
+## Prerequisites
+
+1. Install Vale.
+2. Ensure you run commands from the repository root.
+
+## Run only one rule
+
+Use Vale's filter expression and this repo's config:
+
+```bash
+vale --config=.vale.ini --filter='.Name == "gitlab_base.Wordy"' docs contribute
+```
+
+Notes:
+- Rule file: `styles/ClickHouse/Wordy.yml`
+- Rule name used by Vale output: `gitlab_base.Wordy`
+
+## Run on a subset of files
+
+```bash
+vale --config=.vale.ini --filter='.Name == "gitlab_base.Wordy"' docs/path/to/file.md
+```
+
+## Typical fix loop
+
+1. Run the command above.
+2. Edit flagged lines to remove/replace wordy phrases.
+3. Re-run the same command until no findings remain for the scope you are targeting.
+
+## Common replacements from this rule
+
+- `as well as` → `and`
+- `in order to` → `to`
+- `note that` → remove phrase
+- `a number of` → remove phrase or use a precise quantity


### PR DESCRIPTION
### Motivation

- Reduce occurrences of wordy phrases that trigger the `Wordy.yml` Vale rule and improve prose clarity in the style guide. 
- Provide a concise local runbook so contributors and automation can run the `Wordy` Vale rule against the repo.

### Description

- Edited `contribute/style-guide.md` to remove/replace wordy phrases in several paragraphs (examples: `a number of` → removed/rewritten, `as well as` → `and`, `in order to` → `to`, `note that` → removed) and otherwise streamlined target sentences. 
- Added `skills/vale/SKILL.md` documenting how to run Vale for the `Wordy.yml` rule with the repo config and sample commands (for example `vale --config=.vale.ini --filter='.Name == "gitlab_base.Wordy"' docs contribute`).
- Committed the two changed files (`contribute/style-guide.md` and `skills/vale/SKILL.md`).

### Testing

- Attempted to install Vale via curl and extract (`curl -L -o vale.tar.gz https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_64-bit.tar.gz && tar -xzf vale.tar.gz && install -m 0755 vale /usr/local/bin/vale`), but the download failed due to outbound network/proxy `403` in this environment. 
- Attempted to install Vale via `apt-get install -y vale`, but repository access failed with `403` so installation could not complete. 
- Ran a targeted phrase scan with `rg -n -i "a number of|as well as|note that|\bplease\b|respectively|and so on|in order to|\bquite\b" contribute/style-guide.md` and confirmed no remaining matches in the edited file (scan succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aec5bd59dc832c8c309859ff635e3b)