### PR TITLE
Add clicko migration tool to schema management documentation

### DIFF
--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -118,7 +118,7 @@ These are the tools we generally recommend for ClickHouse users based on maturit
 
 [clicko](https://github.com/arsura/clicko) is a Go-based migration runner inspired by Goose, designed specifically for ClickHouse. It supports versioned SQL files and Go function migrations, and is available both as a CLI and an embeddable Go library.
 
-**Why it works well for ClickHouse:** clicko supports custom table engines for the migration tracking table, insert quorum, and cluster-aware DDL — making it a natural fit for self-hosted sharded deployments where general-purpose runners fall short.
+**Why it works well for ClickHouse:** clicko focuses on the operational details that matter for sharded clusters — custom table engines for the migration tracking table, insert quorum to ensure writes are replicated before being considered applied, and cluster-aware DDL propagation.
 
 **What to watch out for:** Smaller community than golang-migrate or Goose. No schema diffing or autogeneration.
 

--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -34,7 +34,7 @@ Schema management tools generally fall into two categories.
 
 #### Imperative
 These tools use versioned SQL files that describe *how* to get from state A to state B. You write explicit DDL statements like `CREATE TABLE`, `ALTER TABLE`, or `DROP COLUMN` into files. Then the tool runs the files in order and tracks which have been applied. In this category, you dictate the exact SQL to run.
-**Examples**: *golang-migrate, Goose, Flyway*
+**Examples**: *golang-migrate, Goose, Flyway, clicko*
 
 #### Declarative
 These tools start with the user defining a "desired state" schema definition. The tool detects the difference between the current database and the desired state, then generates and applies the necessary migration. This approach reduces manual migration writing and schema drift. In this category, the tool dictates the exact SQL to run.
@@ -113,6 +113,21 @@ These are the tools we generally recommend for ClickHouse users based on maturit
 - **Language:** Go (single binary)
 - **License:** Open Source (MIT, free)
 - **Cluster support:** No
+
+### clicko
+
+[clicko](https://github.com/arsura/clicko) is a Go-based migration runner inspired by Goose, designed specifically for ClickHouse. It supports versioned SQL files and Go function migrations, and is available both as a CLI and an embeddable Go library.
+
+**Why it works well for ClickHouse:** clicko supports custom table engines for the migration tracking table, insert quorum, and cluster-aware DDL — making it a natural fit for self-hosted sharded deployments where general-purpose runners fall short.
+
+**What to watch out for:** Smaller community than golang-migrate or Goose. No schema diffing or autogeneration.
+
+**Best for:** Go teams running self-hosted sharded ClickHouse clusters that need reliable, cluster-aware migration tracking.
+
+- **Type:** Imperative
+- **Language:** Go (single binary)
+- **License:** Open Source (MIT, free)
+- **Cluster support:** Yes
 
 ## Other Tools in the Ecosystem
 


### PR DESCRIPTION
Expanded the section on imperative schema management tools to include clicko, detailing its features, benefits for ClickHouse users, and considerations for use. Updated examples to reflect this addition.

## Summary
Added [clicko](https://github.com/arsura/clicko) to knowledgebase/schema_migration_tools.md as a recommended imperative migration tool. clicko is designed specifically for ClickHouse with support for custom table engines, insert quorum, and cluster-aware DDL — making it a better fit for self-hosted sharded deployments compared to general-purpose runners like Goose or golang-migrate.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
