### PR TITLE
Update supported regions by removing Mexico and Australia

### DIFF
--- a/docs/cloud/reference/05_supported-regions.md
+++ b/docs/cloud/reference/05_supported-regions.md
@@ -33,7 +33,6 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - sa-east-1 (South America)
 - ap-southeast-3 (Jakarta)
 - ap-east-1 (Hong Kong)
-- mx-central-1 (Mexico)
  
 ## Google Cloud regions {#google-cloud-regions}
 
@@ -42,7 +41,6 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 - europe-west4 (Netherlands)
 - us-central1 (Iowa)
 - us-east1 (South Carolina)
-- europe-west2 (London)
 
 **Private Region:**
 
@@ -62,7 +60,6 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 
 - Japan East (Tokyo, Saitama)
 - UAE North (Dubai)
-- Australia East (New South Wales)
 
 :::note 
 Need to deploy to a region not currently listed? [Submit a request](https://clickhouse.com/pricing?modal=open). 
@@ -93,7 +90,6 @@ Customers must sign a Business Associate Agreement (BAA) and request onboarding 
 - AWS eu-west-1 (Ireland)
 - AWS eu-west-2 (London)
 - AWS sa-east-1 (South America) **Private Region**
-- AWS mx-central-1 (Mexico) **Private Region**
 - AWS us-east-1 (N. Virginia)
 - AWS us-east-2 (Ohio)
 - AWS us-west-2 (Oregon)
@@ -112,7 +108,6 @@ Customers must request onboarding through Sales or Support to set up services in
 - AWS eu-north-1 (Stockholm) **Private Region**
 - AWS eu-west-1 (Ireland)
 - AWS eu-west-2 (London)
-- AWS mx-central-1 (Mexico) **Private Region**
 - AWS sa-east-1 (South America) **Private Region**
 - AWS us-east-1 (N. Virginia)
 - AWS us-east-2 (Ohio)


### PR DESCRIPTION
Removed Mexico and Australia East from the supported regions list. As the regions will take longer to setup

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
