### PR TITLE
Update 02_backup_restore_from_ui.md

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/02_backup_restore_from_ui.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/02_backup_restore_from_ui.md
@@ -23,6 +23,10 @@ import restore_backups_azure from '@site/static/images/cloud/manage/backups/rest
 
 # Backup / restore via user-interface {#ui-experience}
 
+:::note
+Automated backups to your external bucket are configured to run as "full" backups every 24 hours, and the frequency is not configurable.  
+:::
+
 ## AWS {#AWS}
 
 ### Taking backups to AWS {#taking-backups-to-aws}


### PR DESCRIPTION
Added a note to specify that for external buckets the backups run every 24 hours and that frequency is not configurable.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
