### PR TITLE
Fix quality issues on warehouses page

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -88,7 +88,7 @@ _Fig. 4 - User Alice was created in Service 1, but she can use the same credenti
 ### Network access control {#network-access-control}
 
 To restrict access to specific services by other applications or ad-hoc users, you can apply network restrictions.
-To do so, navigate to **Settings** in the service tab of the particular service you wish to restrict access to in ClickHouse Cloud console).
+To do so, navigate to **Settings** in the service tab of the particular service you wish to restrict access to in the ClickHouse Cloud console.
 
 IP filtering settings can be applied to each service separately, which means you can control which application can access which service.
 This allows you to restrict users from using specific services.
@@ -171,11 +171,11 @@ Note that read-only services don't execute background merges, thus they don't sp
 - **Inserts on one read-write service can prevent another read-write service from idling if idling is enabled.** There are situations where
  one service performs background merge operations for another service. Those background operations can prevent the second service from idling. Once the background operations are finished, the service will idled. Read-only services aren't affected.
 
-### Helpful Callouts {#callouts}
+### Helpful callouts {#callouts}
 
 - **ClickHouse Versions**: The [upgrade schedule](/manage/updates) is dictated by the primary service's settings. Secondary services cannot have a release schedule independent of the primary service.
 
-- **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you  can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
+- **`CREATE`/`RENAME`/`DROP DATABASE` queries could be blocked by idled/stopped services by default.** If these queries are executed when the service is idled or stopped, these queries can hang. To bypass this, you can run database management queries with [`settings distributed_ddl_task_timeout=0`](/operations/settings/settings#distributed_ddl_task_timeout) at the session or per query level.
 
 For example:
 
@@ -187,19 +187,19 @@ SETTINGS distributed_ddl_task_timeout=0
 If you manually stop a service, you will need to start it up again in order for queries to be executed. 
 
 - **There is currently a soft limit of 5 services per warehouse.** Contact the support team if you need more than 5 services in a single warehouse.
-- **One replica Primary Service** Today, the default behavior is the secondary services can have one replica, the primary service must have at least 2.
+- **One-replica primary service:** Today, the default behavior is that secondary services can have one replica, while the primary service must have at least two replicas.
   To enable single replica primary services, please contact support. This behavior will be enabled by default in Q2 2026.
 - **Primary service idling**: Previously, primary services could not auto-idle by default. As of May 2026, primary service auto-idling is enabled by default. As part of the rollout, existing services have access to the feature while new services created post rollout have it enabled by default. 
 
 ## Pricing {#pricing}
 
-Compute prices are the same for all services in a warehouse (primary and secondary). Storage is billed only once - it is included in the first (original) service.
+Compute prices are the same for all services in a warehouse (primary and secondary). Storage is billed only once—it is included in the first (original) service.
 
 Please refer to the pricing calculator on the [pricing](https://clickhouse.com/pricing) page, which will help estimate the cost based on your workload size and tier selection. The Usage Breakdown table will show you the breakdown of compute costs across services. 
 
 ## Backups {#backups}
 
-- As all services in a single warehouse share the same storage, backups are made only on the primary (initial) service. By this, the data for all services in a warehouse is backed up.
+- As all services in a single warehouse share the same storage, backups are made only on the primary (initial) service. This way, the data for all services in a warehouse is backed up.
 - If you restore a backup from a primary service of a warehouse, it will be restored to a completely new service, not connected to the existing warehouse. You can then add more services to the new service immediately after the restore is finished.
 
 ## How to set up a warehouse {#setup-warehouses}


### PR DESCRIPTION
### Motivation
- Correct a set of copy-and-style issues found on the warehouses documentation page to improve readability and consistency. 
- Apply site conventions (sentence case headings, consistent bullet labels, punctuation) and fix minor typos found during review of the page.

### Description
- Edited `docs/cloud/features/05_infrastructure/warehouses.md` to fix an unmatched closing parenthesis, change the `### Helpful Callouts` heading to sentence case, remove a double space in the distributed DDL guidance, normalize the bullet label for the primary-replica note to sentence case with a colon, replace a hyphen sentence break with an em dash in pricing, and rephrase a backup sentence for clarity. 
- Adjusted the `One-replica primary service` bullet text for grammatical clarity and to match surrounding style.
- Minor whitespace and punctuation fixes to keep the document consistent with site style.

### Testing
- Ran `git diff --check` which returned no issues. 
- No additional automated tests were required because these are docs-only text changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a023172d88c832ab6e15bdee002a6a1)