### PR TITLE
Fix three broken intra-doc links

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
@@ -109,8 +109,7 @@ Yes. ClickPipes expects you to include the port number for the Kafka surface, wh
 
 <summary>Are ClickPipes IPs still relevant for Azure Event Hubs?</summary>
 
-Yes. To restrict traffic to your Event Hubs instance, please add the [documented static NAT IPs](../
-/index.md#list-of-static-ips) to .
+Yes. To restrict traffic to your Event Hubs instance, please add the [documented static NAT IPs](/integrations/clickpipes#list-of-static-ips) to .
 
 </details>
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -90,7 +90,7 @@ ClickHouse chooses the join algorithm adaptively: it starts with fast hash joins
 ## Superior query performance {#superior-query-performance}
 
 ClickHouse is well known for having extremely fast query performance.
-To learn why ClickHouse is so fast, see the [Why is ClickHouse fast?](/concepts/why-clickhouse-is-so-fast.mdx) guide.
+To learn why ClickHouse is so fast, see the [Why is ClickHouse fast?](/concepts/why-clickhouse-is-so-fast) guide.
 
 <!--
 ## What is OLAP? {#what-is-olap}
@@ -111,7 +111,7 @@ Column-oriented databases are better suited to OLAP scenarios: they're at least 
 
 See the difference?
 
-The rest of this article explains why column-oriented databases work well for these scenarios, and why ClickHouse in particular [outperforms](/concepts/why-clickhouse-is-so-fast/concepts/why-clickhouse-is-so-fast#storage-layer-concurrent-inserts-and-selects-are-isolated) others in this category.
+The rest of this article explains why column-oriented databases work well for these scenarios, and why ClickHouse in particular [outperforms](/concepts/why-clickhouse-is-so-fast#storage-layer-concurrent-inserts-and-selects-are-isolated) others in this category.
 
 ## Why is ClickHouse so fast? {#why-is-clickhouse-so-fast}
 


### PR DESCRIPTION
## Summary

- `docs/intro.md`: a duplicated path `/concepts/why-clickhouse-is-so-fast/concepts/why-clickhouse-is-so-fast#…` doesn't resolve. Collapses to `/concepts/why-clickhouse-is-so-fast#…`. Also drops a stray `.mdx` extension on a nearby related link.
- `docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md`: an in-line link broken across a newline (`[text](../\n/index.md#list-of-static-ips)`) renders the bracket text but not the URL. Replaces with the absolute slug `/integrations/clickpipes#list-of-static-ips`.

## Test plan

- [ ] Visit each affected page in a Docusaurus preview build and confirm the rewritten links render and resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)