### PR TITLE
ci: declare contents:read on check-build workflow

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -11,6 +11,9 @@ on:
       - synchronize
       - reopened
       - opened
+permissions:
+  contents: read
+
 jobs:
   stylecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins this docs workflow to `permissions: contents: read` at the workflow level. The job clones the repo, sets up Node, and runs the build / link-check / preview-build steps. No GitHub API call beyond the initial checkout; the deploy itself (when relevant) goes through a separate channel (Vercel, gh-pages, etc).

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the practical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius matched the issued scope. Capping at the actual minimum keeps that runtime authority bounded regardless of repo or org default, gives drift protection if the default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
