### PR TITLE
Corrected a typo in the "Storage backed by object store" section: share → shard

### DIFF
--- a/docs/cloud/reference/02_architecture.md
+++ b/docs/cloud/reference/02_architecture.md
@@ -16,7 +16,7 @@ import Architecture from '@site/static/images/cloud/reference/architecture.png';
 
 ## Storage backed by object store {#storage-backed-by-object-store}
 - Virtually unlimited storage
-- No need to manually share data
+- No need to manually shard data
 - Significantly lower price point for storing data, especially data that is accessed less frequently
 
 ## Compute {#compute}


### PR DESCRIPTION
Corrected typo from 'share' to 'shard' in storage section.

## Summary
Fixes a single-word typo where "No need to manually share data" should read "No need to manually shard data". 
