### PR TITLE
Release Schedule mention on Warehouses page

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -172,7 +172,7 @@ Note that read-only services don't execute background merges, thus they don't sp
 
 ### Helpful Callouts {#callouts}
 
-- **ClickHouse Versions** The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services cannot have a release schedule independent of the primary service.
+- **ClickHouse Versions**: The [upgrade schedule](/manage/updates) is dictated by the primary service's settings. Secondary services cannot have a release schedule independent of the primary service.
 
 - **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you  can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
 

--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -172,7 +172,7 @@ Note that read-only services don't execute background merges, thus they don't sp
 
 ### Helpful Callouts {#callouts}
 
-- The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services are not able to change their release schedule to be independent of the primary service. 
+- **ClickHouse Versions** The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services are not able to change their release schedule to be independent of the primary service. 
 
 - **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you  can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
 

--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -172,7 +172,7 @@ Note that read-only services don't execute background merges, thus they don't sp
 
 ### Helpful Callouts {#callouts}
 
-- **ClickHouse Versions** The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services are not able to change their release schedule to be independent of the primary service. 
+- **ClickHouse Versions** The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services cannot have a release schedule independent of the primary service.
 
 - **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you  can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
 

--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -172,6 +172,8 @@ Note that read-only services don't execute background merges, thus they don't sp
 
 ### Helpful Callouts {#callouts}
 
+- The [upgrade schedule](/docs/manage/updates) is dictated by the primary service's settings. Secondary services are not able to change their release schedule to be independent of the primary service. 
+
 - **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you  can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
 
 For example:


### PR DESCRIPTION
update release schedule info

## Summary
With this slack message (https://clickhouse-inc.slack.com/archives/C02PDM686KF/p1776716418003499), updating the docs to make this release schedule component be more clear

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
