### PR TITLE
Add 26.2 to release status page with rollout dates TBD

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_status.md
+++ b/docs/cloud/reference/01_changelog/02_release_status.md
@@ -47,6 +47,19 @@ For advance testing before production upgrades, use the Fast or Regular channel 
 
 <ReleaseSchedule releases={[
     {
+     changelog_link: 'https://clickhouse.com/docs/changelogs/26.2',
+     version: '26.2',
+     fast_start_date: 'TBD',
+     fast_end_date: 'TBD',
+     regular_start_date: 'TBD',
+     regular_end_date: 'TBD',
+     slow_start_date: 'TBD',
+     slow_end_date: 'TBD',
+     fast_progress: 'green',
+     regular_progress: 'green',
+     slow_progress: 'green'
+    },
+    {
      changelog_link: 'https://clickhouse.com/docs/changelogs/25.12',
      version: '25.12',
      fast_start_date: '2026-02-10',


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Following #5740 update release status page
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
