### PR TITLE
docs(byoc): add ClickHouse data access reference page

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
@@ -74,40 +74,19 @@ The Tailscale connection establishment follows these steps:
    - Each Tailscale agent generates its own public-private key pair (similar to PKI)
    - Traffic remains encrypted regardless of whether it uses direct or relay mode
 
-### Security Features {#tailscale-security}
+### Security features {#tailscale-security}
 
-**Outbound-Only Connections**:
+**Outbound-only connections**:
 - Tailscale agents in your EKS cluster initiate outbound connections to the Tailscale coordination/relay servers
-- **No inbound connections are required**—no security group rules need to allow inbound traffic to Tailscale agents
+- **No inbound connections are required** — no security group rules need to allow inbound traffic to Tailscale agents
 - This reduces the attack surface and simplifies network security configuration
 
-**Access Control**:
-- Access is controlled through ClickHouse's internal approval system
-- Engineers must request access through designated approval workflows
+**Access control**:
+- Engineers must request access through an internal approval workflow before Tailscale can route them to a customer endpoint
 - Access is time-bound and automatically expires
 - All access is audited and logged
 
-**Certificate-Based Authentication**:
-- For ClickHouse system table access, engineers use temporary, time-bound certificates
-- Certificate-based authentication replaces password-based access for all human access in BYOC
-- Access is restricted to system tables only (not customer data)
-- All access attempts are logged in ClickHouse's `query_log` table
-
-### Troubleshooting Access via Tailscale {#troubleshooting-access-tailscale}
-
-When ClickHouse engineers need to troubleshoot issues in your BYOC deployment, they use Tailscale to access:
-
-- **Kubernetes API Server**: For diagnosing EBS mount failures, node-level network issues, and cluster health problems
-- **ClickHouse System Tables**: For query performance analysis and diagnostic queries (read-only access to system tables only)
-
-The troubleshooting access process:
-
-1. **Access Request**: On-call engineers within a designated group request access to the customer ClickHouse instance
-2. **Approval**: The request goes through an internal approval system with designated approvers
-3. **Certificate Generation**: A time-bound certificate is generated for the approved engineer
-4. **ClickHouse Configuration**: The ClickHouse operator configures ClickHouse to accept the certificate
-5. **Connection**: Engineers access the instance via Tailscale using the certificate
-6. **Automatic Expiration**: Access automatically expires after the set time period
+For the full data access policy — what engineers can see, certificate-based authentication, and customer-side auditing — see [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access).
 
 ### Management Services Access {#management-services-access}
 
@@ -132,15 +111,7 @@ By default, ClickHouse management services access your BYOC Kubernetes cluster v
 - Query traffic and customer data never flow through Tailscale
 - All customer data remains within your VPC
 
