### PR TITLE
Fix markdown syntax for 'Insert your own data' section

### DIFF
--- a/docs/getting-started/quick-start/oss.mdx
+++ b/docs/getting-started/quick-start/oss.mdx
@@ -141,7 +141,7 @@ Notice the response comes back in a nice table format:
 4 rows in set. Elapsed: 0.008 sec.
 ```
 
-## Insert your own data [#insert-own-data}
+## Insert your own data {#insert-own-data}
 
 The next step is to get your own data into ClickHouse. We have lots of [table functions](/sql-reference/table-functions/index.md)
 and [integrations](/integrations) for ingesting data. We have some examples in the tabs


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fix mismatched bracket in step 8 heading by replacing the opening [ with { so the anchor syntax reads {#insert-own-data}.

Before:
<img width="586" height="127" alt="Screenshot 2026-04-30 at 10 32 32 AM" src="https://github.com/user-attachments/assets/e391e785-1531-4221-a1c6-1308edbfefea" />
