### PR TITLE
Document clickhousectl install in universal installer

### DIFF
--- a/docs/getting-started/install/_snippets/_quick_install.md
+++ b/docs/getting-started/install/_snippets/_quick_install.md
@@ -6,10 +6,22 @@ If you don't need to install ClickHouse for production, you can run an install s
 
 ## Install ClickHouse using curl {#install-clickhouse-using-curl}
 
-Run the following comand to download a single binary for your operating system.
+Run the following command to download a single binary for your operating system.
 
 ```bash
 curl https://clickhouse.com/ | sh
+```
+
+On Linux and macOS, this also installs [`clickhousectl`](https://github.com/ClickHouse/clickhousectl)
+into `~/.local/bin` (with a `chctl` symlink) so you can manage local ClickHouse
+versions and servers. If `~/.local/bin` isn't already on your `PATH`, the
+installer prints the line to add to your shell profile.
+
+To install just the `clickhouse` binary without `clickhousectl`, set
+`CLICKHOUSE_ONLY=1`:
+
+```bash
+curl https://clickhouse.com/ | CLICKHOUSE_ONLY=1 sh
 ```
 
 :::note

--- a/docs/getting-started/quick-start/oss.mdx
+++ b/docs/getting-started/quick-start/oss.mdx
@@ -33,6 +33,24 @@ curl https://clickhouse.com/cli | sh
 
 A `chctl` alias is also created automatically for convenience.
 
+<details>
+<summary>Advanced: install ClickHouse without `clickhousectl`</summary>
+
+If you only need the `clickhouse` binary and don't want `clickhousectl`, use the
+universal installer with `CLICKHOUSE_ONLY=1`:
+
+```bash
+curl https://clickhouse.com/ | CLICKHOUSE_ONLY=1 sh
+```
+
+This downloads a single `clickhouse` binary into the current directory. You can
+then run `clickhouse-server`, `clickhouse-client`, and `clickhouse-local`
+directly from that binary, and the rest of this guide's `clickhousectl`-based
+steps won't apply. See the [Quick install](/install/quick-install) page for the
+plain-binary workflow.
+
+</details>
+
 ## Install ClickHouse {#install-clickhouse}
 
 ClickHouse runs natively on Linux and macOS, and runs on Windows via


### PR DESCRIPTION
Per ClickHouse/ClickHouse#105399, the universal installer now also installs clickhousectl on Linux/macOS. Document the new behavior plus the CLICKHOUSE_ONLY=1 opt-out in the curl install snippet, and add an "Advanced" collapsible to the OSS quickstart for users who want only the clickhouse binary.

Closes DOC-776

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
