### PR TITLE
Extending beta badge with galaxy tracking

### DIFF
--- a/src/theme/badges/BetaBadge/index.js
+++ b/src/theme/badges/BetaBadge/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 import styles from "./styles.module.css"
+import { galaxyOnClick } from '../../../lib/galaxy/galaxy'
 
 const Icon = () => {
     return (
@@ -11,7 +12,21 @@ const Icon = () => {
     )
 }
 
-const BetaBadge = () => {
+const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
+    if (link) {
+        return (
+            <a
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.betaBadge}
+                onClick={galaxyTrack && galaxyEvent ? galaxyOnClick(galaxyEvent) : undefined}
+            >
+                <Icon />Beta
+            </a>
+        )
+    }
+
     return (
         <div className={styles.betaBadge}>
             <Icon />Beta feature.&nbsp;<u><a href='/docs/beta-and-experimental-features#beta-features'>Learn more.</a></u>


### PR DESCRIPTION
## Summary
Resolves: [DOC-779](https://linear.app/clickhouse/issue/DOC-779/extend-betabadge-to-support-link-galaxytrack-and-slug)
Extending beta badge so that it has galaxy tracking similar to the Private Preview badge.

Another [issue](https://linear.app/clickhouse/issue/DOC-781/fix-privatepreview-badge-galaxy-tracking) will be opened as a follow up to correct the hardcoded galaxy event in the Private Preview badge, and correct existing instances. 

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
