### PR TITLE
Redirect /docs/whats-new/cloud to changelog/cloud

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3809,6 +3809,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/whats-new/cloud",
+      "destination": "/docs/whats-new/changelog/cloud",
+      "permanent": true
+    },
+    {
       "source": "/docs/cloud/reference/byoc/faq/:path*",
       "destination": "/docs/cloud/reference/byoc/reference/faq",
       "permanent": true


### PR DESCRIPTION
## Summary
- Adds a permanent redirect from `/docs/whats-new/cloud` to `/docs/whats-new/changelog/cloud` in `vercel.json`

## Test plan
- [ ] Visit `/docs/whats-new/cloud` on the preview deployment and confirm it redirects to `/docs/whats-new/changelog/cloud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)