-### Monitoring and Auditing {#tailscale-monitoring}
-
-Both ClickHouse and customers can audit Tailscale access activity:
-
-- **ClickHouse Monitoring**: ClickHouse monitors access requests and logs all Tailscale connections
-- **Customer Auditing**: Customers can track activity from ClickHouse engineers within their own systems
-- **Query Logs**: All system table access via Tailscale is logged in ClickHouse's `query_log` table
-
-For more technical details about how Tailscale is implemented in BYOC, see the [Building ClickHouse BYOC on AWS blog post](https://clickhouse.com/blog/building-clickhouse-byoc-on-aws#tailscale-connection).
+For more technical details about how Tailscale is implemented in BYOC, see the [Building ClickHouse BYOC on AWS blog post](https://clickhouse.com/blog/building-clickhouse-byoc-on-aws#tailscale-connection). For what ClickHouse engineers can read once connected and how that is audited, see [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access).
 
 ## Network boundaries {#network-boundaries}
 
@@ -163,7 +134,7 @@ By default, ingress is publicly accessible with IP allow list filtering. Custome
 
 *Inbound, Private*
 
-ClickHouse Cloud engineers require troubleshooting access via Tailscale. They're provisioned with just-in-time certificate-based authentication for BYOC deployments.
+ClickHouse Cloud engineers require troubleshooting access via Tailscale. They're provisioned with just-in-time certificate-based authentication for BYOC deployments. See [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access) for the full access policy.
 
 ### Billing scraper {#billing-scraper}
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
@@ -111,7 +111,7 @@ By default, ClickHouse management services access your BYOC Kubernetes cluster v
 - Query traffic and customer data never flow through Tailscale
 - All customer data remains within your VPC
 
-For more technical details about how Tailscale is implemented in BYOC, see the [Building ClickHouse BYOC on AWS blog post](https://clickhouse.com/blog/building-clickhouse-byoc-on-aws#tailscale-connection). For what ClickHouse engineers can read once connected and how that is audited, see [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access).
+For more technical details about how Tailscale is implemented in BYOC, see the [Building ClickHouse BYOC on AWS blog post](https://clickhouse.com/blog/building-clickhouse-byoc-on-aws#tailscale-connection). For what ClickHouse engineers can read once connected and how ClickHouse audits that access, see [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access).
 
 ## Network boundaries {#network-boundaries}
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
@@ -1,0 +1,62 @@
+---
+title: 'ClickHouse data access'
+slug: /cloud/reference/byoc/reference/clickhouse_data_access
+sidebar_label: 'ClickHouse data access'
+keywords: ['BYOC', 'bring your own cloud', 'data access', 'employee access', 'system.query_log', 'troubleshooting access', 'compliance']
+description: 'What access ClickHouse employees have to customer data in BYOC deployments'
+doc_type: 'reference'
+---
+
+ClickHouse employees have no access to your data by default. Your ClickHouse data, including all user tables and query results, stays inside your VPC. The only paths by which ClickHouse interacts with your deployment are described below — none of them grant access to customer table data.
+
+## Routine operations {#routine-operations}
+
+ClickHouse Cloud's control plane runs your BYOC deployment without reading customer data. The components that send data out of your VPC carry only operational metadata:
+
+| Component | What leaves your VPC |
+|-----------|----------------------|
+| State exporter | Service state (health, status) to an SQS queue owned by ClickHouse Cloud. |
+| Billing scraper | CPU and memory metrics to an S3 bucket owned by ClickHouse Cloud. |
+| AlertManager | Cluster health alerts to ClickHouse Cloud. |
+
+Query traffic, table contents, and schemas never flow through these channels. Logs and metrics stay inside your BYOC VPC.
+
+## Troubleshooting access {#troubleshooting-access}
+
+When ClickHouse engineers need to diagnose a problem in your deployment, they request just-in-time access through an internal escalation and approval workflow. Approved access is granted via a time-bound certificate and routed over [Tailscale](/cloud/reference/byoc/reference/network_security#tailscale-private-network) — never the public internet.
+
+### What engineers can see {#what-engineers-can-see}
+
+With approved troubleshooting access, engineers can read ClickHouse system tables only. This includes:
+
+- `system.query_log` — query text and execution metadata for queries run against your service
+- `system.tables`, `system.columns`, and similar system tables — schema and metadata
+- Other `system.*` tables used for diagnostics (e.g., parts, mutations, replicas)
+
+### What engineers cannot see {#what-engineers-cannot-see}
+
+Engineers cannot read customer user tables. Access is scoped to system tables only.
+
+### How access is enforced {#how-access-is-enforced}
+
+- **Approval required**: every access request goes through an internal approval system with designated approvers. Engineers cannot self-grant access.
+- **Time-bound certificates**: a temporary, time-bound certificate is generated per approved session. Access expires automatically.
+- **Certificate-based authentication**: certificates replace password-based access for all human access to BYOC instances.
+- **Read-only on system tables**: the certificate identity is scoped to system table reads.
+- **No data exported**: logs and query results from troubleshooting sessions are never exported back to ClickHouse infrastructure.
+
+## Auditing {#auditing}
+
+Engineer activity is visible to you and audited by ClickHouse:
+
+- **Customer-visible**: every query a ClickHouse engineer runs on your instance appears in your own `system.query_log`, including the query text and the certificate identity. You can audit this from your ClickHouse service directly.
+- **ClickHouse-side**: all access requests, approvals, and Tailscale connections are logged and audited internally by ClickHouse's security team.
+
+## Future controls {#future-controls}
+
+Customer-controlled approval — where you approve each engineer access request before it takes effect — is on the roadmap. Today, approval is handled through ClickHouse's internal escalation process.
+
+## Related {#related}
+
+- [BYOC network security](/cloud/reference/byoc/reference/network_security) — how Tailscale and the network boundaries work
+- [BYOC privilege](/cloud/reference/byoc/reference/privilege) — IAM roles created during BYOC setup

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
@@ -1,5 +1,5 @@
 ---
-title: 'ClickHouse data access'
+title: 'ClickHouse data access (BYOC)'
 slug: /cloud/reference/byoc/reference/clickhouse_data_access
 sidebar_label: 'ClickHouse data access'
 keywords: ['BYOC', 'bring your own cloud', 'data access', 'employee access', 'system.query_log', 'troubleshooting access', 'compliance']

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
@@ -15,7 +15,7 @@ ClickHouse Cloud's control plane runs your BYOC deployment without reading custo
 
 | Component | What leaves your VPC |
 |-----------|----------------------|
-| State exporter | Service state (health, status) to an SQS queue owned by ClickHouse Cloud. |
+| State exporter | Service state (health, status) to an `SQS` queue owned by ClickHouse Cloud. |
 | Billing scraper | CPU and memory metrics to an S3 bucket owned by ClickHouse Cloud. |
 | AlertManager | Cluster health alerts to ClickHouse Cloud. |
 
@@ -33,13 +33,13 @@ With approved troubleshooting access, engineers can read ClickHouse system table
 - `system.tables`, `system.columns`, and similar system tables — schema and metadata
 - Other `system.*` tables used for diagnostics (e.g., parts, mutations, replicas)
 
-### What engineers cannot see {#what-engineers-cannot-see}
+### What engineers can't see {#what-engineers-cant-see}
 
-Engineers cannot read customer user tables. Access is scoped to system tables only.
+Engineers can't read customer user tables. Access is scoped to system tables only.
 
 ### How access is enforced {#how-access-is-enforced}
 
-- **Approval required**: every access request goes through an internal approval system with designated approvers. Engineers cannot self-grant access.
+- **Approval required**: every access request goes through an internal approval system with designated approvers. Engineers can't self-grant access.
 - **Time-bound certificates**: a temporary, time-bound certificate is generated per approved session. Access expires automatically.
 - **Certificate-based authentication**: certificates replace password-based access for all human access to BYOC instances.
 - **Read-only on system tables**: the certificate identity is scoped to system table reads.
@@ -50,7 +50,7 @@ Engineers cannot read customer user tables. Access is scoped to system tables on
 Engineer activity is visible to you and audited by ClickHouse:
 
 - **Customer-visible**: every query a ClickHouse engineer runs on your instance appears in your own `system.query_log`, including the query text and the certificate identity. You can audit this from your ClickHouse service directly.
-- **ClickHouse-side**: all access requests, approvals, and Tailscale connections are logged and audited internally by ClickHouse's security team.
+- **ClickHouse-side**: ClickHouse's security team internally logs and audits all access requests, approvals, and Tailscale connections.
 
 ## Future controls {#future-controls}
 


### PR DESCRIPTION
## Summary
- Adds new BYOC reference page **ClickHouse data access** (`/cloud/reference/byoc/reference/clickhouse_data_access`) that gives customers and field teams a single authoritative answer to "what can ClickHouse employees see in a BYOC deployment?"
- Covers: default position (no access), what flows out during routine ops, what engineers can read during troubleshooting (system tables only, never user data), how access is enforced (approval workflow, time-bound certs, never exported), and how to audit it from the customer side (via `system.query_log`).
- Consolidates the overlapping troubleshooting-access / certificate-auth / auditing sections out of `network_security.md` and replaces them with cross-links, so the data access policy lives in one place.

## Test plan
- [ ] `yarn check-markdown` passes locally (verified — 0 errors)
- [ ] Docusaurus preview renders the new page under BYOC → Reference with the correct sidebar order (FAQ, Privilege, Network Security, ClickHouse data access)
- [ ] Cross-links from `network_security.md` to `/cloud/reference/byoc/reference/clickhouse_data_access` resolve in preview
- [ ] Anchor links inside the new page (`#troubleshooting-access`, `#auditing`, etc.) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)