### PR TITLE
docs: fix wording and punctuation in remote MCP guide

### DIFF
--- a/docs/cloud/guides/AI_ML/remote_mcp.md
+++ b/docs/cloud/guides/AI_ML/remote_mcp.md
@@ -30,10 +30,10 @@ This guide shows you how to enable the ClickHouse Cloud Remote MCP Server and se
 
 ## Enable remote MCP server for Cloud {#enable-remote-mcp-server}
 
-Connect to the ClickHouse Cloud service for which you want to enable remote MCP server, click on the `Connect` button in the left hand menu.
-A box with connection details will open.
+Connect to the ClickHouse Cloud service for which you want to enable the remote MCP server.
+In the left-hand menu, click **Connect**. A box with connection details will open.
 
-Select "Connect with MCP":
+Select **Connect with MCP**:
 
 <Image img={img1} alt="Select MCP in the Connect Modal" size="md"/>
 
@@ -102,7 +102,7 @@ Add the following configuration to your `.vscode/mcp.json`:
 }
 ```
 
-For more details refer to the [Visual Studio Code docs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+For more details refer to the [Visual Studio Code docs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
 
 ### Windsurf {#windsurf}
 
@@ -119,7 +119,7 @@ Edit your `mcp_config.json` file with the following config:
 }
 ```
 
-For more details refer to the [Windsurf docs](https://docs.windsurf.com/windsurf/cascade/mcp#adding-a-new-mcp)
+For more details refer to the [Windsurf docs](https://docs.windsurf.com/windsurf/cascade/mcp#adding-a-new-mcp).
 
 ### Zed {#zed}
 
@@ -137,7 +137,7 @@ Add the following to your Zed settings under **context_servers**:
 ```
 
 Zed should then prompt you to authenticate via OAuth when it first connects to the server.
-For more details refer to the [Zed docs](https://zed.dev/docs/ai/mcp#as-custom-servers)
+For more details refer to the [Zed docs](https://zed.dev/docs/ai/mcp#as-custom-servers).
 
 ### Codex {#codex}
 


### PR DESCRIPTION
### Motivation
- Fix minor style and punctuation issues in `docs/cloud/guides/AI_ML/remote_mcp.md` discovered during PR review.
- Make UI element labels follow the documentation style and improve clarity by correcting a run-on sentence.

### Description
- Split and rephrased the run-on sentence in the "Enable remote MCP server" section into two clearer sentences.
- Replaced inline code/quoted UI labels with bold formatting for **Connect** and **Connect with MCP** to match docs conventions.
- Added missing terminal periods to the reference lines for Visual Studio Code, Windsurf, and Zed.
- Changes applied to `docs/cloud/guides/AI_ML/remote_mcp.md` and committed.

### Testing
- Displayed the updated file with `nl -ba docs/cloud/guides/AI_ML/remote_mcp.md | sed -n '28,145p'`, which showed the edits successfully.
- Verified repository changes with `git status --short && git diff -- docs/cloud/guides/AI_ML/remote_mcp.md`, which reported the expected diff.
- Confirmed the commit with `git show --stat --oneline --no-patch HEAD` and `git show --name-only --pretty=format: HEAD`, which listed the modified file.
- No runtime or unit tests were required because this is a content-only documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c402a77834832c866a6d56aacf9ecf)