### PR TITLE
Add `interfaces/web-terminal` to sidebar

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -12,3 +12,4 @@ integrations/language-clients/java/jdbc-v1
 integrations/data-ingestion/clickpipes/postgres/maintenance.md
 operations/utilities/clickhouse-keeper-http-api.md
 cloud/features/backups/faq.md
+interfaces/web-terminal

--- a/sidebars.js
+++ b/sidebars.js
@@ -867,7 +867,6 @@ const sidebars = {
       items: [
         'interfaces/cli',
         'interfaces/client',
-        'interfaces/web-terminal',
         {
           type: 'category',
           label: 'Drivers and interfaces',

--- a/sidebars.js
+++ b/sidebars.js
@@ -867,6 +867,7 @@ const sidebars = {
       items: [
         'interfaces/cli',
         'interfaces/client',
+        'interfaces/web-terminal',
         {
           type: 'category',
           label: 'Drivers and interfaces',


### PR DESCRIPTION
The corresponding ClickHouse PR [#100277](https://github.com/ClickHouse/ClickHouse/pull/100277) introduces a new docs page `docs/en/interfaces/web-terminal.md` for the experimental web terminal interface. Without a sidebar entry, the docusaurus build fails with a "floating page" error.

This adds the entry to the "Native clients & interfaces" category, next to `cli` and `client`.

Companion to https://github.com/ClickHouse/ClickHouse/pull/100277.