### PR TITLE
Update restore command to exclude system tables

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -180,7 +180,7 @@ where `uuid` is a unique identifier, used to identify the backup.
 <TabItem value="Restore" label="RESTORE" default>
 
 ```sql
-RESTORE ALL
+RESTORE ALL EXCEPT TABLES system.users, system.roles
 FROM S3(
     'https://testchbackups.s3.amazonaws.com/<uuid>',
     '<key id>',


### PR DESCRIPTION
## Summary
Restore all command fails if it does not exclude system tables system.users, system.roles

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
