### PR TITLE
clickpipes: support 32 vcpus

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/scaling.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/scaling.md
@@ -62,13 +62,13 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 }
 ```
 
-Set the desired scaling. Supported configurations include 1-24 CPU cores with memory (GB) set to 4× the core count:
+Set the desired scaling. Supported configurations include 1-32 CPU cores with memory (GB) set to 4× the core count:
 
 ```bash
 cat <<EOF | tee cdc_scaling.json
 {
-  "replicaCpuMillicores": 24000,
-  "replicaMemoryGb": 96
+  "replicaCpuMillicores": 32000,
+  "replicaMemoryGb": 128
 }
 EOF
 
@@ -88,8 +88,8 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 # example result:
 {
   "result": {
-    "replicaCpuMillicores": 24000,
-    "replicaMemoryGb": 96
+    "replicaCpuMillicores": 32000,
+    "replicaMemoryGb": 128
   },
   "requestId": "5a76d642-d29f-45af-a857-8c4d4b947bf0",
   "status": 200

--- a/i18n/jp/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
@@ -65,13 +65,13 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 }
 ```
 
-希望するスケーリングを設定します。サポートされる構成は、CPU コア数が1～24で、メモリ (GB) はコア数の4倍です：
+希望するスケーリングを設定します。サポートされる構成は、CPU コア数が1～32で、メモリ (GB) はコア数の4倍です：
 
 ```bash
 cat <<EOF | tee cdc_scaling.json
 {
-  "replicaCpuMillicores": 24000,
-  "replicaMemoryGb": 96
+  "replicaCpuMillicores": 32000,
+  "replicaMemoryGb": 128
 }
 EOF
 
@@ -91,8 +91,8 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 # example result:
 {
   "result": {
-    "replicaCpuMillicores": 24000,
-    "replicaMemoryGb": 96
+    "replicaCpuMillicores": 32000,
+    "replicaMemoryGb": 128
   },
   "requestId": "5a76d642-d29f-45af-a857-8c4d4b947bf0",
   "status": 200

--- a/i18n/ru/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
@@ -65,13 +65,13 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 }
 ```
 
-Задайте нужные параметры масштабирования. Поддерживаются конфигурации с 1–24 ядрами CPU, при этом объём памяти (ГБ) должен в 4 раза превышать число ядер:
+Задайте нужные параметры масштабирования. Поддерживаются конфигурации с 1–32 ядрами CPU, при этом объём памяти (ГБ) должен в 4 раза превышать число ядер:
 
 ```bash
 cat <<EOF | tee cdc_scaling.json
 {
-  "replicaCpuMillicores": 24000,
-  "replicaMemoryGb": 96
+  "replicaCpuMillicores": 32000,
+  "replicaMemoryGb": 128
 }
 EOF
 
@@ -91,8 +91,8 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 # example result:
 {
   "result": {
-    "replicaCpuMillicores": 24000,
-    "replicaMemoryGb": 96
+    "replicaCpuMillicores": 32000,
+    "replicaMemoryGb": 128
   },
   "requestId": "5a76d642-d29f-45af-a857-8c4d4b947bf0",
   "status": 200

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations/data-ingestion/clickpipes/postgres/scaling.md
@@ -65,13 +65,13 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 }
 ```
 
-设置所需的扩缩容级别。支持的配置包括 1–24 个 CPU 核心，内存 (GB) 为核心数的 4×：
+设置所需的扩缩容级别。支持的配置包括 1–32 个 CPU 核心，内存 (GB) 为核心数的 4×：
 
 ```bash
 cat <<EOF | tee cdc_scaling.json
 {
-  "replicaCpuMillicores": 24000,
-  "replicaMemoryGb": 96
+  "replicaCpuMillicores": 32000,
+  "replicaMemoryGb": 128
 }
 EOF
 
@@ -91,8 +91,8 @@ https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID/click
 # example result:
 {
   "result": {
-    "replicaCpuMillicores": 24000,
-    "replicaMemoryGb": 96
+    "replicaCpuMillicores": 32000,
+    "replicaMemoryGb": 128
   },
   "requestId": "5a76d642-d29f-45af-a857-8c4d4b947bf0",
   "status": 200


### PR DESCRIPTION
## Summary
Support a higher cpu cores once enabled by the backend.
