### PR TITLE
add FAQ entry for ClickPipes Kafka topic listing limit (1,500 topics)

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
@@ -70,7 +70,7 @@ This can be configured during ClickPipe creation, or at any other point under **
 
 <summary>I can't find some of my Kafka topics in the ClickPipes setup UI. Why?</summary>
 
-The ClickPipes topic discovery UI lists up to 1,500 topics by default. If your Kafka cluster has more than 1,500 topics, some topics may not appear in the dropdown. To verify your topic exists, check directly using a Kafka client with the same credentials. If confirmed and you need to raise the listing limit beyond 1,500, please reach out to ClickHouse Support.
+The ClickPipes topic discovery UI lists up to 1,500 topics by default. If your Kafka cluster has more than 1,500 topics, some topics may not appear in the dropdown. To verify your topic exists, check directly using a Kafka client with the same credentials. If confirmed and you need to raise the listing limit beyond 1,500, reach out to ClickHouse Support.
 </details>
 
 ### Azure Event Hubs {#azure-eventhubs}

--- a/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
@@ -68,6 +68,11 @@ Horizontal scaling adds more replicas to increase throughput, while vertical sca
 This can be configured during ClickPipe creation, or at any other point under **Settings** -> **Advanced Settings** -> **Scaling**.
 </details>
 
+<summary>I can't find some of my Kafka topics in the ClickPipes setup UI. Why?</summary>
+
+The ClickPipes topic discovery UI lists up to 1,500 topics by default. If your Kafka cluster has more than 1,500 topics, some topics may not appear in the dropdown. To verify your topic exists, check directly using a Kafka client with the same credentials. If confirmed and you need to raise the listing limit beyond 1,500, please reach out to ClickHouse Support.
+</details>
+
 ### Azure Event Hubs {#azure-eventhubs}
 
 <details>

--- a/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/05_faq.md
@@ -68,6 +68,8 @@ Horizontal scaling adds more replicas to increase throughput, while vertical sca
 This can be configured during ClickPipe creation, or at any other point under **Settings** -> **Advanced Settings** -> **Scaling**.
 </details>
 
+<details>
+
 <summary>I can't find some of my Kafka topics in the ClickPipes setup UI. Why?</summary>
 
 The ClickPipes topic discovery UI lists up to 1,500 topics by default. If your Kafka cluster has more than 1,500 topics, some topics may not appear in the dropdown. To verify your topic exists, check directly using a Kafka client with the same credentials. If confirmed and you need to raise the listing limit beyond 1,500, reach out to ClickHouse Support.


### PR DESCRIPTION
There is a hard limit of 1500 today for Kafka topic listing in ClickPipes initial creation.

## Summary
Not all Kafka Topics are visible during creation of ClickPipes in the "Incoming Data" section. This is because according to ClickHouse Support, there is a hard limit of 1500 topics by the ClickPipes Discovery API. Support has request to open a ticket to ClickHouse Support to extend the limit. 
