### PR TITLE
Update 02_configurable-backups.md

### DIFF
--- a/docs/cloud/guides/backups/02_configurable-backups.md
+++ b/docs/cloud/guides/backups/02_configurable-backups.md
@@ -28,5 +28,5 @@ Start time and frequency are mutually exclusive. Start time takes precedence.
 :::
 
 :::note
-Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/cloud/manage/backups/overview#understanding-backup-cost) section below.
+Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/cloud/manage/backups/overview#understanding-backup-cost).
 :::


### PR DESCRIPTION
removed the words "section below" - leftover from when we reorganized these docs.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
