### PR TITLE
Fix broken link slugs in _docker snippet

### DIFF
--- a/docs/getting-started/install/_snippets/_docker.md
+++ b/docs/getting-started/install/_snippets/_docker.md
@@ -130,7 +130,7 @@ For more information see ["Configuring CAP_IPC_LOCK and CAP_SYS_NICE Capabilitie
 
 ## Configuration {#configuration}
 
-The container exposes port 8123 for the [HTTP interface](/interfaces/http) and port 9000 for the [native client](/interfaces/cli).
+The container exposes port 8123 for the [HTTP interface](/interfaces/http) and port 9000 for the [native client](/interfaces/tcp).
 
 ClickHouse configuration is represented with a file "config.xml" ([documentation](/operations/configuration-files))
 

--- a/docs/getting-started/install/_snippets/_docker.md
+++ b/docs/getting-started/install/_snippets/_docker.md
@@ -130,9 +130,9 @@ For more information see ["Configuring CAP_IPC_LOCK and CAP_SYS_NICE Capabilitie
 
 ## Configuration {#configuration}
 
-The container exposes port 8123 for the [HTTP interface](https://clickhouse.com/docs/interfaces/http_interface/) and port 9000 for the [native client](https://clickhouse.com/docs/interfaces/tcp/).
+The container exposes port 8123 for the [HTTP interface](/interfaces/http) and port 9000 for the [native client](/interfaces/cli).
 
-ClickHouse configuration is represented with a file "config.xml" ([documentation](https://clickhouse.com/docs/operations/configuration_files/))
+ClickHouse configuration is represented with a file "config.xml" ([documentation](/operations/configuration-files))
 
 ### Start server instance with custom configuration {#start-server-instance-with-custom-config}
 


### PR DESCRIPTION
## Summary

Three intra-doc links in the Docker install snippet use stale slug forms that no longer resolve:

- `interfaces/http_interface/` → `/interfaces/http`
~- `interfaces/tcp/` → `/interfaces/cli`~
- `operations/configuration_files/` → `/operations/configuration-files`

Also drops the `https://clickhouse.com/docs` prefix for these in-site links so they're root-relative like the rest of the docs.

## Test plan

- [ ] Visit `/getting-started/install` (or wherever this snippet renders) and click each link to confirm the destination resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)