### PR TITLE
CI: relax strictness of frontmatter check

### DIFF
--- a/plugins/frontmatter-validation/customParseFrontMatter.js
+++ b/plugins/frontmatter-validation/customParseFrontMatter.js
@@ -267,17 +267,16 @@ async function customParseFrontMatter(params) {
                         currentFieldName === 'pagination_prev';
 
                     if (!isExcludedField && !inMultiLineValue && (
-                        line.includes(': "') || (
-                            line.includes(': ') &&
-                            !line.includes(': \'') &&
-                            !line.includes(': [') &&
-                            !line.includes(': {') &&
-                            !line.includes(': true') &&
-                            !line.includes(': false') &&
-                            !/: \d+/.test(line)
-                        )
+                        line.includes(': ') &&
+                        !line.includes(': \'') &&
+                        !line.includes(': "') &&
+                        !line.includes(': [') &&
+                        !line.includes(': {') &&
+                        !line.includes(': true') &&
+                        !line.includes(': false') &&
+                        !/: \d+/.test(line)
                     )) {
-                        issues.push(`value should use single quotes in line: "${line.trim()}"`);
+                        issues.push(`value should be quoted in line: "${line.trim()}"`);
                     }
                 } else if (inMultiLineValue) {
                     // This is a continuation of a multi-line value


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Markdown linter in https://github.com/ClickHouse/ClickHouse/pull/101550 is failing because this check expects single quotes however this seems excessively strict.

```
docs/operations/system-tables/jemalloc_profile_text.md:
  • value should use single quotes in line: "description: "Displays the symbolized jemalloc heap profile. Run 'SYSTEM JEMALLOC FLUSH PROFILE' to generate a profile first.""

```
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
