### PR TITLE
Update 01_export-backups-to-own-cloud-account.md

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
@@ -14,7 +14,7 @@ In this guide, we show examples of how to take full and incremental backups to A
 :::note
 Any usage where backups are being exported to a different region in the same cloud provider will incur [data transfer](/cloud/manage/network-data-transfer) charges.  
 
-Cross cloud backups are only supported via the backup/restore commands outlined on this page and not via the UI.
+Cross-Cloud backups are only supported via the backup/restore commands outlined on this page, and not via the UI.
 :::
 
 ## Requirements {#requirements}

--- a/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
@@ -12,7 +12,9 @@ For details of how ClickHouse Cloud backups work, including "full" vs. "incremen
 In this guide, we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups.
 
 :::note
-Any usage where backups are being exported to a different region in the same cloud provider will incur [data transfer](/cloud/manage/network-data-transfer) charges.  Currently we don't support cross cloud backups.
+Any usage where backups are being exported to a different region in the same cloud provider will incur [data transfer](/cloud/manage/network-data-transfer) charges.  
+
+Cross cloud backups are only supported via the backup/restore commands outlined on this page and not via the UI.
 :::
 
 ## Requirements {#requirements}


### PR DESCRIPTION
clarified to note that x-cloud backup/restore is only supported via the commands and not from the UI

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
