### PR TITLE
docs: fix ClickStack dashboard and search wording

### DIFF
--- a/docs/use-cases/observability/clickstack/dashboards/index.md
+++ b/docs/use-cases/observability/clickstack/dashboards/index.md
@@ -42,7 +42,7 @@ Visualizations can be created from traces, metrics, logs, or any user-defined wi
 
 The **Chart Explorer** interface in HyperDX allows you to visualize metrics, traces, and logs over time, making it easy to create quick visualizations for data analysis. This interface is also reused when creating dashboards. The following section walks through the process of creating a visualization using Chart Explorer.
 
-Each visualization begins by selecting a **data source**, followed by a **metric**, with optional **filter expressions** and **group by** fields. Conceptually, visualizations in HyperDX map to a SQL `GROUP BY` query under the hood — users define metrics to aggregate across selected dimensions.
+Each visualization begins by selecting a **data source**, followed by a **metric**, with optional **filter expressions** and **group by** fields. Conceptually, visualizations in HyperDX map to a SQL `GROUP BY` query under the hood — you define metrics to aggregate across selected dimensions.
 
 :::tip AI-powered chart generation
 ClickStack also supports creating charts from natural language prompts using the [text-to-chart](/use-cases/observability/clickstack/text-to-chart) feature. Describe what you want to see, and ClickStack generates the visualization automatically.
@@ -163,7 +163,7 @@ The dashboard will be auto-saved. To set the dashboard name, select the title an
 
 </VerticalStepper>
 
-## Dashboards - Editing visualizations {#dashboards-editing-visualizations}
+## Dashboards - editing visualizations {#dashboards-editing-visualizations}
 
 To remove, edit, or duplicate a visualization, hover over it and use the corresponding action buttons.
 
@@ -174,7 +174,7 @@ To remove, edit, or duplicate a visualization, hover over it and use the corresp
 Dashboards are accessible from the left-hand menu, with built-in search to quickly locate specific dashboards.
 <Image img={dashboard_search} alt="Dashboard search" size="sm"/>
 
-## Dashboards - Tagging {#tagging}
+## Dashboards - tagging {#tagging}
 <Tagging />
 
 ## Custom filters {#custom-filters}
@@ -260,7 +260,7 @@ This dashboard queries the ClickHouse [system tables](/operations/system-tables)
 
 ### Services dashboard {#services-dashboard}
 
-The Services dashboard displays currently active services based on trace data. This requires users to have collected traces and configured a valid Traces data source.
+The Services dashboard displays currently active services based on trace data. This requires you to have collected traces and configured a valid Traces data source.
 
 Service names are auto-detected from the trace data, with a series of prebuilt visualizations organized across three tabs: HTTP Services, Database, and Errors.
 

--- a/docs/use-cases/observability/clickstack/search.md
+++ b/docs/use-cases/observability/clickstack/search.md
@@ -19,7 +19,7 @@ ClickStack allows you to do a full-text search on your events (logs and traces).
 This same search syntax is used for filtering events with Dashboards and Charts
 as well.
 
-## Search Features {#search-features}
+## Search features {#search-features}
 
 ### Natural language search syntax {#natural-language-syntax}
 


### PR DESCRIPTION
### Motivation
- Address DOC-690 quality issues by replacing third-person wording with second-person where appropriate and normalizing heading sentence case on the ClickStack dashboards and search pages.

### Description
- Edited `docs/use-cases/observability/clickstack/dashboards/index.md` and `docs/use-cases/observability/clickstack/search.md` to change instances of "users" to "you" in the two noted sentences and to update the headings to sentence case ("Dashboards - editing visualizations", "Dashboards - tagging", and "Search features").

### Testing
- Ran `rg -n "users define metrics|Dashboards - Editing visualizations|Dashboards - Tagging|requires users to have collected traces|Search Features" docs/use-cases/observability/clickstack/dashboards/index.md docs/use-cases/observability/clickstack/search.md` to locate the issues and ran `git status --short && git diff -- docs/use-cases/observability/clickstack/dashboards/index.md docs/use-cases/observability/clickstack/search.md` to verify the intended edits, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d015d098b8832a9ff07e36318cb001)