### PR TITLE
Update Managed Postgres extension versions

### DIFF
--- a/docs/cloud/managed-postgres/extensions.md
+++ b/docs/cloud/managed-postgres/extensions.md
@@ -37,9 +37,10 @@ SELECT * FROM pg_available_extensions;
 
 | Extension | Version | Description |
 |-----------|---------|-------------|
-| `address_standardizer` | 3.6.1 | Used to parse an address into constituent elements |
-| `address_standardizer_data_us` | 3.6.1 | Address Standardizer US dataset example |
+| `address_standardizer` | 3.6.3 | Used to parse an address into constituent elements |
+| `address_standardizer_data_us` | 3.6.3 | Address Standardizer US dataset example |
 | `adminpack` | 2.1 | Administrative functions for PostgreSQL *(PG16 only)* |
+| `age` | 1.7.0 | Apache AGE graph database extension |
 | `amcheck` | | Functions for verifying relation integrity |
 | `autoinc` | 1.0 | Functions for auto-incrementing fields |
 | `bloom` | 1.0 | Bloom access method - signature file based index |
@@ -77,18 +78,18 @@ SELECT * FROM pg_available_extensions;
 | `orafce` | 4.16 | Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS |
 | `pageinspect` | 1.13 | Inspect the contents of database pages at a low level |
 | `pg_buffercache` | | Examine the shared buffer cache |
-| `pg_clickhouse` | 0.1 | Interfaces to query ClickHouse databases from PostgreSQL |
+| `pg_clickhouse` | 0.3 | Interfaces to query ClickHouse databases from PostgreSQL |
 | `pg_cron` | 1.6 | Job scheduler for PostgreSQL |
 | `pg_freespacemap` | 1.3 | Examine the free space map (FSM) |
 | `pg_hint_plan` | | Optimizer hints for PostgreSQL |
 | `pg_ivm` | 1.13 | Incremental view maintenance on PostgreSQL |
 | `pg_logicalinspect` | 1.0 | Functions to inspect logical decoding components *(PG18+)* |
-| `pg_partman` | 5.4.0 | Extension to manage partitioned tables by time or ID |
+| `pg_partman` | 5.4.3 | Extension to manage partitioned tables by time or ID |
 | `pg_prewarm` | 1.2 | Prewarm relation data |
-| `pg_re2` | | ClickHouse-compatible regular expression functions backed by Google's RE2 |
+| `pg_re2` | 0.1 | ClickHouse-compatible regular expression functions backed by Google's RE2 |
 | `pg_repack` | 1.5.3 | Reorganize tables in PostgreSQL databases with minimal locks |
 | `pg_similarity` | 1.0 | Support similarity queries |
-| `pg_stat_ch` | | Streams per-query execution telemetry to ClickHouse in real time |
+| `pg_stat_ch` | 0.3 | Streams per-query execution telemetry to ClickHouse in real time |
 | `pg_stat_statements` | | Track planning and execution statistics of all SQL statements executed |
 | `pg_surgery` | 1.0 | Extension to perform surgery on a damaged relation |
 | `pg_tokenizer` | 0.1.1 | Text tokenizer used with `vchord_bm25` |
@@ -99,7 +100,7 @@ SELECT * FROM pg_available_extensions;
 | `pgcrypto` | 1.4 | Cryptographic functions |
 | `pglogical` | 2.4.6 | PostgreSQL Logical Replication |
 | `pglogical_origin` | 1.0.0 | Dummy extension for compatibility when upgrading from Postgres 9.4 |
-| `pgrouting` | 4.0.0 | pgRouting Extension |
+| `pgrouting` | 4.0.1 | pgRouting Extension |
 | `pgrowlocks` | 1.2 | Show row-level locking information |
 | `pgstattuple` | 1.5 | Show tuple-level statistics |
 | `pgtap` | 1.3.4 | Unit testing for PostgreSQL |
@@ -107,11 +108,11 @@ SELECT * FROM pg_available_extensions;
 | `plperlu` | 1.0 | PL/PerlU untrusted procedural language |
 | `plpgsql` | 1.0 | PL/pgSQL procedural language |
 | `plpgsql_check` | 2.8 | Extended check for plpgsql functions |
-| `postgis` | 3.6.1 | PostGIS geometry and geography spatial types and functions |
-| `postgis_raster` | 3.6.1 | PostGIS raster types and functions |
-| `postgis_sfcgal` | 3.6.1 | PostGIS SFCGAL functions |
-| `postgis_tiger_geocoder` | 3.6.1 | PostGIS tiger geocoder and reverse geocoder |
-| `postgis_topology` | 3.6.1 | PostGIS topology spatial types and functions |
+| `postgis` | 3.6.3 | PostGIS geometry and geography spatial types and functions |
+| `postgis_raster` | 3.6.3 | PostGIS raster types and functions |
+| `postgis_sfcgal` | 3.6.3 | PostGIS SFCGAL functions |
+| `postgis_tiger_geocoder` | 3.6.3 | PostGIS tiger geocoder and reverse geocoder |
+| `postgis_topology` | 3.6.3 | PostGIS topology spatial types and functions |
 | `postgres_fdw` | 1.2 | Foreign-data wrapper for remote PostgreSQL servers |
 | `prefix` | 1.2.0 | Prefix Range module for PostgreSQL |
 | `refint` | 1.0 | Functions for implementing referential integrity (obsolete) |
@@ -129,7 +130,7 @@ SELECT * FROM pg_available_extensions;
 | `uuid-ossp` | 1.1 | Generate universally unique identifiers (UUIDs) |
 | `vchord` | 1.1.1 | Vector indexing access methods for Postgres |
 | `vchord_bm25` | 0.3.0 | BM25 ranking access method for full-text search |
-| `vector` | 0.8.1 | Vector data type and ivfflat and hnsw access methods |
+| `vector` | 0.8.2 | Vector data type and ivfflat and hnsw access methods |
 | `xml2` | 1.2 | XPath querying and XSLT |
 
 ## pg_clickhouse extension {#pg-clickhouse}


### PR DESCRIPTION
Bumps version numbers to match what's currently shipping on Managed Postgres instances. Adds the missing age extension and fills in version numbers for pg_stat_ch and pg_re2.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table updates with no runtime or security impact.
> 
> **Overview**
> Updates the **Available extensions** table in Managed Postgres docs so listed versions match what ships on instances today.
> 
> **New:** `age` (1.7.0) is documented as an available graph extension.
> 
> **Version bumps** include PostGIS-related extensions (3.6.1 → 3.6.3), `address_standardizer*` (3.6.1 → 3.6.3), `pg_clickhouse` / `pg_stat_ch` (0.1 → 0.3), `pg_partman` (5.4.0 → 5.4.3), `pgrouting` (4.0.0 → 4.0.1), and `vector` (0.8.1 → 0.8.2). **`pg_re2`** now shows version **0.1** where the column was previously blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d64d6a74c7d78983c3ee9906acf25cbdc22e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->