### PR TITLE
Show when server settings require restart or not

### DIFF
--- a/scripts/settings/global-server-settings.sql
+++ b/scripts/settings/global-server-settings.sql
@@ -13,7 +13,12 @@ WITH
             name,
             replaceRegexpAll(description, '(?m)^[ \t]+', '') AS description,
             type,
-            default
+            default,
+            multiIf(
+                changeable_without_restart = 'IncreaseOnly', 'Increase only',
+                changeable_without_restart = 'DecreaseOnly', 'Decrease only',
+                CAST(changeable_without_restart, 'String')
+            ) AS changeable_without_restart
         FROM system.server_settings
     ),
     combined_server_settings AS
@@ -22,14 +27,16 @@ WITH
             name,
             description,
             type,
-            default
+            default,
+            changeable_without_restart
         FROM server_settings_in_source
         UNION ALL
         SELECT
             name,
             doc AS description,
             ''  AS type,
-            '' AS default
+            '' AS default,
+            '' AS changeable_without_restart
         FROM server_settings_outside_source
     ),
     formatted_settings AS
@@ -39,7 +46,14 @@ WITH
             '## {}{}{}{}\n\n',
             name,
             lcase(' {#'|| name ||'} \n\n'),
-            if(type != '' AND default != '', format('<SettingsInfoBlock type="{}" default_value="{}" />', type, default), ''),
+            if(type != '' AND default != '',
+                format('<SettingsInfoBlock type="{}" default_value="{}"{} />',
+                    type,
+                    default,
+                    if(changeable_without_restart != '', format(' changeable_without_restart="{}"', changeable_without_restart), '')
+                ),
+                ''
+            ),
             description
         ) AS formatted_text
         FROM combined_server_settings

--- a/src/theme/SettingsInfoBlock/SettingsInfoBlock.js
+++ b/src/theme/SettingsInfoBlock/SettingsInfoBlock.js
@@ -15,7 +15,21 @@ function SettingsInfoBlockPlaceholder() {
     );
 }
 
-const SettingsInfoBlock = ({type, default_value}) => {
+const SettingsInfoBlock = ({type, default_value, changeable_without_restart}) => {
+    const headers = [
+        { label: 'Type' },
+        { label: 'Default value' },
+    ];
+    const items = [
+        { label: `${type}` },
+        { label: `${default_value}` },
+    ];
+
+    if (changeable_without_restart) {
+        headers.push({ label: 'Changeable without restart' });
+        items.push({ label: `${changeable_without_restart}` });
+    }
+
     return(
         <BrowserOnly fallback={<SettingsInfoBlockPlaceholder />}>
             {() => {
@@ -24,22 +38,12 @@ const SettingsInfoBlock = ({type, default_value}) => {
                 >
                     <Suspense fallback={<SettingsInfoBlockPlaceholder />}>
                         <Table
-                            headers={[
-                                {
-                                    label: 'Type'
-                                },
-                                {
-                                    label: 'Default value'
-                                },
-                            ]}
+                            headers={headers}
                             rows={
                                 [
                                     {
                                         id: "row-1",
-                                        items: [
-                                            {label: `${type}`},
-                                            {label: `${default_value}`}
-                                        ]
+                                        items: items
                                     }
                                 ]
                             }


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/113

Pull `changeable_without_restart` during query and display it in the settings information block
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
