### PR TITLE
Add compression documentation for Kinesis ClickPipes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kinesis/01_overview.md
+++ b/docs/integrations/data-ingestion/clickpipes/kinesis/01_overview.md
@@ -4,7 +4,7 @@ description: 'Seamlessly connect your Amazon Kinesis data sources to ClickHouse 
 slug: /integrations/clickpipes/kinesis
 title: 'Integrating Amazon Kinesis with ClickHouse Cloud'
 doc_type: 'guide'
-keywords: ['clickpipes', 'kinesis', 'streaming', 'aws', 'data ingestion']
+keywords: ['clickpipes', 'kinesis', 'streaming', 'aws', 'data ingestion', 'compression', 'gzip', 'zstd', 'lz4', 'snappy']
 integration:
   - support_level: 'core'
   - category: 'clickpipes'
@@ -91,6 +91,23 @@ You have familiarized yourself with the [ClickPipes intro](../index.md) and setu
 
 The supported formats are:
 - [JSON](/interfaces/formats/JSON)
+
+## Compression {#compression}
+
+ClickPipes for Kinesis automatically detects and decompresses compressed records. Unlike Kafka, where the client library handles decompression transparently, Kinesis delivers raw bytes — ClickPipes handles this for you with no configuration required.
+
+The following compression codecs are supported:
+
+- **gzip**
+- **zstd**
+- **lz4**
+- **snappy** (framed format)
+
+Compression is detected automatically via magic bytes in each record. If no known compression signature is found, the record is treated as uncompressed. The detected compression type is also surfaced during schema inference, so the sample data preview in the UI will correctly show the decompressed data.
+
+:::note
+Auto-detection is safe for text-based formats like JSON and CSV, as printable ASCII characters will never collide with compression magic bytes.
+:::
 
 ## Supported data types {#supported-data-types}
 


### PR DESCRIPTION
## Summary
Add documentation for auto-decompression of compressed Kinesis records in ClickPipes (gzip, zstd, lz4, snappy), based on https://github.com/ClickHouse/clickpipes-platform/pull/5665.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
