### PR TITLE
Postgres docs: move pricing to after quickstart

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -338,8 +338,8 @@ const sidebars = {
       link: { type: 'doc', id: 'cloud/managed-postgres/overview' },
       items: [
         'cloud/managed-postgres/overview',
-        'cloud/managed-postgres/pricing',
         'cloud/managed-postgres/quickstart',
+        'cloud/managed-postgres/pricing',
         'cloud/managed-postgres/connection',
         'cloud/managed-postgres/clickhouse-integration',
         'cloud/managed-postgres/high-availability',


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
Changes the order of the pages
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only reorder with no content or redirect changes.
> 
> **Overview**
> Reorders the **Managed Postgres (Preview)** docs sidebar so **Pricing** appears after **Quickstart** instead of immediately after **Overview**. No doc content or URLs change—only navigation order in `sidebars.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f9eb6f6db7b74bc0149f08386d9280cc9451e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->