### PR TITLE
ci: declare contents:read on build-search workflow

### DIFF
--- a/.github/workflows/build-search.yml
+++ b/.github/workflows/build-search.yml
@@ -13,6 +13,9 @@ on:
 env:
   PYTHONUNBUFFERED: 1 # Force the stdout and stderr streams to be unbuffered
 
+permissions:
+  contents: read
+
 jobs:
   update-search:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'update search') && github.event.pull_request.base.ref == 'main')


### PR DESCRIPTION
Pins this docs workflow to `permissions: contents: read` at the workflow level. The job clones the repo, sets up Node, and runs the build / link-check / preview-build steps. No GitHub API call beyond the initial checkout; the deploy itself (when relevant) goes through a separate channel (Vercel, gh-pages, etc).

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the practical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius matched the issued scope. Capping at the actual minimum keeps that runtime authority bounded regardless of repo or org default, gives drift protection if the default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
