### PR TITLE
Clarify credit threshold notifications for PAYG

### DIFF
--- a/docs/cloud/features/07_monitoring/notifications.md
+++ b/docs/cloud/features/07_monitoring/notifications.md
@@ -47,4 +47,5 @@ Certain **required** notifications such as **Payment failed** aren't configurabl
 Currently, we send out notifications related to billing (payment failure, usage exceeded ascertain threshold, etc.) as well as notifications related to scaling events (scaling completed, scaling blocked etc.).
 
 :::note
-Credit threshold notifications are currently only available for organizations with committed spend contracts. Pay-as-you-go (PAYG) organizations do not receive these notifications. :::
+Credit threshold notifications are currently only available for organizations with committed spend contracts. Pay-as-you-go (PAYG) organizations do not receive these notifications.
+:::


### PR DESCRIPTION
Added note about credit threshold notifications for PAYG organizations.
