### PR TITLE
Remove DWH number of services limit

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -186,7 +186,6 @@ SETTINGS distributed_ddl_task_timeout=0
 
 If you manually stop a service, you will need to start it up again in order for queries to be executed. 
 
-- **There is currently a soft limit of 5 services per warehouse.** Contact the support team if you need more than 5 services in a single warehouse.
 - **One replica Primary Service** Today, the default behavior is the secondary services can have one replica, the primary service must have at least 2.
   To enable single replica primary services, please contact support. This behavior will be enabled by default in Q2 2026.
 - **Primary service idling**: Previously, primary services could not auto-idle by default. As of May 2026, primary service auto-idling is enabled by default. As part of the rollout, existing services have access to the feature while new services created post rollout have it enabled by default. 


### PR DESCRIPTION
We don't have this limit any more on number of service in a DWH.
