### PR TITLE
Add comprehensive monitoring queries to troubleshooting docs

### DIFF
--- a/knowledgebase/useful-queries-for-troubleshooting.mdx
+++ b/knowledgebase/useful-queries-for-troubleshooting.mdx
@@ -270,3 +270,265 @@ WHERE (database = 'default') AND active AND (level = 0)
 ORDER BY modification_time DESC
 LIMIT 100
 ```
+
+## Cluster-wide monitoring queries \{#cluster-wide-monitoring-queries\}
+
+The following queries are useful for monitoring ClickHouse clusters. They use `clusterAllReplicas()` to aggregate data across all nodes.
+
+:::note
+These queries assume your cluster is named `default`. If your cluster has a different name, replace `'default'` and `default` with your cluster's actual name.
+:::
+
+### Average new parts created per minute and second (last hour) \{#avg-new-parts-per-minute-and-second\}
+
+```sql
+WITH
+    PER_MINUTE AS
+    (
+    SELECT
+        toStartOfInterval(modification_time, toIntervalMinute(1)) AS t,
+        count() AS new_part_count
+    FROM
+        clusterAllReplicas(default, merge(system, '^parts'))
+    WHERE
+        (database = 'default') AND
+        (table = 'your_table') AND
+        (active = true) AND
+        (level = 0) AND
+        (modification_time >= (now() - toIntervalHour(1)))
+    GROUP BY
+        t
+    ORDER BY
+        t ASC
+    SETTINGS skip_unavailable_shards = 1
+    )
+SELECT
+    AVG(new_part_count) AS new_parts_per_minute,
+    new_parts_per_minute / 60 AS new_parts_per_second
+FROM
+    PER_MINUTE
+```
+
+Replace `'your_table'` with the actual table name you want to monitor.
+
+### CPU and memory intensive queries (cluster-wide) \{#cpu-and-memory-intensive-queries-cluster-wide\}
+
+```sql
+SELECT
+    type,
+    event_time,
+    initial_query_id,
+    formatReadableSize(memory_usage) AS memory,
+    `ProfileEvents.Values`[indexOf(`ProfileEvents.Names`, 'UserTimeMicroseconds')] AS userCPU,
+    `ProfileEvents.Values`[indexOf(`ProfileEvents.Names`, 'SystemTimeMicroseconds')] AS systemCPU,
+    normalizedQueryHash(query) AS normalized_query_hash
+FROM clusterAllReplicas(default, merge(system, '^query_log'))
+ORDER BY memory_usage DESC
+LIMIT 10
+```
+
+### Merges in progress with ETA \{#merges-in-progress-with-eta\}
+
+This query shows currently executing merges on the cluster with estimated time to completion:
+
+```sql
+SELECT
+    hostName(),
+    database,
+    table,
+    round(elapsed, 0) AS elapsed_seconds,
+    round(progress, 4) AS progress_ratio,
+    formatReadableTimeDelta((elapsed / progress) - elapsed) AS estimated_time_remaining,
+    num_parts,
+    result_part_name
+FROM clusterAllReplicas(default, merge(system, '^merges'))
+ORDER BY (elapsed / progress) - elapsed ASC
+```
+
+### Most common queries by normalized hash \{#most-common-queries-by-normalized-hash\}
+
+Find the most frequently executed queries (useful for identifying which queries to optimize):
+
+```sql
+SELECT
+    normalizedQueryHash(query) AS query_hash,
+    count() AS execution_count,
+    any(query) AS example_query
+FROM clusterAllReplicas(default, merge(system, '^query_log'))
+WHERE event_date >= today() - 1
+GROUP BY normalizedQueryHash(query)
+ORDER BY execution_count DESC
+LIMIT 20
+```
+
+### Error counts by event type and date \{#error-counts-by-event-type-and-date\}
+
+Analyze part creation errors across the cluster:
+
+```sql
+SELECT
+    event_date,
+    event_type,
+    table,
+    error,
+    COUNT() AS error_count
+FROM clusterAllReplicas(default, merge(system, '^part_log'))
+WHERE database = 'default'
+GROUP BY
+    event_date,
+    event_type,
+    error,
+    table
+ORDER BY
+    event_date DESC,
+    error_count DESC
+```
+
+### Number of tables by node \{#number-of-tables-by-node\}
+
+Check table distribution across cluster nodes:
+
+```sql
+SELECT
+    hostName() AS host,
+    count() AS table_count
+FROM clusterAllReplicas('default', merge(system, '^tables'))
+WHERE database = 'default'
+GROUP BY hostName()
+ORDER BY table_count DESC
+```
+
+### Check for async insert operations \{#check-for-async-insert-operations\}
+
+Monitor async insert activity:
+
+```sql
+SELECT
+    event_date,
+    count() AS total_count,
+    sum(if(query LIKE '%async%', 1, 0)) AS async_count,
+    sum(if(query LIKE '%INSERT%', 1, 0)) AS insert_count
+FROM clusterAllReplicas(default, merge(system, '^query_log'))
+WHERE event_date >= today() - 7
+GROUP BY event_date
+ORDER BY event_date DESC
+```
+
+## Parts and merges analysis \{#parts-and-merges-analysis\}
+
+### Currently active parts by table \{#currently-active-parts-by-table\}
+
+See the number of active parts per table across the cluster:
+
+```sql
+SELECT
+    database,
+    table,
+    count() AS part_count,
+    formatReadableSize(sum(bytes_on_disk)) AS total_size
+FROM clusterAllReplicas(default, system.parts)
+WHERE active = 1 AND database = 'default'
+GROUP BY database, table
+ORDER BY part_count DESC
+```
+
+### Partitions with too many parts \{#partitions-with-too-many-parts\}
+
+Find partitions that may have too many parts (which can impact query performance):
+
+```sql
+SELECT
+    database,
+    table,
+    partition,
+    count() AS part_count,
+    formatReadableSize(sum(bytes_on_disk)) AS total_size
+FROM clusterAllReplicas(default, system.parts)
+WHERE active = 1
+GROUP BY database, table, partition
+HAVING part_count > 100
+ORDER BY part_count DESC
+```
+
+### Detached parts \{#detached-parts\}
+
+Check for detached parts that might need investigation:
+
+```sql
+SELECT
+    database,
+    table,
+    partition_id,
+    name,
+    reason,
+    count()
+FROM clusterAllReplicas(default, system.detached_parts)
+GROUP BY database, table, partition_id, name, reason
+ORDER BY database, table
+```
+
+## System information queries \{#system-information-queries\}
+
+### Cluster-wide memory usage by node \{#cluster-wide-memory-usage-by-node\}
+
+Monitor memory consumption across nodes:
+
+```sql
+SELECT
+    hostName() AS host,
+    formatReadableSize(max(memory_usage)) AS peak_memory,
+    formatReadableSize(avg(memory_usage)) AS avg_memory,
+    formatReadableSize(min(memory_usage)) AS min_memory
+FROM clusterAllReplicas(default, merge(system, '^query_log'))
+WHERE event_date >= today() - 1
+GROUP BY hostName()
+ORDER BY peak_memory DESC
+```
+
+### Running queries on the cluster \{#running-queries-on-the-cluster\}
+
+Check what queries are currently executing:
+
+```sql
+SELECT
+    hostName() AS host,
+    initial_user,
+    query_id,
+    elapsed,
+    read_rows,
+    formatReadableSize(memory_usage) AS memory_usage,
+    normalizedQueryHash(query) AS query_hash
+FROM clusterAllReplicas(default, system.processes)
+ORDER BY elapsed DESC
+```
+
+### Modified settings from defaults \{#modified-settings-from-defaults\}
+
+See which settings have been changed from defaults:
+
+```sql
+SELECT
+    hostName() AS host,
+    name,
+    value
+FROM clusterAllReplicas(default, system.settings)
+WHERE changed = 1
+ORDER BY hostName(), name
+```
+
+### Replication queue status \{#replication-queue-status\}
+
+For replicated tables, check the replication queue:
+
+```sql
+SELECT
+    hostName() AS host,
+    database,
+    table,
+    count() AS queue_size,
+    sum(if(is_currently_executing = 1, 1, 0)) AS executing_count
+FROM clusterAllReplicas(default, system.replication_queue)
+GROUP BY hostName(), database, table
+HAVING queue_size > 0
+ORDER BY queue_size DESC
+```


### PR DESCRIPTION
- Add new "Cluster-wide monitoring queries" section with 7 cluster-wide monitoring queries
- Add "Parts and merges analysis" section with 3 queries for analyzing part distribution
- Add "System information queries" section with 5 queries for system-wide monitoring
- Include note about cluster name configuration requirement
- All queries reviewed for correctness and ClickHouse best practices

Queries cover: part creation rates, CPU/memory intensive queries, merge progress, query frequency analysis, partition health, replication queue status, and more.

Resolves DOC-762

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
