### PR TITLE
Add mx-central-1 and us-west1 to supported regions

### DIFF
--- a/docs/cloud/reference/05_supported-regions.md
+++ b/docs/cloud/reference/05_supported-regions.md
@@ -44,7 +44,6 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - us-east1 (South Carolina)
 - europe-west2 (London)
 
-
 **Private Region:**
 
 - australia-southeast1(Sydney)

--- a/docs/cloud/reference/05_supported-regions.md
+++ b/docs/cloud/reference/05_supported-regions.md
@@ -42,7 +42,8 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - europe-west4 (Netherlands)
 - us-central1 (Iowa)
 - us-east1 (South Carolina)
-- us-west1 (Oregon)
+- europe-west2 (London)
+
 
 **Private Region:**
 
@@ -50,6 +51,7 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - europe-west3 (Frankfurt)
 - europe-west6 (Zurich)
 - northamerica-northeast1 (Montréal)
+- us-west1 (Oregon)
 
 ## Azure regions {#azure-regions}
 

--- a/docs/cloud/reference/05_supported-regions.md
+++ b/docs/cloud/reference/05_supported-regions.md
@@ -33,6 +33,7 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - sa-east-1 (South America)
 - ap-southeast-3 (Jakarta)
 - ap-east-1 (Hong Kong)
+- mx-central-1 (Mexico)
  
 ## Google Cloud regions {#google-cloud-regions}
 
@@ -41,10 +42,10 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - europe-west4 (Netherlands)
 - us-central1 (Iowa)
 - us-east1 (South Carolina)
+- us-west1 (Oregon)
 
 **Private Region:**
 
-- us-west1 (Oregon)
 - australia-southeast1(Sydney)
 - europe-west3 (Frankfurt)
 - europe-west6 (Zurich)
@@ -60,6 +61,7 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 
 - Japan East (Tokyo, Saitama)
 - UAE North (Dubai)
+- Australia East (New South Wales)
 
 :::note 
 Need to deploy to a region not currently listed? [Submit a request](https://clickhouse.com/pricing?modal=open). 
@@ -90,6 +92,7 @@ Customers must sign a Business Associate Agreement (BAA) and request onboarding 
 - AWS eu-west-1 (Ireland)
 - AWS eu-west-2 (London)
 - AWS sa-east-1 (South America) **Private Region**
+- AWS mx-central-1 (Mexico) **Private Region**
 - AWS us-east-1 (N. Virginia)
 - AWS us-east-2 (Ohio)
 - AWS us-west-2 (Oregon)
@@ -108,6 +111,7 @@ Customers must request onboarding through Sales or Support to set up services in
 - AWS eu-north-1 (Stockholm) **Private Region**
 - AWS eu-west-1 (Ireland)
 - AWS eu-west-2 (London)
+- AWS mx-central-1 (Mexico) **Private Region**
 - AWS sa-east-1 (South America) **Private Region**
 - AWS us-east-1 (N. Virginia)
 - AWS us-east-2 (Ohio)


### PR DESCRIPTION
Added Mexico and Oregon as supported regions for AWS and GCP.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
