### PR TITLE
Except operations/external-authenticators/jwt.md from floating-pages …

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -14,3 +14,4 @@ operations/utilities/clickhouse-keeper-http-api.md
 cloud/features/backups/faq.md
 interfaces/web-terminal
 operations/query-rules
+operations/external-authenticators/jwt.md


### PR DESCRIPTION
…check

Temporary unblocker for the ClickHouse JWT auth docs landing in ClickHouse/ClickHouse#103825. The page is reachable from `operations/external-authenticators/index.md` but is not yet in the sidebar, so the floating-pages check fails.

The sidebar entry will be added (and this exception removed) in a follow-up after ClickHouse/ClickHouse#103825 is merged and the JWT page is synced into clickhouse-docs.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line allowlist change for a docs CI plugin; no runtime or security impact.
> 
> **Overview**
> Adds **`operations/external-authenticators/jwt.md`** to **`plugins/floating-pages-exceptions.txt`** so the docs build’s floating-pages check skips that page until it appears in **`sidebars.js`**.
> 
> This is a **temporary** unblocker: the JWT auth doc is linked from the external authenticators index but not yet in the nav, which would otherwise fail CI. A follow-up is expected to add the sidebar entry and remove this exception after the upstream JWT docs land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c63a8fcc74a0df522592d2b43ab2e2ddceef10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->