### PR TITLE
docs: call out sentence case standards in style guides

### DIFF
--- a/contribute/contrib-writing-guide.md
+++ b/contribute/contrib-writing-guide.md
@@ -23,6 +23,16 @@ Every page in the docs has an **Edit this page** link that opens the page in the
 
 Usually, these plugins provide a preview of how the markdown will render, and they catch basic errors like unclosed tags very early.
 
+## Use sentence case in headings and titles {#use-sentence-case-in-headings-and-titles}
+
+Use sentence case for doc titles and headings:
+
+- Capitalize the first word and proper nouns.
+- Keep official capitalization for product names (for example, `ClickHouse` and `clickhouse-local`).
+- Avoid title case for headers unless there is a specific brand requirement.
+
+For details, see the [ClickHouse docs style guide](./style-guide.md#sentence-casing-for-titles-and-headings) and Google's guidance on [headings](https://developers.google.com/style/headings) and [product names](https://developers.google.com/style/product-names).
+
 ## Building the docs locally {#building-the-docs-locally}
 
 You can build the ClickHouse docs on most machines.

--- a/contribute/style-guide.md
+++ b/contribute/style-guide.md
@@ -35,6 +35,22 @@ checks on front-matter:
 
 For implementation details see [plugins/frontmatter-validation](https://github.com/ClickHouse/clickhouse-docs/tree/main/plugins/frontmatter-validation)
 
+## Sentence casing for titles and headings
+
+Use sentence case for document titles, headings, and UI labels in docs content.
+
+- Capitalize the first word and proper nouns only.
+- Keep official product and brand capitalization when names are intentionally styled (for example, `ClickHouse`, `clickhouse-local`, `GitHub`).
+- Use the same sentence case style in front matter (`title`, `sidebar_label`) and in-page headings (`##`, `###`, etc.).
+
+Examples:
+
+- ✅ `title: 'Install ClickHouse on Debian/Ubuntu'`
+- ✅ `## Configure backups for self-managed ClickHouse`
+- ❌ `## Configure Backups For Self-Managed ClickHouse`
+
+Reference: [Google developer documentation style guide: Headings and titles](https://developers.google.com/style/headings) and [Product names](https://developers.google.com/style/product-names).
+
 ## Explicit header tags
 
 Due to the way our translation system works, it is necessary to add an explicit


### PR DESCRIPTION
### Motivation

- Standardize sentence casing for document titles, headings, and UI labels across the ClickHouse docs and reduce inconsistent header capitalization.
- Align internal guidance with external recommendations for headings and product names by referencing Google developer documentation style guidance.

### Description

- Add a new `Sentence casing for titles and headings` section to `contribute/style-guide.md` that defines sentence-case rules, covers front-matter fields (`title`, `sidebar_label`), and includes correct/incorrect examples and Google references.
- Add a matching `Use sentence case in headings and titles` section to `contribute/contrib-writing-guide.md` that summarizes the rule for contributors and links back to the style guide.
- Clarifies product-name capitalization behavior (preserve official styling for names like `ClickHouse` and `clickhouse-local`).
- No external skills were invoked during this change.

### Testing

- Ran `yarn check-markdown`, which failed in the local environment because `markdownlint-cli2` is not installed.
- No other automated checks were executed locally; repository CI is expected to run full linting and build checks after this change is merged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4f950a404832cbad5f50b05c72774)