### PR TITLE
Fix broken /s3/ and /docs/ prefix links

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -14,7 +14,7 @@ import crash_reports_collection from '@site/static/images/cloud/reference/crash-
 In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibility](/whats-new/cloud-compatibility) page.
 
 :::tip[Automatically keep up to date!]
-  <a href="/docs/cloud/changelog-rss.xml">
+  <a href="/cloud/changelog-rss.xml">
     Subscribe to Cloud Changelog via RSS
   </a>
 :::

--- a/docs/integrations/data-ingestion/gcs/index.md
+++ b/docs/integrations/data-ingestion/gcs/index.md
@@ -180,7 +180,7 @@ Replication with GCS disks can be accomplished by using the `ReplicatedMergeTree
 
 The [Cloud Storage XML API](https://cloud.google.com/storage/docs/xml-api/overview) is interoperable with some tools and libraries that work with services such as Amazon Simple Storage Service (Amazon S3).
 
-For further information on tuning threads, see [Optimizing for Performance](../s3/index.md#s3-optimizing-performance).
+For further information on tuning threads, see [Optimizing for Performance](/integrations/s3#s3-optimizing-performance).
 
 ## Using Google Cloud Storage (GCS) {#gcs-multi-region}
 


### PR DESCRIPTION
## Summary

Two broken intra-doc links:

- **`docs/integrations/data-ingestion/gcs/index.md`** — `../s3/index.md` resolves filesystem-wise to `docs/integrations/data-ingestion/../s3/index.md` which doesn't exist (the `s3/` dir lives under `data-ingestion/`, not as a sibling). Fix: use the absolute slug `/integrations/s3#s3-optimizing-performance`.
- **`docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md`** — `/docs/cloud/changelog-rss.xml` has the legacy `/docs/` URL prefix. Other intra-doc links use root-relative paths; replacing with `/cloud/changelog-rss.xml`.

## Test plan

- [ ] Visit each affected page in a Docusaurus preview build and click through the rewritten links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)