### PR TITLE
Update BigLake Metastore link in documentation

### DIFF
--- a/docs/use-cases/data_lake/reference/biglake_catalog.md
+++ b/docs/use-cases/data_lake/reference/biglake_catalog.md
@@ -15,7 +15,7 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 <BetaBadge/>
 
-ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, etc.). This guide will walk you through the steps to query your Iceberg tables in [BigLake Metastore](https://cloud.google.com/biglake/docs) via ClickHouse.
+ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, etc.). This guide will walk you through the steps to query your Iceberg tables in [BigLake Metastore](https://docs.cloud.google.com/biglake/docs/) via ClickHouse.
 
 :::note
 As this feature is beta, you will need to enable it using:


### PR DESCRIPTION
## Summary
Link seems to have changed

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
