### PR TITLE
Clarify moving to faster release channel wouldn't upgrade their servi…

### DIFF
--- a/docs/cloud/features/06_admin_features/upgrades.md
+++ b/docs/cloud/features/06_admin_features/upgrades.md
@@ -96,7 +96,7 @@ Specifically, services will:
 :::note
 You can change release channels at any time. However, in certain cases, the change will only apply to future releases. 
 - Moving to a faster channel will immediately upgrade your service. i.e. Slow to Regular, Regular to Fast
-- However, If your service is using the [scheduled upgrade](#scheduled-upgrades)), then the upgrade will happen on the next scheduled upgrade instead immediately.
+- If your service is using [scheduled upgrades](#scheduled-upgrades)), then the upgrade will happen on the next scheduled upgrade instead
 - Moving to a slower channel won't downgrade your service and keep you on your current version until a newer one is available in that channel. i.e. Regular to Slow, Fast to Regular or Slow
 :::
 

--- a/docs/cloud/features/06_admin_features/upgrades.md
+++ b/docs/cloud/features/06_admin_features/upgrades.md
@@ -96,6 +96,7 @@ Specifically, services will:
 :::note
 You can change release channels at any time. However, in certain cases, the change will only apply to future releases. 
 - Moving to a faster channel will immediately upgrade your service. i.e. Slow to Regular, Regular to Fast
+- However, If your service is using the [scheduled upgrade](#scheduled-upgrades)), then the upgrade will happen on the next scheduled upgrade instead immediately.
 - Moving to a slower channel won't downgrade your service and keep you on your current version until a newer one is available in that channel. i.e. Regular to Slow, Fast to Regular or Slow
 :::
 


### PR DESCRIPTION
…ce if they are already using scheduled upgrade

## Summary

We haven't clarify yet that moving to faster release channel wouldn't upgrade their service immediately if customers are using the schedule upgrade. 

Thread: https://clickhouse-inc.slack.com/archives/C09VBN05XPG/p1778229466790039?thread_ts=1777958179.231129&cid=C09VBN05XPG

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
