### PR TITLE
Docs: add titles to fenced code blocks and fix a missing code fence in examples

### DIFF
--- a/docs/chdb/datastore/execution-model.md
+++ b/docs/chdb/datastore/execution-model.md
@@ -169,7 +169,7 @@ result = (ds
 
 Use `explain()` to see what will be executed:
 
-```python
+```python title="Query"
 ds = pd.read_csv("sales.csv")
 
 query = (ds

--- a/docs/chdb/datastore/execution-model.md
+++ b/docs/chdb/datastore/execution-model.md
@@ -182,8 +182,7 @@ query = (ds
 query.explain()
 ```
 
-Output:
-```text
+```text title="Response"
 Pipeline:
   1. Source: file('sales.csv', 'CSVWithNames')
   2. Filter: amount > 1000

--- a/docs/chdb/datastore/quickstart.md
+++ b/docs/chdb/datastore/quickstart.md
@@ -234,7 +234,7 @@ df = ds.to_pandas() # Same as to_df()
 
 ### Viewing Generated SQL {#view-sql}
 
-```python
+```python title="Query"
 # See what SQL DataStore will execute
 query = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'mean'})
 print(query.to_sql())

--- a/docs/chdb/datastore/quickstart.md
+++ b/docs/chdb/datastore/quickstart.md
@@ -240,8 +240,7 @@ query = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'mean'})
 print(query.to_sql())
 ```
 
-Output:
-```sql
+```sql title="Response"
 SELECT city, AVG(salary) AS mean
 FROM file('data.csv', 'CSVWithNames')
 WHERE age > 25

--- a/docs/chdb/debugging/index.md
+++ b/docs/chdb/debugging/index.md
@@ -70,8 +70,7 @@ query = (ds
 query.explain()
 ```
 
-Output:
-```text
+```text title="Response"
 Pipeline:
   Source: file('data.csv', 'CSVWithNames')
   Filter: amount > 1000
@@ -115,8 +114,7 @@ profiler = get_profiler()
 profiler.report(min_duration_ms=0.1)
 ```
 
-Output:
-```text
+```text title="Response"
 Performance Report
 ==================
 Step                          Duration    Calls

--- a/docs/chdb/debugging/index.md
+++ b/docs/chdb/debugging/index.md
@@ -57,7 +57,7 @@ profiler.report()
 
 View the execution plan before running a query.
 
-```python
+```python title="Query"
 ds = pd.read_csv("data.csv")
 
 query = (ds
@@ -92,7 +92,7 @@ See [explain() Documentation](explain.md) for details.
 
 Measure execution time for each operation.
 
-```python
+```python title="Query"
 from chdb.datastore.config import config, get_profiler
 
 # Enable profiling

--- a/docs/chdb/debugging/logging.md
+++ b/docs/chdb/debugging/logging.md
@@ -68,8 +68,7 @@ config.enable_debug()  # Sets DEBUG level + verbose format
 config.set_log_format("simple")
 ```
 
-Output:
-```text
+```text title="Response"
 DEBUG - Executing SQL query
 DEBUG - Cache miss for key abc123
 ```
@@ -80,8 +79,7 @@ DEBUG - Cache miss for key abc123
 config.set_log_format("verbose")
 ```
 
-Output:
-```text
+```text title="Response"
 2024-01-15 10:30:45.123 DEBUG datastore.core - Executing SQL query
 2024-01-15 10:30:45.456 DEBUG datastore.cache - Cache miss for key abc123
 ```

--- a/docs/chdb/debugging/logging.md
+++ b/docs/chdb/debugging/logging.md
@@ -64,7 +64,7 @@ config.enable_debug()  # Sets DEBUG level + verbose format
 
 ### Simple Format (Default) {#simple}
 
-```python
+```python title="Query"
 config.set_log_format("simple")
 ```
 
@@ -75,7 +75,7 @@ DEBUG - Cache miss for key abc123
 
 ### Verbose Format {#verbose}
 
-```python
+```python title="Query"
 config.set_log_format("verbose")
 ```
 

--- a/docs/chdb/guides/pandas-to-sql.md
+++ b/docs/chdb/guides/pandas-to-sql.md
@@ -39,8 +39,7 @@ query = (ds
 print(query.to_sql())
 ```
 
-Output:
-```sql
+```sql title="Response"
 SELECT region, SUM(amount) AS sum, AVG(amount) AS mean
 FROM file('sales.csv', 'CSVWithNames')
 WHERE amount > 1000

--- a/docs/chdb/guides/pandas-to-sql.md
+++ b/docs/chdb/guides/pandas-to-sql.md
@@ -12,7 +12,7 @@ DataStore compiles pandas-style operations into optimized SQL. This guide helps 
 
 ## Viewing Generated SQL {#viewing-sql}
 
-```python
+```python title="Query"
 from pathlib import Path
 Path("sales.csv").write_text("""\
 region,product,category,amount,quantity,price,date,order_id

--- a/docs/getting-started/example-datasets/menus.md
+++ b/docs/getting-started/example-datasets/menus.md
@@ -184,15 +184,11 @@ FROM menu_item
 
 ## Validate the data {#validate-data}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT count() FROM menu_item_denorm;
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌─count()─┐
 │ 1329175 │
 └─────────┘
@@ -202,9 +198,7 @@ Result:
 
 ### Averaged historical prices of dishes {#query-averaged-historical-prices}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     round(toUInt32OrZero(extract(menu_date, '^\\d{4}')), -1) AS d,
     count(),
@@ -216,9 +210,7 @@ GROUP BY d
 ORDER BY d ASC;
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌────d─┬─count()─┬─round(avg(price), 2)─┬─bar(avg(price), 0, 100, 100)─┐
 │ 1850 │     618 │                  1.5 │ █▍                           │
 │ 1860 │    1634 │                 1.29 │ █▎                           │
@@ -244,9 +236,7 @@ Take it with a grain of salt.
 
 ### Burger prices {#query-burger-prices}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     round(toUInt32OrZero(extract(menu_date, '^\\d{4}')), -1) AS d,
     count(),
@@ -258,9 +248,7 @@ GROUP BY d
 ORDER BY d ASC;
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌────d─┬─count()─┬─round(avg(price), 2)─┬─bar(avg(price), 0, 50, 100)───────────┐
 │ 1880 │       2 │                 0.42 │ ▋                                     │
 │ 1890 │       7 │                 0.85 │ █▋                                    │
@@ -281,9 +269,7 @@ Result:
 
 ### Vodka {#query-vodka}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     round(toUInt32OrZero(extract(menu_date, '^\\d{4}')), -1) AS d,
     count(),
@@ -295,9 +281,7 @@ GROUP BY d
 ORDER BY d ASC;
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌────d─┬─count()─┬─round(avg(price), 2)─┬─bar(avg(price), 0, 50, 100)─┐
 │ 1910 │       2 │                    0 │                             │
 │ 1920 │       1 │                  0.3 │ ▌                           │
@@ -317,9 +301,7 @@ To get vodka we have to write `ILIKE '%vodka%'` and this definitely makes a stat
 
 Let's print caviar prices. Also let's print a name of any dish with caviar.
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     round(toUInt32OrZero(extract(menu_date, '^\\d{4}')), -1) AS d,
     count(),
@@ -332,9 +314,7 @@ GROUP BY d
 ORDER BY d ASC;
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌────d─┬─count()─┬─round(avg(price), 2)─┬─bar(avg(price), 0, 50, 100)──────┬─any(dish_name)──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ 1090 │       1 │                    0 │                                  │ Caviar                                                                                                                              │
 │ 1880 │       3 │                    0 │                                  │ Caviar                                                                                                                              │

--- a/docs/getting-started/example-datasets/nypd_complaint_data.md
+++ b/docs/getting-started/example-datasets/nypd_complaint_data.md
@@ -69,8 +69,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 "describe file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')"
 ```
 
-Result:
-```response
+```response title="Response"
 CMPLNT_NUM        Nullable(String)
 ADDR_PCT_CD       Nullable(Float64)
 BORO_NM           Nullable(String)
@@ -125,8 +124,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
  FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─JURISDICTION_CODE─┬─count()─┐
 │                 0 │  188875 │
 │                 1 │    4799 │
@@ -162,8 +160,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
  FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─uniqExact(PARKS_NM)─┐
 │                 319 │
 └─────────────────────┘
@@ -179,8 +176,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
  FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─PARKS_NM───────────────────┐
 │ (null)                     │
 │ ASSER LEVY PARK            │
@@ -208,8 +204,7 @@ file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')
 FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─min(CMPLNT_FR_DT)─┬─max(CMPLNT_FR_DT)─┐
 │ 01/01/1973        │ 12/31/2021        │
 └───────────────────┴───────────────────┘
@@ -223,8 +218,7 @@ file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')
 FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─min(CMPLNT_TO_DT)─┬─max(CMPLNT_TO_DT)─┐
 │                   │ 12/31/2021        │
 └───────────────────┴───────────────────┘
@@ -238,8 +232,7 @@ file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')
 FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─min(CMPLNT_FR_TM)─┬─max(CMPLNT_FR_TM)─┐
 │ 00:00:00          │ 23:59:00          │
 └───────────────────┴───────────────────┘
@@ -253,8 +246,7 @@ file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')
 FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─min(CMPLNT_TO_TM)─┬─max(CMPLNT_TO_TM)─┐
 │ (null)            │ 23:59:00          │
 └───────────────────┴───────────────────┘
@@ -290,8 +282,7 @@ LIMIT 10
 FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─complaint_begin─────┐
 │ 07/29/2010 00:01:00 │
 │ 12/01/2011 12:00:00 │
@@ -325,8 +316,7 @@ FORMAT PrettyCompact"
 
 Lines 2 and 3 above contain the concatenation from the previous step, and lines 4 and 5 above parse the strings into `DateTime64`.  As the complaint end time isn't guaranteed to exist `parseDateTime64BestEffortOrNull` is used.
 
-Result:
-```response
+```response title="Response"
 ┌─────────complaint_begin─┬───────────complaint_end─┐
 │ 1925-01-01 10:00:00.000 │ 2021-02-12 09:30:00.000 │
 │ 1925-01-01 11:37:00.000 │ 2022-01-16 11:49:00.000 │
@@ -399,8 +389,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
   FORMAT PrettyCompact"
 ```
 
-Result:
-```response
+```response title="Response"
 ┌─cardinality_OFNS_DESC─┬─cardinality_RPT_DT─┬─cardinality_BORO_NM─┐
 │ 60.00                 │ 306.00             │ 6.00                │
 └───────────────────────┴────────────────────┴─────────────────────┘
@@ -546,16 +535,12 @@ cat ${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv \
 The dataset changes once or more per year, your counts may not match what is in this document.
 :::
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT count()
 FROM NYPD_Complaint
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌─count()─┐
 │  208993 │
 └─────────┘
@@ -565,16 +550,13 @@ Result:
 
 The size of the dataset in ClickHouse is just 12% of the original TSV file, compare the size of the original TSV file with the size of the table:
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT formatReadableSize(total_bytes)
 FROM system.tables
 WHERE name = 'NYPD_Complaint'
 ```
 
-Result:
-```text
+```text title="Response"
 ┌─formatReadableSize(total_bytes)─┐
 │ 8.63 MiB                        │
 └─────────────────────────────────┘
@@ -584,9 +566,7 @@ Result:
 
 ### Query 1. Compare the number of complaints by month {#query-1-compare-the-number-of-complaints-by-month}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     dateName('month', date_reported) AS month,
     count() AS complaints,
@@ -596,8 +576,7 @@ GROUP BY month
 ORDER BY complaints DESC
 ```
 
-Result:
-```response
+```response title="Response"
 Query id: 7fbd4244-b32a-4acf-b1f3-c3aa198e74d9
 
 ┌─month─────┬─complaints─┬─bar(count(), 0, 50000, 80)───────────────────────────────┐
@@ -620,9 +599,7 @@ Query id: 7fbd4244-b32a-4acf-b1f3-c3aa198e74d9
 
 ### Query 2. Compare total number of complaints by borough {#query-2-compare-total-number-of-complaints-by-borough}
 
-Query:
-
-```sql
+```sql title="Query"
 SELECT
     borough,
     count() AS complaints,
@@ -632,8 +609,7 @@ GROUP BY borough
 ORDER BY complaints DESC
 ```
 
-Result:
-```response
+```response title="Response"
 Query id: 8cdcdfd4-908f-4be0-99e3-265722a2ab8d
 
 ┌─borough───────┬─complaints─┬─bar(count(), 0, 125000, 60)──┐

--- a/docs/getting-started/example-datasets/nypd_complaint_data.md
+++ b/docs/getting-started/example-datasets/nypd_complaint_data.md
@@ -41,7 +41,7 @@ Before starting to work with the ClickHouse database familiarize yourself with t
 ### Look at the fields in the source TSV file {#look-at-the-fields-in-the-source-tsv-file}
 
 This is an example of a command to query a TSV file, but don't run it yet.
-```sh
+```sh title="Query"
 clickhouse-local --query \
 "describe file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')"
 ```
@@ -63,7 +63,7 @@ Note: as of version 22.5 the default is now 25,000 rows for inferring the schema
 :::
 
 Run this command at your command prompt.  You will be using `clickhouse-local` to query the data in the TSV file you downloaded.
-```sh
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "describe file('${HOME}/NYPD_Complaint_Data_Current__Year_To_Date_.tsv', 'TSVWithNames')"
@@ -114,7 +114,7 @@ At this point you should check that the columns in the TSV file match the names 
 
 In order to figure out what types should be used for the fields it is necessary to know what the data looks like. For example, the field `JURISDICTION_CODE` is a numeric: should it be a `UInt8`, or an `Enum`, or is `Float64` appropriate?
 
-```sql
+```sql title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select JURISDICTION_CODE, count() FROM
@@ -152,7 +152,7 @@ Similarly, look at some of the `String` fields and see if they're well suited to
 
 For example, the field `PARKS_NM` is described as "Name of NYC park, playground or greenspace of occurrence, if applicable (state parks aren't included)".  The names of parks in New York City may be a good candidate for a `LowCardinality(String)`:
 
-```sh
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select count(distinct PARKS_NM) FROM
@@ -167,7 +167,7 @@ clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 ```
 
 Have a look at some of the park names:
-```sql
+```sql title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select distinct PARKS_NM FROM
@@ -196,7 +196,7 @@ The dataset in use at the time of writing has only a few hundred distinct parks 
 ### DateTime fields {#datetime-fields}
 Based on the **Columns in this Dataset** section of the [dataset web page](https://data.cityofnewyork.us/Public-Safety/NYPD-Complaint-Data-Current-Year-To-Date-/5uac-w243) there are date and time fields for the start and end of the reported event.  Looking at the min and max of the `CMPLNT_FR_DT` and `CMPLT_TO_DT` gives an idea of whether or not the fields are always populated:
 
-```sh title="CMPLNT_FR_DT"
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select min(CMPLNT_FR_DT), max(CMPLNT_FR_DT) FROM
@@ -210,7 +210,7 @@ FORMAT PrettyCompact"
 └───────────────────┴───────────────────┘
 ```
 
-```sh title="CMPLNT_TO_DT"
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select min(CMPLNT_TO_DT), max(CMPLNT_TO_DT) FROM
@@ -224,7 +224,7 @@ FORMAT PrettyCompact"
 └───────────────────┴───────────────────┘
 ```
 
-```sh title="CMPLNT_FR_TM"
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select min(CMPLNT_FR_TM), max(CMPLNT_FR_TM) FROM
@@ -238,7 +238,7 @@ FORMAT PrettyCompact"
 └───────────────────┴───────────────────┘
 ```
 
-```sh title="CMPLNT_TO_TM"
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select min(CMPLNT_TO_TM), max(CMPLNT_TO_TM) FROM
@@ -273,7 +273,7 @@ There are many more changes to be made to the types, they all can be determined 
 
 To concatenate the date and time fields `CMPLNT_FR_DT` and `CMPLNT_FR_TM` into a single `String` that can be cast to a `DateTime`, select the two fields joined by the concatenation operator: `CMPLNT_FR_DT || ' ' || CMPLNT_FR_TM`.  The `CMPLNT_TO_DT` and `CMPLNT_TO_TM` fields are handled similarly.
 
-```sh
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select CMPLNT_FR_DT || ' ' || CMPLNT_FR_TM AS complaint_begin FROM
@@ -301,7 +301,7 @@ FORMAT PrettyCompact"
 
 Earlier in the guide we discovered that there are dates in the TSV file before January 1st 1970, which means that we need a 64 bit DateTime type for the dates.  The dates also need to be converted from `MM/DD/YYYY` to `YYYY/MM/DD` format.  Both of these can be done with [`parseDateTime64BestEffort()`](../../sql-reference/functions/type-conversion-functions.md#parseDateTime64BestEffort).
 
-```sh
+```sh title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "WITH (CMPLNT_FR_DT || ' ' || CMPLNT_FR_TM) AS CMPLNT_START,
@@ -378,7 +378,7 @@ New York City.  These fields might be then included in the `ORDER BY`:
 
 Querying the TSV file for the cardinality of the three candidate columns:
 
-```bash
+```bash title="Query"
 clickhouse-local --input_format_max_rows_to_read_for_schema_inference=2000 \
 --query \
 "select formatReadableQuantity(uniq(OFNS_DESC)) as cardinality_OFNS_DESC,

--- a/docs/integrations/data-visualization/community_integrations/embeddable-and-clickhouse.md
+++ b/docs/integrations/data-visualization/community_integrations/embeddable-and-clickhouse.md
@@ -50,8 +50,9 @@ fetch('https://api.embeddable.com/api/v1/connections', {
     },
   }),
 });
+```
 
-Response:
+```text title="Response"
 Status 201 { errorMessage: null }
 ```
 

--- a/docs/integrations/data-visualization/community_integrations/embeddable-and-clickhouse.md
+++ b/docs/integrations/data-visualization/community_integrations/embeddable-and-clickhouse.md
@@ -30,7 +30,7 @@ Built-in row-level security means that every user only ever sees exactly the dat
 
 You add a database connection using Embeddable API. This connection is used to connect to your ClickHouse service. You can add a connection using the following API call:
 
-```javascript
+```javascript title="Query"
 // for security reasons, this must *never* be called from your client-side
 fetch('https://api.embeddable.com/api/v1/connections', {
   method: 'POST',

--- a/docs/integrations/interfaces/arrowflight.md
+++ b/docs/integrations/interfaces/arrowflight.md
@@ -387,9 +387,7 @@ for endpoint in info.endpoints:
     print(table.to_pandas())
 ```
 
-Output:
-
-```text
+```text title="Response"
    id value
 0   1     a
 1   2     b

--- a/docs/integrations/interfaces/arrowflight.md
+++ b/docs/integrations/interfaces/arrowflight.md
@@ -356,7 +356,7 @@ These commands map to features that ClickHouse does not provide, so they are not
 
 ## Complete Example {#complete-example}
 
-```python
+```python title="Query"
 import pyarrow as pa
 import pyarrow.flight as flight
 

--- a/docs/integrations/interfaces/grpc.md
+++ b/docs/integrations/interfaces/grpc.md
@@ -92,9 +92,7 @@ cat a.csv | ./clickhouse-grpc-client.py -q "INSERT INTO grpc_example_table FORMA
 ./clickhouse-grpc-client.py --format PrettyCompact -q "SELECT * FROM grpc_example_table;"
 ```
 
-Result:
-
-```text
+```text title="Response"
 ┌─id─┬─text──────────────────┐
 │  0 │ Input data for        │
 │  1 │ gRPC protocol example │

--- a/docs/integrations/interfaces/grpc.md
+++ b/docs/integrations/interfaces/grpc.md
@@ -84,7 +84,7 @@ In a batch mode query data can be passed via `stdin`.
 
 In the following example a table is created and loaded with data from a CSV file. Then the content of the table is queried.
 
-```bash
+```bash title="Query"
 ./clickhouse-grpc-client.py -q "CREATE TABLE grpc_example_table (id UInt32, text String) ENGINE = MergeTree() ORDER BY id;"
 echo -e "0,Input data for\n1,gRPC protocol example" > a.csv
 cat a.csv | ./clickhouse-grpc-client.py -q "INSERT INTO grpc_example_table FORMAT CSV"


### PR DESCRIPTION
In many places we write:

```
Query:

<CodeBlock>

Response:

<CodeBlock>
```

But imo labelling the codeblock with `title="Query"` and `title="Response"` looks much cleaner, as the codeblock gets a rendered title:

<img width="1616" height="584" alt="image" src="https://github.com/user-attachments/assets/96429c94-16d6-4b82-85d5-f062cef9daf0" />

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
