### PR TITLE
Add Hex getting started info to chDB overview page

### DIFF
--- a/docs/chdb/index.md
+++ b/docs/chdb/index.md
@@ -29,7 +29,8 @@ You can use it when you want to get the power of ClickHouse in a programming lan
 **NEW!** DataStore provides a pandas-compatible API that combines familiar pandas syntax with ClickHouse performance.
 
 :::tip Get Started on Hex
-Ready to try ClickHouse in Hex? Follow the <a href="https://app.hex.tech/partnerships/app/chDB-Tutorial-032XsQ4qoKtlXxcw49joav/latest" target="_blank">getting started tutorial</a> to set up your first connection. Want more time to explore? Sign up for an <a href="https://app.hex.tech/signup/clickhouse-30" target="_blank">extended 30-day Hex trial</a> with full access to ClickHouse integrations.
+- 📖 <a href="https://app.hex.tech/partnerships/app/chDB-Tutorial-032XsQ4qoKtlXxcw49joav/latest" target="_blank"><b>Getting Started Tutorial</b></a> — set up your first connection
+- 🚀 <a href="https://app.hex.tech/signup/clickhouse-30" target="_blank"><b>Extended 30-day Hex Trial</b></a> — full access to ClickHouse integrations
 :::
 
 ### One-Line Migration {#one-line-migration}


### PR DESCRIPTION
## Summary
- Add a tip callout with links to the Hex getting started tutorial and the extended 30-day Hex trial
- Placed under the DataStore section on the chDB overview page to make it visually prominent

## Test plan
- [ ] Verify the `:::tip` admonition renders correctly on the docs site
- [ ] Verify the two Hex links open correctly in new tabs