### PR TITLE
Fix reader-reported errors in RU docs (DOC-709/710/718/719)

### DIFF
--- a/docs/deployment-guides/replication-sharding-examples/02_2_shards_1_replica.md
+++ b/docs/deployment-guides/replication-sharding-examples/02_2_shards_1_replica.md
@@ -66,7 +66,7 @@ for i in {01..02}; do
 done
 ```
 
-Add the following `docker-compose.yml` file to the `clickhouse-cluster` directory:
+Add the following `docker-compose.yml` file to the `cluster_2S_1R` directory:
 
 ```yaml title="docker-compose.yml"
 version: '3.8'
@@ -494,7 +494,7 @@ WHERE path IN ('/', '/clickhouse')
 
 <VerifyKeeperStatus/>
 
-With this, you have successfully set up a ClickHouse cluster with a single shard and two replicas.
+With this, you have successfully set up a ClickHouse cluster with two shards and one replica per shard.
 In the next step, you will create a table in the cluster.
 
 ## Create a database {#creating-a-database}

--- a/docs/operations_/backup_restore/01_local_disk.md
+++ b/docs/operations_/backup_restore/01_local_disk.md
@@ -141,14 +141,14 @@ This setting can therefore cause data duplication in the table, and should be us
 To restore the table with data already in it, run:
 
 ```sql
-RESTORE TABLE test_db.table_table FROM Disk('backups', '1.zip')
+RESTORE TABLE test_db.test_table FROM Disk('backups', '1.zip')
 SETTINGS allow_non_empty_tables=true
 ```
 
 Tables can be restored, or backed up, with new names:
 
 ```sql
-RESTORE TABLE test_db.table_table AS test_db.test_table_renamed FROM Disk('backups', '1.zip')
+RESTORE TABLE test_db.test_table AS test_db.test_table_renamed FROM Disk('backups', '1.zip')
 ```
 
 The backup archive for this backup has the following structure:

--- a/i18n/ru/docusaurus-plugin-content-docs/current/deployment-guides/replication-sharding-examples/02_2_shards_1_replica.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/deployment-guides/replication-sharding-examples/02_2_shards_1_replica.md
@@ -65,7 +65,7 @@ import CloudTip from '@site/i18n/ru/docusaurus-plugin-content-docs/current/deplo
   done
   ```
 
-  Добавьте следующий файл `docker-compose.yml` в каталог `clickhouse-cluster`:
+  Добавьте следующий файл `docker-compose.yml` в каталог `cluster_2S_1R`:
 
   ```yaml title="docker-compose.yml"
   version: '3.8'
@@ -490,7 +490,7 @@ import CloudTip from '@site/i18n/ru/docusaurus-plugin-content-docs/current/deplo
 
   <VerifyKeeperStatus />
 
-  Таким образом, вы успешно настроили кластер ClickHouse с одним сегментом и двумя репликами.
+  Таким образом, вы успешно настроили кластер ClickHouse с двумя сегментами и одной репликой в каждом сегменте.
   На следующем шаге вы создадите таблицу в кластере.
 
   ## Создание базы данных

--- a/i18n/ru/docusaurus-plugin-content-docs/current/operations/system-tables/databases.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/operations/system-tables/databases.md
@@ -52,5 +52,6 @@ SELECT * FROM system.databases;
 │ information_schema  │ Memory     │ /data/clickhouse_data/       │                                                                       │ 00000000-0000-0000-0000-000000000000 │ Memory                                                 │         │
 │ replicated_database │ Replicated │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/da8/da85bb71-102b-4f69-9aad-f8d6c403905e/ │ da85bb71-102b-4f69-9aad-f8d6c403905e │ Replicated('some/path/database', 'shard1', 'replica1') │         │
 │ system              │ Atomic     │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/b57/b5770419-ac7a-4b67-8229-524122024076/ │ b5770419-ac7a-4b67-8229-524122024076 │ Atomic                                                 │         │
+│ test                │ Atomic     │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/2a1/2a1b3c4d-5e6f-7890-abcd-ef1234567890/ │ 2a1b3c4d-5e6f-7890-abcd-ef1234567890 │ Atomic                                                 │         │
 └─────────────────────┴────────────┴──────────────────────────────┴───────────────────────────────────────────────────────────────────────┴──────────────────────────────────────┴────────────────────────────────────────────────────────┴─────────┘
 ```

--- a/i18n/ru/docusaurus-plugin-content-docs/current/operations_/backup_restore/01_local_disk.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/operations_/backup_restore/01_local_disk.md
@@ -142,14 +142,14 @@ RESTORE TABLE test_db.test_table FROM Disk('backups', '1.zip')
 Чтобы восстановить таблицу, уже содержащую данные, выполните:
 
 ```sql
-RESTORE TABLE test_db.table_table FROM Disk('backups', '1.zip')
+RESTORE TABLE test_db.test_table FROM Disk('backups', '1.zip')
 SETTINGS allow_non_empty_tables=true
 ```
 
 Таблицы можно восстанавливать или создавать их резервные копии с новыми именами:
 
 ```sql
-RESTORE TABLE test_db.table_table AS test_db.test_table_renamed FROM Disk('backups', '1.zip')
+RESTORE TABLE test_db.test_table AS test_db.test_table_renamed FROM Disk('backups', '1.zip')
 ```
 
 Архив этой резервной копии имеет следующую структуру:


### PR DESCRIPTION
Closes DOC-709, DOC-710, DOC-718, DOC-719.

## Summary

Fixes four reader-reported errors flagged on the Russian docs. All four bugs were present in the English source as well, so this PR patches both `docs/` and `i18n/ru/` where the source lives in this repo.

- **DOC-709** ([#6054](https://github.com/ClickHouse/clickhouse-docs/issues/6054)) — `architecture/replication`: `docker-compose.yml` instructions referenced a `clickhouse-cluster` directory that doesn't exist; corrected to `cluster_2S_1R` to match the `mkdir` step above.
- **DOC-710** ([#6055](https://github.com/ClickHouse/clickhouse-docs/issues/6055)) — same page: summary line claimed "single shard and two replicas" on the 2-shards-1-replica example page; corrected to "two shards and one replica per shard".
- **DOC-718** ([#6085](https://github.com/ClickHouse/clickhouse-docs/issues/6085)) — `operations/backup/disk`: `RESTORE TABLE` examples used `test_db.table_table` typo; corrected to `test_db.test_table`.
- **DOC-719** ([#6090](https://github.com/ClickHouse/clickhouse-docs/issues/6090)) — `system-tables/databases`: example created database `test` but the example output didn't include it. Added the missing row. **Note:** the English source for this page is mirrored from `ClickHouse/ClickHouse` (`docs/en/operations/system-tables/databases.md`) and is gitignored here, so only the Russian translation is patched in this PR. Companion upstream PR: ClickHouse/ClickHouse#104292.

## Test plan

- [ ] Visual check of rendered RU pages for `/operations/backup/disk`, `/architecture/replication`, `/operations/system-tables/databases`
- [ ] Visual check of rendered EN pages for the first two
- [ ] Confirm code blocks still parse