### PR TITLE
docs: normalize ClickHouse example output formatting in Postgres migration guide

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/02_postgres/migration_guide/02_migration_guide_part2.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/02_postgres/migration_guide/02_migration_guide_part2.md
@@ -39,13 +39,13 @@ HAVING count() > 10
 ORDER BY total_views DESC
 LIMIT 5
 
-┌─OwnerDisplayName────────┬─total_views─┐
-│ Joan Venge            │       25520387 │
-│ Ray Vega              │       21576470 │
-│ anon                  │       19814224 │
-│ Tim                   │       19028260 │
-│ John                  │       17638812 │
-└─────────────────────────┴─────────────┘
+┌─OwnerDisplayName─┬─total_views─┐
+│ Joan Venge       │    25520387 │
+│ Ray Vega         │    21576470 │
+│ anon             │    19814224 │
+│ Tim              │    19028260 │
+│ John             │    17638812 │
+└──────────────────┴─────────────┘
 
 5 rows in set. Elapsed: 0.360 sec. Processed 24.37 million rows, 140.45 MB (67.73 million rows/s., 390.38 MB/s.)
 Peak memory usage: 510.71 MiB.
@@ -85,10 +85,10 @@ LIMIT 5
 
 ┌─tags───────┬──────views─┐
 │ javascript │ 8190916894 │
-│ python        │ 8175132834 │
-│ java          │ 7258379211 │
-│ c#            │ 5476932513 │
-│ android       │ 4258320338 │
+│ python     │ 8175132834 │
+│ java       │ 7258379211 │
+│ c#         │ 5476932513 │
+│ android    │ 4258320338 │
 └────────────┴────────────┘
 
 5 rows in set. Elapsed: 0.908 sec. Processed 59.82 million rows, 1.45 GB (65.87 million rows/s., 1.59 GB/s.)
@@ -224,11 +224,11 @@ ORDER BY percent_change DESC
 LIMIT 5
 
 ┌─tag─────────┬─count_2023─┬─count_2022─┬──────percent_change─┐
-│ next.js       │       13788 │         10520 │   31.06463878326996 │
-│ spring-boot │         16573 │         17721 │  -6.478189718413183 │
-│ .net          │       11458 │         12968 │ -11.644046884639112 │
-│ azure         │       11996 │         14049 │ -14.613139725247349 │
-│ docker        │       13885 │         16877 │  -17.72826924216389 │
+│ next.js     │      13788 │      10520 │   31.06463878326996 │
+│ spring-boot │      16573 │      17721 │  -6.478189718413183 │
+│ .net        │      11458 │      12968 │ -11.644046884639112 │
+│ azure       │      11996 │      14049 │ -14.613139725247349 │
+│ docker      │      13885 │      16877 │  -17.72826924216389 │
 └─────────────┴────────────┴────────────┴─────────────────────┘
 
 5 rows in set. Elapsed: 0.247 sec. Processed 5.08 million rows, 155.73 MB (20.58 million rows/s., 630.61 MB/s.)


### PR DESCRIPTION
### Motivation
- Improve consistency and readability of example CLI output shown in the PostgreSQL-to-ClickHouse migration guide by normalizing spacing and table alignment in the ClickHouse result blocks.

### Description
- Updated multiple ClickHouse example output blocks in `02_migration_guide_part2.md` to adjust column spacing and box-drawing alignment for clearer, more compact presentation.
- This change is documentation-only and does not modify any executable code or SQL examples themselves.

### Testing
- Ran a documentation site build with `mkdocs build` to verify markdown renders correctly and the changed output blocks do not break the site, and the build succeeded.
- Ran `markdownlint` over the modified file to ensure formatting rules are satisfied and the lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0497bbbb90832cb957c63e5d9749fe)