### PR TITLE
Cloud changelog: Week of 2026-04-10 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -14,10 +14,34 @@ import crash_reports_collection from '@site/static/images/cloud/reference/crash-
 In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibility](/whats-new/cloud-compatibility) page.
 
 :::tip[Automatically keep up to date!]
-  <a href="/docs/cloud/changelog-rss.xml">
+  &lt;a href="/docs/cloud/changelog-rss.xml"&gt;
     Subscribe to Cloud Changelog via RSS
-  </a>
+  &lt;/a&gt;
 :::
+
+## April 10, 2026 {#2026-04-10}
+
+### Centralized Marketplace Billing {#centralized-marketplace-billing}
+
+Customers can now consolidate billing across organizations through a single cloud marketplace subscription (AWS, Azure, and GCP). Key capabilities include:
+
+* **Marketplace Subscription Sharing:** Switch an organization from credit card billing to an existing marketplace subscription from another organization — no need to set up an additional marketplace subscription. Note: only PAYG usage is consolidated (not prepaid credits).
+* **Update Marketplace Subscriptions:** Swap an organization's marketplace subscription to one used by a different organization.
+* **Backup Payment Method:** Organizations on marketplace billing can now add a credit card as a fallback if the primary marketplace subscription is cancelled or expires.
+
+For more details, see the [billing documentation](/cloud/manage/billing/managing-payment-methods).
+
+### ClickHouse Assistant RAG API {#clickhouse-assistant-rag-api}
+
+The ClickHouse Assistant in the SQL Console is now powered by a new RAG (Retrieval-Augmented Generation) API, delivering context-aware responses grounded in the full ClickHouse documentation. Every assistant conversation in the SQL Console now benefits from improved accuracy and relevance.
+
+### clickhousectl CLI (Public Beta) {#clickhousectl-cli}
+
+[clickhousectl](https://github.com/ClickHouse/clickhousectl) is the new official ClickHouse CLI for managing local ClickHouse installations, running local servers, and operating ClickHouse Cloud — all through a single interface. Install it now:
+
+```
+curl https://clickhouse.com/cli | sh
+```
 
 ## April 3, 2026 {#april-3-2026}
 - **Smarter auto-scaling with two-window recommender:** ClickHouse Cloud now uses a dual-lookback-window approach to vertical auto-scaling, replacing the previous single 30-hour window with a combined 3-hour "small window" and 30-hour "large window." This reduces scale-down latency from up to 30 hours to as little as 3 hours, lowering infrastructure costs for variable workloads without sacrificing scale-up responsiveness. Read the [blog post](https://clickhouse.com/blog/smarter-auto-scaling) for more details.
@@ -43,7 +67,7 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   - GCP us-east1 (South Carolina)
 - Crash report collection preferences can now be configured at the organization level. This setting was previously available only at the service level. When disabled at the organization level, all existing and future services will be opted out automatically.
 
-<Image img={crash_reports_collection} size="md" alt="Crash reports collection" />
+&lt;Image img={crash_reports_collection} size="md" alt="Crash reports collection" /&gt;
 
 ## January 23, 2026 {#january-23-2026}
 - ClickPipes is now available in AWS `eu-west-1`. For new ClickHouse Cloud services created from January 20 in that region, the matching region will be used for ClickPipes. For older services, ClickPipes defaults to `eu-central-1`. See the [documentation](/integrations/clickpipes#list-of-static-ips) for more details.


### PR DESCRIPTION
## Summary

Weekly Cloud changelog update generated from #shipped Slack channel (April 3–10, 2026).

## Changes included

- **Centralized Marketplace Billing** — Subscription sharing across orgs (AWS, Azure, GCP), ability to swap marketplace subscriptions, and backup payment method support.
- **ClickHouse Assistant RAG API** — New RAG-powered backend now live in the SQL Console, replacing Kapa.ai for documentation-grounded assistant responses.
- **clickhousectl CLI (Public Beta)** — New official CLI for managing local ClickHouse installations and operating ClickHouse Cloud.

## Needs review

- **Rust Client 0.15.0** was shipped this week (tracing/OpenTelemetry, zstd compression, X-ClickHouse-Summary header) but tagged as OSS deployment — excluded from the Cloud changelog. Please confirm if it should be included.
- **ClickHouse Assistant RAG API** — The #shipped post focused on the internal RAG infrastructure. The changelog entry was written to be user-facing, but reviewers should confirm the framing is appropriate.
- **clickhousectl** — Docs/blog links were noted as "coming shortly" in #shipped. Placeholder link points to the GitHub repo only. Update once docs are live.