### PR TITLE
Replace `ENGINE = Log` with `ENGINE = MergeTree` + `ORDER BY ()` in documentation examples

### DIFF
--- a/docs/getting-started/example-datasets/amplab-benchmark.md
+++ b/docs/getting-started/example-datasets/amplab-benchmark.md
@@ -35,7 +35,8 @@ CREATE TABLE rankings_tiny
     pageURL String,
     pageRank UInt32,
     avgDuration UInt32
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 CREATE TABLE uservisits_tiny
 (
@@ -55,7 +56,8 @@ CREATE TABLE rankings_1node
     pageURL String,
     pageRank UInt32,
     avgDuration UInt32
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 CREATE TABLE uservisits_1node
 (
@@ -75,7 +77,8 @@ CREATE TABLE rankings_5nodes_on_single
     pageURL String,
     pageRank UInt32,
     avgDuration UInt32
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 CREATE TABLE uservisits_5nodes_on_single
 (

--- a/docs/getting-started/example-datasets/criteo.md
+++ b/docs/getting-started/example-datasets/criteo.md
@@ -54,7 +54,8 @@ CREATE TABLE criteo_log (
     cat24 String,
     cat25 String,
     cat26 String
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 ```
 
 Insert the data:

--- a/docs/getting-started/install/_snippets/_docker.md
+++ b/docs/getting-started/install/_snippets/_docker.md
@@ -194,5 +194,6 @@ set -e
 
 clickhouse client -n <<-EOSQL
     CREATE DATABASE docker;
-    CREATE TABLE docker.docker (x Int32) ENGINE = Log;
+    CREATE TABLE docker.docker (x Int32) ENGINE = MergeTree
+    ORDER BY ();
 EOSQL

--- a/docs/guides/examples/aggregate_function_combinators/argMinIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/argMinIf.md
@@ -30,7 +30,8 @@ CREATE TABLE product_prices(
     price Decimal(10,2),
     timestamp DateTime,
     in_stock UInt8
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO product_prices VALUES
     (1, 10.99, '2024-01-01 10:00:00', 1),

--- a/docs/guides/examples/aggregate_function_combinators/avgIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/avgIf.md
@@ -25,7 +25,8 @@ CREATE TABLE sales(
     transaction_id UInt32,
     amount Decimal(10,2),
     is_successful UInt8
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO sales VALUES
     (1, 100.50, 1),

--- a/docs/guides/examples/aggregate_function_combinators/avgMap.md
+++ b/docs/guides/examples/aggregate_function_combinators/avgMap.md
@@ -26,7 +26,8 @@ CREATE TABLE metrics(
     date Date,
     timeslot DateTime,
     status Map(String, UInt64)
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO metrics VALUES
     ('2000-01-01', '2000-01-01 00:00:00', (['a', 'b', 'c'], [15, 25, 35])),

--- a/docs/guides/examples/aggregate_function_combinators/countIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/countIf.md
@@ -25,7 +25,8 @@ CREATE TABLE login_attempts(
     user_id UInt32,
     timestamp DateTime,
     is_successful UInt8
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO login_attempts VALUES
     (1, '2024-01-01 10:00:00', 1),

--- a/docs/guides/examples/aggregate_function_combinators/maxMap.md
+++ b/docs/guides/examples/aggregate_function_combinators/maxMap.md
@@ -26,7 +26,8 @@ CREATE TABLE metrics(
     date Date,
     timeslot DateTime,
     status Map(String, UInt64)
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO metrics VALUES
     ('2000-01-01', '2000-01-01 00:00:00', (['a', 'b', 'c'], [15, 25, 35])),

--- a/docs/guides/examples/aggregate_function_combinators/minMap.md
+++ b/docs/guides/examples/aggregate_function_combinators/minMap.md
@@ -26,7 +26,8 @@ CREATE TABLE metrics(
     date Date,
     timeslot DateTime,
     status Map(String, UInt64)
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO metrics VALUES
     ('2000-01-01', '2000-01-01 00:00:00', (['a', 'b', 'c'], [15, 25, 35])),

--- a/docs/guides/examples/aggregate_function_combinators/quantilesTimingArrayIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/quantilesTimingArrayIf.md
@@ -26,7 +26,8 @@ CREATE TABLE api_responses(
     endpoint String,
     response_times_ms Array(UInt32),
     success_rate Float32
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO api_responses VALUES
     ('orders', [82, 94, 98, 87, 103, 92, 89, 105], 0.98),

--- a/docs/guides/examples/aggregate_function_combinators/quantilesTimingIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/quantilesTimingIf.md
@@ -25,7 +25,8 @@ CREATE TABLE api_responses(
     endpoint String,
     response_time_ms UInt32,
     is_successful UInt8
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO api_responses VALUES
     ('orders', 82, 1),

--- a/docs/guides/examples/aggregate_function_combinators/sumIf.md
+++ b/docs/guides/examples/aggregate_function_combinators/sumIf.md
@@ -25,7 +25,8 @@ CREATE TABLE sales(
     transaction_id UInt32,
     amount Decimal(10,2),
     is_successful UInt8
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO sales VALUES
     (1, 100.50, 1),

--- a/docs/guides/examples/aggregate_function_combinators/sumMap.md
+++ b/docs/guides/examples/aggregate_function_combinators/sumMap.md
@@ -26,7 +26,8 @@ CREATE TABLE metrics(
     date Date,
     timeslot DateTime,
     status Map(String, UInt64)
-) ENGINE = Log;
+) ENGINE = MergeTree
+ORDER BY ();
 
 INSERT INTO metrics VALUES
     ('2000-01-01', '2000-01-01 00:00:00', (['a', 'b', 'c'], [15, 25, 35])),


### PR DESCRIPTION
### Motivation
- Update documentation examples to use `MergeTree` instead of the deprecated/less-appropriate `Log` engine to reflect current ClickHouse best practices.
- Ensure example CREATE TABLE statements include a valid `MergeTree` declaration with an `ORDER BY` clause so examples work on modern ClickHouse installations.

### Description
- Replaced `ENGINE = Log;` with `ENGINE = MergeTree\nORDER BY ();` across multiple docs and example files, including dataset guides and aggregate function examples.
- Updated the Docker initialization snippet to create a `MergeTree` table instead of a `Log` table in the `/docker-entrypoint-initdb.d` example.
- Files touched include `docs/getting-started/example-datasets/*` and many files under `docs/guides/examples/aggregate_function_combinators/` such as `argMinIf.md`, `avgIf.md`, `avgMap.md`, `countIf.md`, `maxMap.md`, `minMap.md`, `quantilesTimingArrayIf.md`, `quantilesTimingIf.md`, `sumIf.md`, and `sumMap.md`.
- Kept SQL and shell examples unchanged aside from the table engine updates so example workflows remain the same.

### Testing
- Built the documentation site with `mkdocs build` to validate the markdown and site generation, and the build completed successfully.
- Ran markdown linting (`mdl`) on the modified files and there were no linting errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1513554d8832aabdaaae9dcbfb97a)