### PR TITLE
docs: note Transparent Huge Pages recommendation for Linux <5.10 in Windows ClickHouse guide

### DIFF
--- a/knowledgebase/install-clickhouse-windows10.mdx
+++ b/knowledgebase/install-clickhouse-windows10.mdx
@@ -82,6 +82,14 @@ Connected to ClickHouse server version 23.4.1 revision 54462.
 Warnings:
  * Linux transparent hugepages are set to "always". Check /sys/kernel/mm/transparent_hugepage/enabled
 
+On Linux kernels earlier than `5.10`, set Transparent Huge Pages to `madvise` instead of `always`:
+
+```bash
+echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+For Linux kernel `5.10` and newer (including typical WSL2 kernels), this warning is generally not critical.
+
 marspc2. :)
 ```
 


### PR DESCRIPTION
### Motivation
- Provide users of the ClickHouse Windows/WSL2 installation guide guidance to address the "transparent hugepages" warning on older Linux kernels by recommending a safe system setting change.

### Description
- Add a short note that on Linux kernels earlier than `5.10` users should set Transparent Huge Pages to `madvise` with `echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled`, and that kernel `5.10` and newer (including typical WSL2 kernels) generally do not require this change.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c15f43940c832a8fe71d27ee448307)