### PR TITLE
Update video duration in cloud quick start

### DIFF
--- a/docs/getting-started/quick-start/cloud.mdx
+++ b/docs/getting-started/quick-start/cloud.mdx
@@ -318,7 +318,7 @@ See ["Setting IP filters"](/cloud/security/setting-ip-filters) for more details.
 
 - The [Tutorial](/tutorial.md) has you insert 2 million rows into a table and write some analytical queries
 - We have a list of [example datasets](/getting-started/index.md) with instructions on how to insert them
-- Check out our 25-minute video on [Getting Started with ClickHouse](https://clickhouse.com/company/events/getting-started-with-clickhouse/)
+- Check out our 12-minute video on [Getting Started with ClickHouse](https://clickhouse.com/company/events/getting-started-with-clickhouse/)
 - If your data is coming from an external source, view our [collection of integration guides](/integrations/index.mdx) for connecting to message queues, databases, pipelines and more
 - If you're using a UI/BI visualization tool, view the [user guides for connecting a UI to ClickHouse](/integrations/data-visualization)
 - The user guide on [primary keys](/guides/best-practices/sparse-primary-indexes.md) is everything you need to know about primary keys and how to define them


### PR DESCRIPTION
## Summary
Resolves https://github.com/ClickHouse/clickhouse-docs/issues/6266

Corrects the description of the length of the video linked under "What's next"

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single bullet point with no impact on product behavior or APIs.
> 
> **Overview**
> Updates the ClickHouse Cloud quick start `What's Next?` section to correct the referenced “Getting Started with ClickHouse” video duration from 25 minutes to 12 minutes while keeping the same link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668c649b5bbcfed86d97be33caba3df66da15331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->