### PR TITLE
Cloud changelog: Week of 2026-04-17 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,20 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## April 17, 2026 {#april-17-2026}
+
+### Refunds visible in billing UI {#refunds-billing-ui}
+
+Customers can now see all refunds directly in the Cloud console billing UI. Refunds appear once processed; credit card refunds may take additional time to show on statements depending on the bank.
+
+### Organization spend alerts (Private Preview) {#org-spend-alerts}
+
+Organization spend alerts are now available in Private Preview. Get notified at 50%, 75%, and 100% of your configured organization spend per billing period. Choose from Email, Cloud console, and/or Slack notification channels. Alerts are based on organization gross usage, fire hourly, and reset automatically each billing period. Requires Org Admin or Billing Admin role.
+
+### ClickPipes region parity on AWS {#clickpipes-aws-region-parity}
+
+ClickPipes is now available in all AWS regions (public and private) supported by ClickHouse Cloud, expanding from 6 regions to 18. This includes strategic regions like Singapore (ap-southeast-1), Seoul (ap-northeast-2), and Tokyo (ap-northeast-1). The new regions are available for services created after April 14, 2026. See the [documentation](/integrations/clickpipes#list-of-static-ips) for more details.
+
 ## April 3, 2026 {#april-3-2026}
 - **Smarter auto-scaling with two-window recommender:** ClickHouse Cloud now uses a dual-lookback-window approach to vertical auto-scaling, replacing the previous single 30-hour window with a combined 3-hour "small window" and 30-hour "large window." This reduces scale-down latency from up to 30 hours to as little as 3 hours, lowering infrastructure costs for variable workloads without sacrificing scale-up responsiveness. Read the [blog post](https://clickhouse.com/blog/smarter-auto-scaling) for more details.
 - **Monitoring in the Cloud console:** New overview and infrastructure dashboards provide better visibility into the behavior of ClickHouse servers. Admin users now receive email notifications for common issues when using ClickHouse Cloud. Read the [blog post](https://clickhouse.com/blog/clickhouse-cloud-new-monitoring-capabilities) for more details.


### PR DESCRIPTION
## Summary

This PR adds the Cloud changelog entries for the week of April 17, 2026, covering 3 shipped changes scraped from #shipped in Slack.

### Changes included

- **Refunds visible in billing UI** — Customers can now see all refunds directly in the Cloud console billing UI (GA, April 16)
- **Organization spend alerts (Private Preview)** — Threshold-based spend notifications at 50%, 75%, and 100% of configured org spend per billing period, via Email, Cloud console, and/or Slack (Private Preview, April 15)
- **ClickPipes region parity on AWS** — ClickPipes now available in all 18 AWS regions (public and private) supported by ClickHouse Cloud, up from 6 (April 14)

### Needs review

- **Organization Spend Alerts** is in Private Preview — please confirm whether it should appear in the public changelog or be noted differently.
- **ClickPipes regions** — Verify that Singapore (ap-southeast-1), Seoul (ap-northeast-2), and Tokyo (ap-northeast-1) match the official region codes.
- The **.NET Driver 1.2.0** was also shipped this week but marked as OSS deployment, so it was excluded from the Cloud changelog. Let me know if it should be included.

---
*This PR was generated automatically by the Cloud changelog bot.*