### PR TITLE
Remove me-central-1

### DIFF
--- a/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
+++ b/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
@@ -30,7 +30,6 @@ To restrict access to your ClickHouse Cloud services exclusively through AWS Pri
 ClickHouse Cloud supports [cross-region PrivateLink](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-privatelink-across-region-connectivity/) from the following regions:
 - sa-east-1
 - il-central-1
-- me-central-1
 - me-south-1
 - eu-central-2
 - eu-north-1

--- a/docs/cloud/reference/05_supported-regions.md
+++ b/docs/cloud/reference/05_supported-regions.md
@@ -21,7 +21,6 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - eu-central-1 (Frankfurt)
 - eu-west-1 (Ireland)
 - eu-west-2 (London)
-- me-central-1 (UAE)
 - us-east-1 (N. Virginia)
 - us-east-2 (Ohio)
 - us-west-2 (Oregon)


### PR DESCRIPTION
## Summary
Remove me-central-1 from docs due to ongoing AWS outage

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
