### PR TITLE
Clarification on Aggregate Function

### DIFF
--- a/docs/integrations/language-clients/java/index.md
+++ b/docs/integrations/language-clients/java/index.md
@@ -76,18 +76,21 @@ Java Client was developed far back in 2015. Its codebase became very hard to mai
 |Ring                   |✔                    |✔                    |
 |Polygon                |✔                    |✔                    |
 |SimpleAggregateFunction|✔                    |✔                    |
-|AggregateFunction      |✗                    |✔                    |
+|AggregateFunction*     |✔                    |✔                    |
 |Variant                |✔                    |✗                    |
 |Dynamic                |✔                    |✗                    |
 |JSON                   |✔                    |✗                    |
 
 [ClickHouse Data Types](/sql-reference/data-types)
 
-:::note
-- AggregatedFunction - :warning: doesn't support `SELECT * FROM table ...`
-- Decimal - `SET output_format_decimal_trailing_zeros=1` in 21.9+ for consistency
-- Enum - can be treated as both string and integer
-- UInt64 - mapped to `long` in client-v1
+:::note[Partial support]
+- **AggregateFunction** — Only `groupBitmap` is supported for direct binary reads. For other aggregate functions (`min`, `max`, `avg`, etc.), use `-Merge` combinators in your query (e.g., `minMerge()`, `avgMerge()`) to resolve the state server-side. `SELECT * FROM table ...` is not supported for columns with `AggregateFunction` type.
+:::
+
+:::note[Data type notes]
+- **Decimal** — `SET output_format_decimal_trailing_zeros=1` in 21.9+ for consistency.
+- **Enum** — can be treated as both string and integer.
+- **UInt64** — mapped to `long` in client-v1.
 :::
 
 ### Features {#features}

--- a/docs/integrations/language-clients/java/jdbc/jdbc.mdx
+++ b/docs/integrations/language-clients/java/jdbc/jdbc.mdx
@@ -1037,7 +1037,7 @@ try (PreparedStatement ps = conn.prepareStatement("select date_time from mytable
 ## Handling `AggregateFunction` {#handling-aggregatefunction}
 
 :::note
-As of now, only `groupBitmap` is supported.
+Direct binary reading of `AggregateFunction` state is only supported for `groupBitmap`. For other aggregate functions (`min`, `max`, `avg`, etc.), use `-Merge` combinators in your query (e.g., `SELECT minMerge(min_state) FROM ...`) to resolve the aggregate state server-side and return a plain value.
 :::
 
 ```java showLineNumbers


### PR DESCRIPTION
## Summary
Clarify AggregateFunction support in the Java client docs. Fixes misleading data type table (V2 was marked unsupported) and explains the `-Merge` combinator workaround.

Resolves linear ticket DOC-122 and https://github.com/ClickHouse/clickhouse-docs/issues/1454

Had to open up a new PR with v2 branch because Vercel thought I was a bot 🤖 🤣 

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
