### PR TITLE
Update async_insert_max_data_size default from 10 MiB to 100 MiB

### DIFF
--- a/docs/best-practices/_snippets/_async_inserts.md
+++ b/docs/best-practices/_snippets/_async_inserts.md
@@ -17,7 +17,7 @@ Asynchronous inserts are supported over both the HTTP and native TCP interfaces.
 
 When enabled (`async_insert = 1`), inserts are buffered and only written to disk once one of the flush conditions is met:
 
-- The buffer reaches a specified data size ([`async_insert_max_data_size`](/operations/settings/settings#async_insert_max_data_size), default 10 MiB).
+- The buffer reaches a specified data size ([`async_insert_max_data_size`](/operations/settings/settings#async_insert_max_data_size), default 100 MiB).
 - A time threshold elapses ([`async_insert_busy_timeout_ms`](/operations/settings/settings#async_insert_busy_timeout_max_ms), default 200 ms or 1000 ms on Cloud).
 - A maximum number of insert queries accumulate ([`async_insert_max_query_number`](/operations/settings/settings#async_insert_max_query_number), default 450).
 

--- a/docs/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
+++ b/docs/integrations/data-ingestion/kafka/kafka-clickhouse-connect-sink.md
@@ -553,7 +553,7 @@ With asynchronous inserts enabled, ClickHouse:
 2. Writes data to an in-memory buffer (instead of immediately to disk)
 3. Returns success to the connector (if `wait_for_async_insert=0`)
 4. Flushes the buffer to disk when one of these conditions is met:
-   - Buffer reaches `async_insert_max_data_size` (default: 10 MB)
+   - Buffer reaches `async_insert_max_data_size` (default: 100 MB)
    - `async_insert_busy_timeout_ms` milliseconds elapsed since first insert (default: 1000 ms)
    - Maximum number of queries accumulated (`async_insert_max_query_number`, default: 100)
 
@@ -585,12 +585,12 @@ Add async insert settings to the `clickhouseSettings` configuration parameter:
 You can fine-tune the async insert flush behavior:
 
 ```json
-"clickhouseSettings": "async_insert=1,wait_for_async_insert=1,async_insert_max_data_size=10485760,async_insert_busy_timeout_ms=1000"
+"clickhouseSettings": "async_insert=1,wait_for_async_insert=1,async_insert_max_data_size=104857600,async_insert_busy_timeout_ms=1000"
 ```
 
 Common tuning parameters:
 
-- **`async_insert_max_data_size`** (default: 10485760 / 10 MB): Maximum buffer size before flush
+- **`async_insert_max_data_size`** (default: 104857600 / 100 MB): Maximum buffer size before flush
 - **`async_insert_busy_timeout_ms`** (default: 1000): Maximum time (ms) before flush
 - **`async_insert_stale_timeout_ms`** (default: 0): Time (ms) since last insert before flush
 - **`async_insert_max_query_number`** (default: 100): Maximum queries before flush


### PR DESCRIPTION
## Summary

- Updates `async_insert_max_data_size` default value from 10 MiB to 100 MiB in the async inserts guide (`/optimize/asynchronous-inserts`)
- Updates the same default in the Kafka ClickHouse Connect Sink integration docs (description text and example config value)

## Test plan

- [ ] Verify rendered page at `/optimize/asynchronous-inserts` shows 100 MiB
- [ ] Verify Kafka connector async inserts section shows 100 MB / 104857600

🤖 Generated with [Claude Code](https://claude.com/claude-code)