### PR TITLE
Cloud changelog: Week of 2026-04-25 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -21,13 +21,13 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
 
 ## April 25, 2026 {#2026-04-25}
 
-### Index Sharding (Private Preview) {#index-sharding}
+### Index sharding (private preview) {#index-sharding}
 
-Index Sharding is now available in Private Preview. This feature distributes the index analysis phase across multiple replicas, reducing per-replica memory usage and improving query performance through distributed parallelization. This is especially beneficial for tables with heavy secondary indexes such as vector search and full-text search. Read the [blog post](https://clickhouse.com/blog/index-sharding-clickhouse-cloud-petabyte-scale-indexing) for more details.
+Index sharding is now available in private preview. This feature distributes the index analysis phase across multiple replicas, reducing per-replica memory usage and improving query performance through distributed parallelization. This is especially beneficial for tables with heavy secondary indexes such as vector search and full-text search. Read the [blog post](https://clickhouse.com/blog/index-sharding-clickhouse-cloud-petabyte-scale-indexing) for more details.
 
-### Terraform & OpenAPI for ClickPipes (GA) {#terraform-openapi-clickpipes-ga}
+### Terraform & OpenAPI for ClickPipes (general access) {#terraform-openapi-clickpipes-ga}
 
-ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now Generally Available as part of stable releases, and [OpenAPI endpoints](https://clickhouse.com/docs/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
+ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now generally available as part of stable releases, and [OpenAPI endpoints](https://clickhouse.com/docs/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
 
 ## April 17, 2026 {#april-17-2026}
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,16 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## April 25, 2026 {#2026-04-25}
+
+### Index Sharding (Private Preview) {#index-sharding}
+
+Index Sharding is now available in Private Preview. This feature distributes the index analysis phase across multiple replicas, reducing per-replica memory usage and improving query performance through distributed parallelization. This is especially beneficial for tables with heavy secondary indexes such as vector search and full-text search. Read the [blog post](https://clickhouse.com/blog/index-sharding-clickhouse-cloud-petabyte-scale-indexing) for more details.
+
+### Terraform & OpenAPI for ClickPipes (GA) {#terraform-openapi-clickpipes-ga}
+
+ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now Generally Available as part of stable releases, and [OpenAPI endpoints](https://clickhouse.com/docs/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
+
 ## April 17, 2026 {#april-17-2026}
 
 ### Refunds visible in billing UI {#refunds-billing-ui}

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -27,7 +27,7 @@ Index sharding is now available in private preview. This feature distributes the
 
 ### Terraform & OpenAPI for ClickPipes (general access) {#terraform-openapi-clickpipes-ga}
 
-ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now generally available as part of stable releases, and [OpenAPI endpoints](https://clickhouse.com/docs/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](https://clickhouse.com/docs/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
+ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now generally available as part of stable releases, and [OpenAPI endpoints](/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
 
 ## April 17, 2026 {#april-17-2026}
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -27,7 +27,7 @@ Index sharding is now available in private preview. This feature distributes the
 
 ### Terraform & OpenAPI for ClickPipes (general access) {#terraform-openapi-clickpipes-ga}
 
-ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now generally available as part of stable releases, and [OpenAPI endpoints](/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
+ClickPipes resources in the ClickHouse [Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) are now generally available as part of stable releases, and [OpenAPI endpoints](https://clickhouse.com/docs/cloud/manage/api/swagger) are no longer marked as beta. This includes full coverage for CDC connectors (Postgres, MySQL, MongoDB). See the [Terraform documentation](/integrations/clickpipes/programmatic-access/terraform), [OpenAPI documentation](/integrations/clickpipes/programmatic-access/openapi), and [blog post](https://clickhouse.com/blog/terraform-ga) for more details.
 
 ## April 17, 2026 {#april-17-2026}
 


### PR DESCRIPTION
## Summary

This PR adds the Cloud changelog entries for the week of April 25, 2026, based on updates posted in #shipped.

### Included changes

- **Index Sharding (Private Preview)** — Distributed index analysis across replicas for reduced memory usage and improved query performance, especially for tables with heavy secondary indexes (vector search, full-text search).
- **Terraform & OpenAPI for ClickPipes (GA)** — ClickPipes resources in the Terraform provider are now stable/GA, and OpenAPI endpoints are no longer beta. Full coverage for CDC connectors (Postgres, MySQL, MongoDB).

### Needs review

- The Index Sharding entry links to the public blog post. Please verify the release date (listed as April 25 based on this week's changelog cycle; the #shipped post mentioned April 21 as the release date — adjust if needed).
- The Terraform/OpenAPI entry was shipped April 10 per #shipped but may not have been included in previous changelogs. Please confirm this is the correct week to include it.