### PR TITLE
Fix storage tiers wording

### DIFF
--- a/docs/integrations/data-ingestion/s3/index.md
+++ b/docs/integrations/data-ingestion/s3/index.md
@@ -538,7 +538,7 @@ ClickHouse recognizes that S3 represents an attractive storage solution, especia
 
 ### Storage Tiers {#storage-tiers}
 
-ClickHouse storage volumes allow physical disks to be abstracted from the MergeTree table engine. Any single volume can be composed of an ordered set of disks. Whilst principally allowing multiple block devices to be potentially used for data storage, this abstraction also allows other storage types, including S3. ClickHouse data parts can be moved between volumes and fill rates according to storage policies, thus creating the concept of storage tiers.
+ClickHouse storage volumes allow physical disks to be abstracted from the MergeTree table engine. Any single volume can be composed of an ordered set of disks. Whilst principally allowing multiple block devices to be potentially used for data storage, this abstraction also allows other storage types, including S3. ClickHouse data parts can be moved between volumes according to storage policies and fill rates, thus creating the concept of storage tiers.
 
 Storage tiers unlock hot-cold architectures where the most recent data, which is typically also the most queried, requires only a small amount of space on high-performing storage, e.g., NVMe SSDs. As the data ages, SLAs for query times increase, as does query frequency. This fat tail of data can be stored on slower, less performant storage such as HDD or object storage such as S3.
 


### PR DESCRIPTION
## Summary

  Fixes the wording in the S3 storage tiers documentation so storage policies and fill rates are described in the correct relationship.

## Changes

  - Updates the sentence to say data parts can be moved between volumes according to storage policies and fill rates.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
