### PR TITLE
Remove dead ClickHouse Operator cleanup docs link

### DIFF
--- a/docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm-upgrade.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm-upgrade.md
@@ -44,8 +44,6 @@ helm uninstall clickstack-operators
 PersistentVolumeClaims created by the MongoDB and ClickHouse operators are **not** removed by `helm uninstall`. This is by design to prevent accidental data loss. To clean up PVCs after uninstalling, refer to:
 
 - [MongoDB Kubernetes Operator docs](https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity)
-- [ClickHouse Operator cleanup docs](https://clickhouse.com/docs/clickhouse-operator/managing-clusters/cleanup)
-
 ### Storage class {#storage-class}
 
 `global.storageClassName` and `global.keepPVC` have been removed. Storage class is now configured directly in each operator's CR spec:

--- a/docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm.md
+++ b/docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm.md
@@ -288,8 +288,6 @@ helm uninstall clickstack-operators     # Remove operators + CRDs
 **Note:** PersistentVolumeClaims created by the MongoDB and ClickHouse operators are **not** removed by `helm uninstall`. This is by design to prevent accidental data loss. To clean up PVCs, refer to:
 
 - [MongoDB Kubernetes Operator docs](https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity)
-- [ClickHouse Operator cleanup docs](https://clickhouse.com/docs/clickhouse-operator/managing-clusters/cleanup)
-
 ## Troubleshooting {#troubleshooting}
 
 ### Checking logs {#checking-logs}


### PR DESCRIPTION
## Summary

The link `https://clickhouse.com/docs/clickhouse-operator/managing-clusters/cleanup` no longer exists. Removing the bullet from two ClickStack v2 helm deployment files. The accompanying MongoDB Kubernetes Operator bullet in the same list still works and is kept.

## Files changed

- `docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm.md` (removed 1 line)
- `docs/use-cases/observability/clickstack/deployment/oss/helm/v2/helm-upgrade.md` (removed 1 line)

## Test plan

- [ ] Visit both pages in a Docusaurus preview build and confirm the "Data persistence" / cleanup-PVCs section reads cleanly with just the MongoDB bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)