### PR TITLE
docs(clickpipes): add mx-central-1 static NAT IPs

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/index.md
@@ -80,6 +80,7 @@ For all services, ClickPipes traffic will originate from a default region based 
 - **eu-north-1**: For services in AWS `eu-north-1` created on or after 15 Apr 2026 (services created before this date use `eu-central-1` IPs).
 - **eu-west-2**: For services in AWS `eu-west-2` created on or after 15 Apr 2026 (services created before this date use `eu-central-1` IPs).
 - **il-central-1**: For services in AWS `il-central-1` created on or after 15 Apr 2026 (services created before this date use `us-east-2` IPs).
+- **mx-central-1**: For services in AWS `mx-central-1` created on or after 19 May 2026 (services created before this date use `us-east-2` IPs).
 - **sa-east-1**: For services in AWS `sa-east-1` created on or after 15 Apr 2026 (services created before this date use `us-east-2` IPs).
 - **us-west-2**: For services in AWS `us-west-2` created on or after 24 Jun 2025 (services created before this date use `us-east-2` IPs).
 - **us-east-2**: For all other regions not explicitly listed (including GCP and Azure regions).
@@ -103,6 +104,7 @@ For all services, ClickPipes traffic will originate from a default region based 
 | **eu-north-1** - Stockholm (from 15 Apr 2026)           | `13.63.1.65`, `16.171.127.30`, `56.228.76.44`, `13.63.101.248`, `16.170.124.188`, `13.60.109.201`                                                    |
 | **eu-west-2** - London (from 15 Apr 2026)               | `13.134.82.158`, `16.60.209.167`, `18.134.221.203`, `16.60.139.176`, `13.43.66.75`, `3.11.78.183`                                                    |
 | **il-central-1** - Tel Aviv (from 15 Apr 2026)          | `16.164.25.13`, `51.84.162.29`, `51.85.90.183`, `51.84.36.146`, `51.84.72.29`, `51.85.28.184`                                                        |
+| **mx-central-1** - Mexico (from 19 May 2026)            | `78.12.67.220`, `78.12.117.175`, `78.13.186.238`, `78.13.219.184`, `78.13.224.212`, `78.13.248.162`                                                  |
 | **sa-east-1** - São Paulo (from 15 Apr 2026)            | `18.230.164.131`, `56.126.1.234`, `18.230.39.24`, `15.229.102.116`, `18.230.174.204`, `18.229.237.116`                                               |
 | **us-west-2** - Oregon (from 24 Jun 2025)               | `52.42.100.5`, `44.242.47.162`, `52.40.44.52`, `44.227.206.163`, `44.246.241.23`, `35.83.230.19`                                                     |
 


### PR DESCRIPTION
## Summary
Adds mx-central-1 to the ClickPipes static NAT IP list. Services in this region created on or after 19 May 2026 use the listed mx-central-1 IPs; services created before use us-east-2.

NAT IPs (3 alterNAT + 3 NAT gateway): \`78.12.67.220\`, \`78.12.117.175\`, \`78.13.186.238\`, \`78.13.219.184\`, \`78.13.224.212\`, \`78.13.248.162\`.

## Test plan
- [ ] Render the page locally and verify the table row appears
- [ ] Cross-check IPs against \`aws ec2 describe-addresses --region mx-central-1\` in account 072088201116

🤖 Generated with [Claude Code](https://claude.com/claude-code)