### PR TITLE
Fix BACKUP ASYNC syntax documentation

### DIFF
--- a/docs/operations_/backup_restore/00_overview.md
+++ b/docs/operations_/backup_restore/00_overview.md
@@ -177,7 +177,6 @@ Each of the commands above is detailed below:
 |------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `BACKUP`                                                               | Creates a backup of specified objects                                                                                                                |
 | `RESTORE`                                                              | Restores objects from a backup                                                                                                                       |
-| `[ASYNC]`                                                              | Makes the operation run asynchronously (returns immediately with an ID you can monitor)                                                              |
 | `TABLE [db.]table_name [AS [db.]table_name_in_backup]`                 | Backs up/restores a specific table (can be renamed)                                                                                                  |
 | `[PARTITION[S] partition_expr [,...]]`                                 | Only backup/restore specific partitions of the table                                                                                                 |
 | `DICTIONARY [db.]dictionary_name [AS [db.]name_in_backup]`             | Backs up/restores a dictionary object                                                                                                                |
@@ -193,6 +192,7 @@ Each of the commands above is detailed below:
 | `Disk('<disk_name>', '<path>/')`                                       | Store to/restore from a configured disk                                                                                                              |
 | `S3('<S3 endpoint>/<path>', '<Access key ID>', '<Secret access key>')` | Store to/restore from Amazon S3 or S3-compatible storage                                                                                             |
 | `[SETTINGS ...]`                                                       | See below for complete list of settings                                                                                                              |                                                                                                                         |
+| `[ASYNC]`                                                              | Makes the operation run asynchronously (returns immediately with an ID you can monitor)                                                              |
 
 ### Settings {#settings}
 

--- a/docs/operations_/backup_restore/_snippets/_syntax.md
+++ b/docs/operations_/backup_restore/_snippets/_syntax.md
@@ -1,6 +1,6 @@
 ```sql
 -- core commands
-BACKUP | RESTORE [ASYNC]
+BACKUP | RESTORE 
 --- what to backup/restore (or exclude)
 TABLE [db.]table_name           [AS [db.]table_name_in_backup] |
 DICTIONARY [db.]dictionary_name [AS [db.]name_in_backup] |
@@ -19,6 +19,7 @@ S3('<S3 endpoint>/<path>', '<Access key ID>', '<Secret access key>', '<extra_cre
 AzureBlobStorage('<connection string>/<url>', '<container>', '<path>', '<account name>', '<account key>')
 --- additional settings
 [SETTINGS ...]
+[ASYNC]
 ```
 
 **See ["command summary"](/operations/backup/overview/#command-summary) for more details


### PR DESCRIPTION
## Summary

Fixes ClickHouse/ClickHouse#104336

The backup/restore syntax documentation could imply that `ASYNC` may be specified immediately after `BACKUP` or `RESTORE`, for example:

```sql id="lf9w3x"
BACKUP ASYNC DATABASE ...
```

However, ClickHouse accepts `ASYNC` only at the end of the query.

This change updates:

* the syntax block
* the command summary ordering

to better reflect actual parser behavior.