### PR TITLE
Cloud changelog: Week of 2026-05-25 (Agent generated)

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -188,7 +188,7 @@ If you manually stop a service, you will need to start it up again in order for 
 
 - **One replica Primary Service** Today, the default behavior is the secondary services can have one replica, the primary service must have at least 2.
   To enable single replica primary services, please contact support. This behavior will be enabled by default in Q2 2026.
-- **Primary service idling**: Previously, primary services could not auto-idle by default. As of May 2026, primary service auto-idling is enabled by default. As part of the rollout, existing services have access to the feature while new services created post rollout have it enabled by default. 
+- **Primary service idling**: primary service auto-idling is enabled by default.
 
 ## Pricing {#pricing}
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -28,6 +28,12 @@ Organization [spend alerts](/cloud/manage/billing/spend-alerts) are now generall
 ### New ClickPipes AWS regions {#clickpipes-aws-mx-central-1}
 
 The `mx-central-1` (Mexico Central) AWS region is now live for [ClickPipes](/integrations/clickpipes), following the [Cloud region launch](/whats-new/changelog/cloud#new-region-support). For ClickHouse Cloud services created in this region from May 19 2026, ClickPipes will be co-located in the same region. For services created prior to that date, ClickPipes will default to the `us-east-2` region; if that's the case, please [reach out to our team](https://clickhouse.com/company/contact?loc=clickpipes) to get your service patched to use the new region.
+
+### Primary service idling for compute-compute separation now generally available {#primary-service-idling-ga}
+
+Primary service idling for compute-compute separation is now generally available.
+All primary services now have the ability to idle.
+
 ## May 18, 2026 {#2026-05-18}
 
 ### Python client v1.0.0 {#python-client-v1}

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -25,10 +25,9 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
 
 Organization [spend alerts](/cloud/manage/billing/spend-alerts) are now generally available. Get notified at 50%, 75%, and 100% of your configured organization spend per billing period. Choose from Email, Cloud console (UI), and/or Slack as notification channels. Alerts are based on organization gross usage, fire hourly, and reset automatically each billing period. Requires Org Admin or Billing Admin role.
 
-### mx-central-1 ClickPipes private region {#mx-central-1-clickpipes}
+### New ClickPipes AWS regions {#clickpipes-aws-mx-central-1}
 
-The mx-central-1 (Mexico Central) private region is now live for [ClickPipes](/integrations/clickpipes), following the [Cloud region launch](/whats-new/changelog/cloud#new-region-support) on May 18.
-
+The `mx-central-1` (Mexico Central) AWS region is now live for [ClickPipes](/integrations/clickpipes), following the [Cloud region launch](/whats-new/changelog/cloud#new-region-support). For ClickHouse Cloud services created in this region from May 19 2026, ClickPipes will be co-located in the same region. For services created prior to that date, ClickPipes will default to the `us-east-2` region; if that's the case, please [reach out to our team](https://clickhouse.com/company/contact?loc=clickpipes) to get your service patched to use the new region.
 ## May 18, 2026 {#2026-05-18}
 
 ### Python client v1.0.0 {#python-client-v1}

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,16 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## May 25, 2026 {#2026-05-25}
+
+### GA release of organization spend alerts {#spend-alerts-ga}
+
+Organization [spend alerts](/cloud/manage/billing/spend-alerts) are now generally available. Get notified at 50%, 75%, and 100% of your configured organization spend per billing period. Choose from Email, Cloud console (UI), and/or Slack as notification channels. Alerts are based on organization gross usage, fire hourly, and reset automatically each billing period. Requires Org Admin or Billing Admin role.
+
+### mx-central-1 ClickPipes private region {#mx-central-1-clickpipes}
+
+The mx-central-1 (Mexico Central) private region is now live for [ClickPipes](/integrations/clickpipes), following the [Cloud region launch](/whats-new/changelog/cloud#new-region-support) on May 18.
+
 ## May 18, 2026 {#2026-05-18}
 
 ### Python client v1.0.0 {#python-client-v1}


### PR DESCRIPTION
## Summary

Automated Cloud changelog update for the week of May 19–25, 2026, based on updates posted in #shipped.

### Included changes

- **GA release of organization spend alerts** — Organization spend alerts have moved from Private Preview (April 17) to General Availability. Threshold-based notifications at 50%, 75%, and 100% of configured org spend per billing period, with Email, UI, and Slack notification channels.
- **mx-central-1 ClickPipes private region** — The mx-central-1 (Mexico Central) private region is now live for ClickPipes, following the Cloud region launch on May 18.

### Needs review

- The mx-central-1 ClickPipes entry references the Cloud region launch from May 18. Please verify the cross-link anchor `#new-region-support` renders correctly.
- Light week in #shipped — only two user-facing items were posted. If anything else shipped this week that wasn't posted in #shipped, please add it before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to changelog and warehouse reference; no product code or security-sensitive behavior changes.
> 
> **Overview**
> Adds a **May 25, 2026** Cloud changelog section documenting three GA announcements: **organization spend alerts**, **ClickPipes in `mx-central-1`** (with co-location rules and a link to the May 18 region entry), and **primary service idling** for compute-compute separation.
> 
> Updates the **warehouses** reference so the primary-service idling callout no longer describes preview/rollout timing—it now states that **primary service auto-idling is enabled by default**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb1f9f56c3e47853cd197b8608f16f5265b4ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->