### PR TITLE
Migration prep: remove unused CodeBlock imports

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/01_clickhouse-local-etl.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/08_other_methods/01_clickhouse-local-etl.md
@@ -10,7 +10,6 @@ doc_type: 'guide'
 import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 import AddARemoteSystem from '@site/docs/_snippets/_add_remote_ip_access_list_detail.md';
 import ch_local_01 from '@site/static/images/integrations/migration/ch-local-01.png';
 import ch_local_02 from '@site/static/images/integrations/migration/ch-local-02.png';

--- a/docs/getting-started/example-datasets/cell-towers.md
+++ b/docs/getting-started/example-datasets/cell-towers.md
@@ -13,7 +13,6 @@ import ConnectionDetails from '@site/docs/_snippets/_gather_your_details_http.md
 import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 import ActionsMenu from '@site/docs/_snippets/_service_actions_menu.md';
 import SQLConsoleDetail from '@site/docs/_snippets/_launch_sql_console.md';
 import SupersetDocker from '@site/docs/_snippets/_add_superset_detail.md';

--- a/docs/getting-started/quick-start/oss.mdx
+++ b/docs/getting-started/quick-start/oss.mdx
@@ -11,7 +11,6 @@ doc_type: 'guide'
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 import {VerticalStepper} from '@clickhouse/click-ui/bundled';
 
 # ClickHouse OSS quick start

--- a/docs/integrations/language-clients/java/index.md
+++ b/docs/integrations/language-clients/java/index.md
@@ -12,7 +12,6 @@ integration:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Java clients overview
 

--- a/docs/integrations/language-clients/java/r2dbc.md
+++ b/docs/integrations/language-clients/java/r2dbc.md
@@ -13,7 +13,6 @@ integration:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # R2DBC driver
 

--- a/docs/integrations/language-clients/python/index.md
+++ b/docs/integrations/language-clients/python/index.md
@@ -12,7 +12,6 @@ integration:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 import ConnectionDetails from '@site/docs/_snippets/_gather_your_details_http.mdx';
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Removes unused imports of `CodeBlock` component
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
