### PR TITLE
docs: use arrayElement for random event_type in generating test data guide

### DIFF
--- a/docs/guides/starter_guides/generating-test-data.md
+++ b/docs/guides/starter_guides/generating-test-data.md
@@ -32,13 +32,13 @@ INSERT INTO user_events
 SELECT
   generateUUIDv4() AS event_id,
   rand() % 10000 AS user_id,
-  arrayJoin(['click','view','purchase']) AS event_type,
+  arrayElement(['click','view','purchase'], toUInt32(rand()) % 3 + 1) AS event_type,
   now() - INTERVAL rand() % 3600*24 SECOND AS event_time
 FROM numbers(1000000);
 ```
 
 * `rand() % 10000`: uniform distribution of 10k users
-* `arrayJoin(...)`: randomly selects one of three event types
+* `arrayElement(...)`: randomly selects one of three event types
 * Timestamps spread over the previous 24 hours
 
 ---


### PR DESCRIPTION
### Motivation
- Clarify the Simple uniform dataset example because `arrayJoin` expands rows rather than selecting a single random element, so the example and description were misleading.

### Description
- Replace `arrayJoin(['click','view','purchase'])` with `arrayElement(['click','view','purchase'], toUInt32(rand()) % 3 + 1)` and update the explanatory bullet to reference `arrayElement(...)` in `docs/guides/starter_guides/generating-test-data.md`.

### Testing
- Ran `git diff --check -- docs/guides/starter_guides/generating-test-data.md`, which reported no issues.
- Attempted to fetch the published guide URL to confirm the change, but the HTTP request failed due to a proxy error in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b2cd7f4198832cb6f197f67eb526c3)