### PR TITLE
Cloud changelog: Week of 2026-05-18 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -50,7 +50,7 @@ See [supported regions](/cloud/reference/supported-regions) for the full list an
 
 ### Protobuf support for Kafka ClickPipes {#protobuf-kafka-clickpipes}
 
-[Kafka ClickPipes](/integrations/clickpipes/kafka/reference#protobuf) now supports Protobuf as a format, in addition to Avro and JSON. Features include automatic schema resolution via schema registry integration with support for recursive references, well-known types, and the native `oneof` type. Available across all Kafka ClickPipes interfaces (UI, Open API, Terraform).
+[Kafka ClickPipes](/integrations/clickpipes/kafka) now supports [**Protobuf**](/integrations/clickpipes/kafka/reference#protobuf) as a format, in addition to Avro and JSON. Features include automatic schema resolution via schema registry integration, support for recursive references, well-known types, and the native `oneof` type. Protobuf support is available across all Kafka ClickPipes interfaces (UI, Open API, and Terraform).
 
 ## May 8, 2026 {#2026-05-08}
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,39 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## May 18, 2026 {#2026-05-18}
+
+### Python client v1.0.0 {#python-client-v1}
+
+Major version release of [clickhouse-connect](/integrations/python), the Python client for ClickHouse. Key highlights include:
+
+* First-class SQLAlchemy dialect with deeper support for ClickHouse-specific SQL
+* Native async client built on aiohttp with full feature parity, including streaming
+* Significant performance improvements for DateTime, DateTime64, fixed-width numeric inserts, Maps, Decimals, and BigDecimals
+* Timezone handling redesign with new `tz_mode` and `tz_source` parameters
+* Native Variant column writes
+* Lazy imports for optional dependencies (numpy, pandas, pyarrow, polars), speeding up bare import by 4x
+* Experimental Python 3.14 free-threading support
+
+**Breaking changes:** Dropped support for Python < 3.9 and Pandas 1.x. Review the [changelog](https://github.com/ClickHouse/clickhouse-connect) for other breaking changes around timezones.
+
+### SQL-based charting and alerting in ClickStack {#clickstack-sql-charting-alerting}
+
+ClickStack now supports building charts and alerts using arbitrary ClickHouse SQL queries. Users can write raw SQL directly in the dashboard and alert builder, with full support for window functions, CTEs, multi-stage queries, and ClickHouse-native analytical functions. SQL alerting allows encoding the entire alerting decision inside the query itself, unlocking anomaly detection, lagging averages, and statistical spike detection. Available across all ClickStack deployments (Cloud, Private, BYOC, OSS). See [SQL-based visualizations](/use-cases/observability/clickstack/dashboards/sql-visualizations) and [SQL alert result interpretation](/use-cases/observability/clickstack/alerts#sql-result-interpretation) for more details.
+
+### New region support {#new-region-support}
+
+Support for new ClickHouse Cloud regions:
+
+* AWS Mexico (mx-central-1) — Private Region, PCI
+* Azure Australia East — Private Region
+
+See [supported regions](/cloud/reference/supported-regions) for the full list and [Private Region considerations](/cloud/reference/supported-regions#private-regions).
+
+### Protobuf support for Kafka ClickPipes {#protobuf-kafka-clickpipes}
+
+[Kafka ClickPipes](/integrations/clickpipes/kafka/reference#protobuf) now supports Protobuf as a format, in addition to Avro and JSON. Features include automatic schema resolution via schema registry integration with support for recursive references, well-known types, and the native `oneof` type. Available across all Kafka ClickPipes interfaces (UI, Open API, Terraform).
+
 ## May 8, 2026 {#2026-05-08}
 
 ### Postgres query insights (private preview) {#postgres-query-insights}

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -33,11 +33,11 @@ Major version release of [clickhouse-connect](/integrations/python), the Python 
 * Lazy imports for optional dependencies (numpy, pandas, pyarrow, polars), speeding up bare import by 4x
 * Experimental Python 3.14 free-threading support
 
-**Breaking changes:** Dropped support for Python < 3.9 and Pandas 1.x. Review the [changelog](https://github.com/ClickHouse/clickhouse-connect) for other breaking changes around timezones.
+**Breaking changes:** Dropped support for Python < 3.9 and Pandas 1.x. Review the [release notes](https://github.com/ClickHouse/clickhouse-connect/releases) for other breaking changes around timezones.
 
 ### SQL-based charting and alerting in ClickStack {#clickstack-sql-charting-alerting}
 
-ClickStack now supports building charts and alerts using arbitrary ClickHouse SQL queries. Users can write raw SQL directly in the dashboard and alert builder, with full support for window functions, CTEs, multi-stage queries, and ClickHouse-native analytical functions. SQL alerting allows encoding the entire alerting decision inside the query itself, unlocking anomaly detection, lagging averages, and statistical spike detection. Available across all ClickStack deployments (Cloud, Private, BYOC, OSS). See [SQL-based visualizations](/use-cases/observability/clickstack/dashboards/sql-visualizations) and [SQL alert result interpretation](/use-cases/observability/clickstack/alerts#sql-result-interpretation) for more details.
+[ClickStack](/use-cases/observability/clickstack) now supports building charts and alerts using arbitrary ClickHouse SQL queries. Users can write raw SQL directly in the dashboard and alert builder, with full support for window functions, CTEs, multi-stage queries, and ClickHouse-native analytical functions. SQL alerting allows encoding the entire alerting decision inside the query itself, unlocking anomaly detection, lagging averages, and statistical spike detection. Available across all ClickStack deployments (Cloud, Private, BYOC, OSS). See [SQL-based visualizations](/use-cases/observability/clickstack/dashboards/sql-visualizations) and [SQL alert result interpretation](/use-cases/observability/clickstack/alerts#sql-result-interpretation) for more details.
 
 ### New region support {#new-region-support}
 
@@ -50,7 +50,7 @@ See [supported regions](/cloud/reference/supported-regions) for the full list an
 
 ### Protobuf support for Kafka ClickPipes {#protobuf-kafka-clickpipes}
 
-[Kafka ClickPipes](/integrations/clickpipes/kafka) now supports [**Protobuf**](/integrations/clickpipes/kafka/reference#protobuf) as a format, in addition to Avro and JSON. Features include automatic schema resolution via schema registry integration, support for recursive references, well-known types, and the native `oneof` type. Protobuf support is available across all Kafka ClickPipes interfaces (UI, Open API, and Terraform).
+[Kafka ClickPipes](/integrations/clickpipes/kafka) now supports [**Protobuf**](/integrations/clickpipes/kafka/reference#protobuf) as a format, in addition to Avro and JSON. Features include automatic schema resolution via schema registry integration, support for recursive references, well-known types, and the native `oneof` type. Protobuf support is available across all Kafka ClickPipes interfaces (UI, OpenAPI, and Terraform).
 
 ## May 8, 2026 {#2026-05-08}
 


### PR DESCRIPTION
## Summary

This PR adds the Cloud changelog entry for the week of May 18, 2026, based on updates posted in #shipped on Slack.

### Included changes

- **Python client v1.0.0** — Major release of clickhouse-connect with first-class SQLAlchemy dialect, native async client, performance improvements, timezone redesign, native Variant writes, lazy imports, and experimental Python 3.14 free-threading support.
- **SQL-based charting and alerting in ClickStack** — Users can now build charts and alerts using arbitrary ClickHouse SQL queries in ClickStack dashboards, with full support for window functions, CTEs, and ClickHouse-native analytical functions.
- **New region support** — AWS Mexico (mx-central-1) as Private Region with PCI, and Azure Australia East as Private Region.
- **Protobuf support for Kafka ClickPipes** — Kafka ClickPipes now supports Protobuf format via schema registry integration, including recursive references, well-known types, and `oneof` support.

### Needs review

- The Python client v1.0.0 entry links to `/integrations/python` — please verify this is the correct docs path for the clickhouse-connect Python client.
- The ClickStack SQL charting entry links to `/use-cases/observability/clickstack/dashboards/sql-visualizations` and `/use-cases/observability/clickstack/alerts#sql-result-interpretation` — these were taken from the original Slack post URLs; please confirm the relative paths are correct.
- The new region entry for Azure Australia East did not include a specific region code in the Slack post — please verify if one should be added.