### PR TITLE
fix(vale): track full line range per hunk in CI annotation parser

### DIFF
--- a/scripts/vale/changed_lines_to_json.py
+++ b/scripts/vale/changed_lines_to_json.py
@@ -51,11 +51,14 @@ def get_changed_lines(file_path, base_sha, head_sha):
         changed_lines = []
         for line in diff_output.splitlines():
             if line.startswith("@@"):
-                # Extract line number from git diff header
-                match = re.search(r"^@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,[0-9]+)? @@", line)
+                # Extract the full added range from a unified=0 hunk header.
+                # Format: @@ -A,B +C[,D] @@ — D is omitted when exactly 1 line
+                # was added; D is 0 for pure deletions.
+                match = re.search(r"^@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,([0-9]+))? @@", line)
                 if match:
-                    line_number = int(match.group(1))
-                    changed_lines.append(line_number)
+                    start = int(match.group(1))
+                    count = int(match.group(2)) if match.group(2) is not None else 1
+                    changed_lines.extend(range(start, start + count))
 
         return changed_lines
     except subprocess.CalledProcessError as e:

--- a/scripts/vale/test/test_changed_lines_to_json.py
+++ b/scripts/vale/test/test_changed_lines_to_json.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Unit tests for changed_lines_to_json.get_changed_lines().
+
+Run from the repo root:
+    python3 scripts/vale/test/test_changed_lines_to_json.py
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import changed_lines_to_json
+from changed_lines_to_json import get_changed_lines
+
+
+class GetChangedLinesTest(unittest.TestCase):
+    def _run(self, diff_output):
+        with patch.object(changed_lines_to_json.subprocess, "check_output", return_value=diff_output):
+            return get_changed_lines("dummy.md", "BASE", "HEAD")
+
+    def test_single_line_addition_no_count(self):
+        # `+26` (count omitted) means exactly one added line
+        self.assertEqual(self._run("@@ -25,0 +26 @@"), [26])
+
+    def test_multi_line_addition(self):
+        # `+43,26` means 26 lines starting at 43 — this is the case PR #6183 hit
+        self.assertEqual(self._run("@@ -41,0 +43,26 @@"), list(range(43, 69)))
+
+    def test_pure_deletion_yields_no_lines(self):
+        # `+9,0` is a pure deletion — no lines exist in the new file to lint
+        self.assertEqual(self._run("@@ -10,5 +9,0 @@"), [])
+
+    def test_modified_hunk(self):
+        self.assertEqual(self._run("@@ -10,3 +10,5 @@"), [10, 11, 12, 13, 14])
+
+    def test_multiple_hunks_concatenated(self):
+        diff = "\n".join([
+            "@@ -25,0 +26 @@",
+            "@@ -41,0 +43,3 @@",
+        ])
+        self.assertEqual(self._run(diff), [26, 43, 44, 45])
+
+    def test_hunk_header_with_trailing_context(self):
+        # Real git output often appends a context line after the second @@
+        self.assertEqual(
+            self._run("@@ -41,0 +43,2 @@ Some context line"),
+            [43, 44],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`scripts/vale/changed_lines_to_json.py` was only recording the **start line** of each `@@` hunk header, so any error-level Vale finding past the first added line of a hunk got filtered out by `vale_annotations.py` and silently passed CI.

This was caught while reviewing #6183 — Vale flagged two `ClickHouse.Headings` errors (lines 44 and 56), but CI was green because both lines fell outside the `[26, 43]` `changed_lines` list the script produced.

### Before

```python
match = re.search(r"^@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,[0-9]+)? @@", line)
if match:
    line_number = int(match.group(1))
    changed_lines.append(line_number)   # only the start line
```

For PR #6183's `@@ -41,0 +43,26 @@` hunk this produced `[43]` instead of `[43..68]`.

### After

```python
match = re.search(r"^@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,([0-9]+))? @@", line)
if match:
    start = int(match.group(1))
    count = int(match.group(2)) if match.group(2) is not None else 1
    changed_lines.extend(range(start, start + count))
```

Now `[43, 44, 45, …, 68]`. Pure deletions (`+A,0`) yield an empty range as expected.

### Validation against PR #6183

| | Before fix | After fix |
|---|---|---|
| `changed_lines` for the PR file | `[26, 43]` | 27 entries (`[26, 43..68]` — matches `+27` additions) |
| Annotation script exit code | `0` (pass) | `1` (fail) |
| Errors surfaced to GitHub annotations | 0 | 2 (sentence-case violations on lines 44 + 56) |

### Blast radius

This bug affected any error-level Vale finding past the first added line of every hunk, for as long as this script has existed. A separate sweep of recently-merged PRs may be worth doing to identify escapes — out of scope here.

## Test plan

- [x] New unit tests at `scripts/vale/test/test_changed_lines_to_json.py` cover six cases: single-line addition (omitted count), multi-line addition, pure deletion, modified hunk, multiple hunks concatenated, and hunk header with trailing context.
- [x] Verified the new tests pass against the fix (6/6).
- [x] Verified the new tests fail against the buggy version (5/6 fail; the single-line case coincidentally matched the buggy output).
- [x] End-to-end validation against PR #6183: ran the fixed `changed_lines_to_json.py` + `vale_annotations.py` against the PR's diff and confirmed CI would now exit with code 1 and surface both heading errors.

Run locally:
```bash
python3 scripts/vale/test/test_changed_lines_to_json.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)