### PR TITLE
Add operations/query-rules to sidebar

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -13,3 +13,4 @@ integrations/data-ingestion/clickpipes/postgres/maintenance.md
 operations/utilities/clickhouse-keeper-http-api.md
 cloud/features/backups/faq.md
 interfaces/web-terminal
+operations/query-rules

--- a/sidebars.js
+++ b/sidebars.js
@@ -1404,6 +1404,7 @@ const sidebars = {
         'operations/optimizing-performance/sampling-query-profiler',
         'operations/query-cache',
         'operations/query-condition-cache',
+        'operations/query-rules',
         'operations/userspace-page-cache',
         'operations/performance-test',
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -1404,7 +1404,6 @@ const sidebars = {
         'operations/optimizing-performance/sampling-query-profiler',
         'operations/query-cache',
         'operations/query-condition-cache',
-        'operations/query-rules',
         'operations/userspace-page-cache',
         'operations/performance-test',
       ],


### PR DESCRIPTION
ClickHouse PR https://github.com/ClickHouse/ClickHouse/pull/88234 introduces
a new docs page at `docs/en/operations/query-rules.md` for the new Query
Rewrite Rules feature.

Without an entry in `sidebars.js` the page is reported as a "floating page"
by the docs build, which fails the docs check on the ClickHouse PR.

This adds `'operations/query-rules'` to the operations sidebar group, next to
the existing query-cache / query-condition-cache entries.