### PR TITLE
Fix double-slash typo in Cloud Endpoints API link

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/archive/2023.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/archive/2023.md
@@ -329,7 +329,7 @@ This release updates the ClickHouse version to 23.3, significantly improves the 
 This release brings an API for retrieving cloud endpoints, an advanced scaling control for minimum idle timeout, and support for external data in Python client query methods.
 
 ### API changes {#api-changes}
-* Added ability to programmatically query ClickHouse Cloud endpoints via [Cloud Endpoints API](//cloud/get-started/query-endpoints.md)
+* Added ability to programmatically query ClickHouse Cloud endpoints via [Cloud Endpoints API](/cloud/get-started/query-endpoints)
 
 ### Console changes {#console-changes-21}
 - Added 'minimum idle timeout' setting to advanced scaling settings

--- a/docs/integrations/data-sources/mysql.md
+++ b/docs/integrations/data-sources/mysql.md
@@ -64,7 +64,7 @@ The `MySQL` table engine allows you to connect ClickHouse to MySQL. **SELECT** a
 
 :::note
 If you're using this feature in ClickHouse Cloud, you may need the to allow the ClickHouse Cloud IP addresses to access your MySQL instance.
-Check the ClickHouse [Cloud Endpoints API](//cloud/get-started/query-endpoints.md) for egress traffic details.
+Check the ClickHouse [Cloud Endpoints API](/cloud/get-started/query-endpoints) for egress traffic details.
 :::
 
 ### 2. Define a Table in ClickHouse {#2-define-a-table-in-clickhouse}


### PR DESCRIPTION
## Summary

Two files reference `//cloud/get-started/query-endpoints.md` with an extra leading slash and a `.md` extension. The intended target is the existing slug `/cloud/get-started/query-endpoints`. Renders as a broken link in current docs.

## Files changed

- `docs/integrations/data-sources/mysql.md` (1 link)
- `docs/cloud/reference/01_changelog/01_cloud_changelog/archive/2023.md` (1 link)

## Test plan

- [ ] In a preview build, click the "Cloud Endpoints API" link in both pages and confirm it lands at `/cloud/get-started/query-endpoints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)