### PR TITLE
Cloud changelog: Week of 2026-04-27 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,12 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## May 2, 2026 {#2026-05-02}
+
+### New GCP London region (europe-west2) {#gcp-london-europe-west2}
+
+ClickHouse Cloud now supports a new public region: GCP London (europe-west2). See the full list of [supported regions](/cloud/reference/supported-regions) for more details.
+
 ## April 25, 2026 {#2026-04-25}
 
 ### Index sharding (private preview) {#index-sharding}


### PR DESCRIPTION
## Summary

Weekly Cloud changelog update generated from #shipped Slack channel (April 25 – May 2, 2026).

### Included changes

- **New GCP London region (europe-west2):** ClickHouse Cloud now supports GCP London (europe-west2) as a public region.

### Needs review

- Light week in #shipped — only one user-facing change was posted. Please confirm nothing was missed.
- The `create_pull_request_with_copilot` tool returned a 401 Unauthorized error, so this PR was created via direct file commit instead.