### PR TITLE
docs(gcs): remove note that multi object delete is not supported

### DIFF
--- a/docs/integrations/data-ingestion/gcs/index.md
+++ b/docs/integrations/data-ingestion/gcs/index.md
@@ -30,7 +30,6 @@ To utilize a GCS bucket as a disk, we must first declare it within the ClickHous
 #### Storage configuration > disks > gcs {#storage_configuration--disks--gcs}
 
 This part of the configuration is shown in the highlighted section and specifies that:
-- Batch deletes aren't to be performed.  GCS doesn't currently support batch deletes, so the autodetect is disabled to suppress error messages.
 - The type of the disk is `s3` because the S3 API is in use.
 - The endpoint as provided by GCS
 - The service account HMAC key and secret


### PR DESCRIPTION
## Summary
XML Multi Object Delete is now GA for GCS.
Referece: https://docs.cloud.google.com/storage/docs/xml-api/post-bucket
## Checklist
- [ x] Delete items not relevant to your PR
- [ x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
