### PR TITLE
fix(vale): scope changed-files diff to PR branch additions only

### DIFF
--- a/scripts/vale/changed_lines_to_json.py
+++ b/scripts/vale/changed_lines_to_json.py
@@ -29,7 +29,11 @@ from pathlib import Path
 def get_changed_files(base_sha, head_sha, pattern=r'^docs/.*\.(md|mdx)$'):
     """Get list of changed files matching the pattern."""
     try:
-        cmd = f"git diff --name-only {base_sha} {head_sha}"
+        # Three-dot diff (base...head) scopes the comparison to the changes
+        # the PR branch added since it diverged from base. Two-dot or
+        # endpoint form would also surface commits main has gained since
+        # the branch was created, causing Vale to run on unrelated files.
+        cmd = f"git diff --name-only {base_sha}...{head_sha}"
         result = subprocess.check_output(cmd, shell=True, text=True)
         all_files = result.splitlines()
 
@@ -45,7 +49,7 @@ def get_changed_files(base_sha, head_sha, pattern=r'^docs/.*\.(md|mdx)$'):
 def get_changed_lines(file_path, base_sha, head_sha):
     """Get line numbers that were changed in a specific file."""
     try:
-        cmd = f"git diff --unified=0 {base_sha} {head_sha} -- {file_path}"
+        cmd = f"git diff --unified=0 {base_sha}...{head_sha} -- {file_path}"
         diff_output = subprocess.check_output(cmd, shell=True, text=True)
 
         changed_lines = []


### PR DESCRIPTION
## Summary

- Vale CI was flagging style issues on files no PR ever touched when the PR's branch was behind `main`. Reproduced on #6210 (a one-file PR; Vale reported 30 errors across 17 unrelated files).
- Root cause: `scripts/vale/changed_lines_to_json.py` used endpoint diff (`git diff <base> <head>`), which surfaces both the PR's edits *and* `main`'s drift since the branch was created.
- Fix: switch to three-dot syntax (`<base>...<head>`), which scopes the diff to what the branch added since it diverged from `main`.

## Problem (reproduced on #6210)

PR #6210 ("support 32 vcpus") changes a single file: `docs/integrations/data-ingestion/clickpipes/postgres/scaling.md`, +5/−5. Vale CI failed with **30 annotations across 17 different files**, none of them `scaling.md`. Examples of flagged files:

- `docs/whats-new/changelog/index.md`
- `docs/best-practices/json_type.md`
- `docs/cloud/_snippets/_clickpipes_faq.md`
- `docs/chdb/index.md`

These are pre-existing style issues on files modified on `main` after the PR's branch was cut.

## Cause

`scripts/vale/changed_lines_to_json.py` builds the "PR-changed" file list with `git diff --name-only <base_sha> <head_sha>` (endpoint comparison). When `base.sha` is today's `main` HEAD and `head.sha` is a PR commit whose parent is an older `main`, this diff returns two kinds of differences lumped together:

1. The PR's actual edits (correct).
2. Everything `main` has gained since the branch diverged but that the PR doesn't have (incorrect — that's `main`'s drift, not the PR's work).

Vale then runs on the combined file set and reports pre-existing issues in files the PR never modified.

## Fix

```diff
-cmd = f"git diff --name-only {base_sha} {head_sha}"
+cmd = f"git diff --name-only {base_sha}...{head_sha}"

-cmd = f"git diff --unified=0 {base_sha} {head_sha} -- {file_path}"
+cmd = f"git diff --unified=0 {base_sha}...{head_sha} -- {file_path}"
```

`<base>...<head>` is git shorthand for `merge-base(base, head)..head` — only what the branch added since it diverged. No behavior change for up-to-date PRs (when the branch's parent equals `base.sha`, three-dot and endpoint forms are identical).

## Verification

Running the patched script against #6210's actual SHAs:

```
Found 1 changed files matching pattern
Processing file: docs/integrations/data-ingestion/clickpipes/postgres/scaling.md
Found 5 changed lines in docs/integrations/data-ingestion/clickpipes/postgres/scaling.md
```

1 file, 5 lines — matches the PR's actual `+5` diff exactly. With the same SHAs on the unpatched script, the file list contained 17 files of `main`-drift.

## Test plan

- [x] Patched script returns 1 file (`scaling.md`) when run against #6210's SHAs locally
- [ ] CI re-run on a behind-`main` PR (e.g., #6210) confirms Vale annotations are scoped to PR-touched files
- [ ] CI re-run on an up-to-date PR confirms no regression — three-dot and endpoint forms are equivalent when the branch is current
- [ ] Spot-check that a PR with multi-hunk edits still produces correct line numbers in `logs/changed_lines.json`

## Related

Sibling fix to #6188, which fixed within-hunk line-range tracking in `vale_annotations.py`. That PR corrected how the annotation parser maps Vale output to PR lines; this PR corrects which files and lines are considered "PR-changed" in the first place. Both scripts now agree on the PR scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)