### PR TITLE
Modify ClickHouse Private deployment options

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
@@ -44,7 +44,7 @@ ClickHouse Private is currently supported in the following configurations:
 |:------------|:---------------------------------|:----------------------------|:-------------|
 | AWS         | Elastic Kubernetes Service (EKS) | Simple Storage Service (S3) | Available    |
 | GCP         | Google Kubernetes Service (GKS)  | Google Cloud Storage (GCS)  | Preview      |
-| Bare metal  | Kubernetes                       | AIStor (NVMe required)      | Preview      | 
+
 
 ## Onboarding process {#onboarding-process}
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
@@ -45,7 +45,6 @@ ClickHouse Private is currently supported in the following configurations:
 | AWS         | Elastic Kubernetes Service (EKS) | Simple Storage Service (S3) | Available    |
 | GCP         | Google Kubernetes Service (GKS)  | Google Cloud Storage (GCS)  | Preview      |
 
-
 ## Onboarding process {#onboarding-process}
 
 Customers interested in ClickHouse Private can [contact us](https://clickhouse.com/company/contact) to schedule a review call for their use case. Requests that meet minimum size requirements and target supported configurations will be considered - note that onboarding capacity is limited. Setup involves following an environment-specific install guide using images and Helm charts pulled from AWS ECR.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
@@ -48,4 +48,4 @@ ClickHouse Private is currently supported in the following configurations:
 
 ## Onboarding process {#onboarding-process}
 
-Customers may [contact us](https://clickhouse.com/company/contact?loc=nav) to request a call to review ClickHouse Private for their use case. Use cases meeting minimum size requirements and deployed to supported configurations will be reviewed. Onboarding is limited. The installation process involves following an install guide for the specific environment where ClickHouse will be deployed using images and Helm charts downloaded from AWS ECR.
+Customers interested in ClickHouse Private can [contact us](https://clickhouse.com/company/contact) to schedule a review call for their use case. Requests that meet minimum size requirements and target supported configurations will be considered - note that onboarding capacity is limited. Setup involves following an environment-specific install guide using images and Helm charts pulled from AWS ECR.


### PR DESCRIPTION
Updated deployment options table for ClickHouse Private. removed bare metal/AIStor as this is not certified yet

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
