### PR TITLE
Translations: support Korean search and update all language indexes

### DIFF
--- a/.github/workflows/build-search.yml
+++ b/.github/workflows/build-search.yml
@@ -33,8 +33,32 @@ jobs:
       - name: Run Auto Generate Settings
         run: yarn autogenerate-settings
 
-      - name: Run Indexer
-        run: yarn run-indexer
+      - name: Run Indexer (en)
+        run: yarn run-indexer --locale en
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_APP_ID: 5H9UG7CX5W
+
+      - name: Run Indexer (jp)
+        run: yarn run-indexer --locale jp
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_APP_ID: 5H9UG7CX5W
+
+      - name: Run Indexer (zh)
+        run: yarn run-indexer --locale zh
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_APP_ID: 5H9UG7CX5W
+
+      - name: Run Indexer (ru)
+        run: yarn run-indexer --locale ru
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_APP_ID: 5H9UG7CX5W
+
+      - name: Run Indexer (ko)
+        run: yarn run-indexer --locale ko
         env:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ALGOLIA_APP_ID: 5H9UG7CX5W

--- a/scripts/search/index_pages.py
+++ b/scripts/search/index_pages.py
@@ -36,6 +36,11 @@ LOCALE_CONFIG = {
         'base_path': 'i18n/ru/docusaurus-plugin-content-docs/current',
         'url_prefix': '/ru',
         'index_suffix': '-ru'
+    },
+    'ko': {
+        'base_path': 'i18n/ko/docusaurus-plugin-content-docs/current',
+        'url_prefix': '/ko',
+        'index_suffix': '-ko'
     }
 }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- Adds Korean to Algolia config
- Modifies search index build script to target all languages
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
