### PR TITLE
Note that warehouse service type is fixed at creation

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -127,7 +127,8 @@ _Fig. 6 - Read-write and Read-only services in a warehouse_
 
 :::note
 1. Read-only services currently support user management operations (CREATE, DROP, etc).
-2. [Refreshable materialized views](/materialized-view/refreshable-materialized-view) run **only** on read-write (RW) services in a warehouse. 
+2. [Refreshable materialized views](/materialized-view/refreshable-materialized-view) run **only** on read-write (RW) services in a warehouse.
+3. A service's type (read-only or read-write) is fixed at creation and cannot be changed from the Cloud Console afterwards. To switch between read-only and read-write access, create a new service in the warehouse with the desired type.
 :::
 
 ## Scaling {#scaling}


### PR DESCRIPTION
## Summary
- Adds a note to the [Read vs read-write services](https://clickhouse.com/docs/cloud/reference/warehouses#read-vs-read-write) section clarifying that a service's type (read-only vs read-write) is fixed at creation and cannot be changed from the Cloud Console afterwards.
- Points users to creating a new service in the warehouse with the desired type as the way to switch.

Closes [DOC-707](https://linear.app/clickhouse/issue/DOC-707) / #6031

## Test plan
- [ ] Verify the note renders correctly in the warehouses page preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)