### PR TITLE
Fix broken anchor fragments in settings and function links

### DIFF
--- a/docs/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/guides/best-practices/sparse-primary-indexes.md
@@ -390,7 +390,7 @@ In total the index has 1083 entries for our table with 8.87 million rows and 108
 
 On a self-managed ClickHouse cluster we can use the <a href="https://clickhouse.com/docs/sql-reference/table-functions/file/" target="_blank">file table function</a> for inspecting the content of the primary index of our example table.
 
-For that we first need to copy the primary index file into the <a href="https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#server_configuration_parameters-user_files_path" target="_blank">user_files_path</a> of a node from the running cluster:
+For that we first need to copy the primary index file into the <a href="https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#user_files_path" target="_blank">user_files_path</a> of a node from the running cluster:
 <ul>
 <li>Step 1: Get part-path that contains the primary index file</li>
 `
@@ -504,7 +504,7 @@ Processed 8.19 thousand rows,
 
 The output for the ClickHouse client is now showing that instead of doing a full table scan, only 8.19 thousand rows were streamed into ClickHouse.
 
-If <a href="https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#server_configuration_parameters-logger" target="_blank">trace logging</a> is enabled then the ClickHouse server log file shows that ClickHouse was running a <a href="https://github.com/ClickHouse/ClickHouse/blob/22.3/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp#L1452" target="_blank">binary search</a> over the 1083 UserID index marks, in order to identify granules that possibly can contain rows with a UserID column value of `749927693`. This requires 19 steps with an average time complexity of `O(log2 n)`:
+If <a href="https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#logger" target="_blank">trace logging</a> is enabled then the ClickHouse server log file shows that ClickHouse was running a <a href="https://github.com/ClickHouse/ClickHouse/blob/22.3/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp#L1452" target="_blank">binary search</a> over the 1083 UserID index marks, in order to identify granules that possibly can contain rows with a UserID column value of `749927693`. This requires 19 steps with an average time complexity of `O(log2 n)`:
 ```response
 ...Executor): Key condition: (column 0 in [749927693, 749927693])
 # highlight-next-line

--- a/docs/guides/sre/tls/configuring-tls.md
+++ b/docs/guides/sre/tls/configuring-tls.md
@@ -304,7 +304,7 @@ The settings below are configured in the ClickHouse server `config.xml`
     </openSSL>
     ```
 
-    For more information, visit https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#openssl
+    For more information, visit [this page](/operations/server-configuration-parameters/settings/#openssl)
 
 7. Configure TLS for gRPC on every node:
     ```xml

--- a/docs/guides/sre/tls/configuring-tls.md
+++ b/docs/guides/sre/tls/configuring-tls.md
@@ -304,7 +304,7 @@ The settings below are configured in the ClickHouse server `config.xml`
     </openSSL>
     ```
 
-    For more information, visit https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#server_configuration_parameters-openssl
+    For more information, visit https://clickhouse.com/docs/operations/server-configuration-parameters/settings/#openssl
 
 7. Configure TLS for gRPC on every node:
     ```xml

--- a/docs/integrations/language-clients/rust.md
+++ b/docs/integrations/language-clients/rust.md
@@ -170,7 +170,7 @@ insert.end().await?;
 
 * If `end()` isn't called, the `INSERT` is aborted.
 * Rows are being sent progressively as a stream to spread the network load.
-* ClickHouse inserts batches atomically only if all rows fit in the same partition and their number is less [`max_insert_block_size`](https://clickhouse.tech/docs/operations/settings/settings/#settings-max_insert_block_size).
+* ClickHouse inserts batches atomically only if all rows fit in the same partition and their number is less [`max_insert_block_size`](https://clickhouse.tech/docs/operations/settings/settings/#max_insert_block_size).
 
 ### Async insert (server-side batching) {#async-insert-server-side-batching}
 

--- a/docs/integrations/language-clients/rust.md
+++ b/docs/integrations/language-clients/rust.md
@@ -170,7 +170,7 @@ insert.end().await?;
 
 * If `end()` isn't called, the `INSERT` is aborted.
 * Rows are being sent progressively as a stream to spread the network load.
-* ClickHouse inserts batches atomically only if all rows fit in the same partition and their number is less [`max_insert_block_size`](https://clickhouse.tech/docs/operations/settings/settings/#max_insert_block_size).
+* ClickHouse inserts batches atomically only if all rows fit in the same partition and their number is less [`max_insert_block_size`](/operations/settings/settings/#max_insert_block_size).
 
 ### Async insert (server-side batching) {#async-insert-server-side-batching}
 

--- a/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
+++ b/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
@@ -1069,7 +1069,7 @@ equivalents as follows:
 * `array_prepend`: [arrayPushFront](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushFront)
 * `array_remove`: [arrayRemove](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRemove)
 * `array_length` & `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
-* `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#arrayStringConcat)
+* `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayStringConcat)
 * `string_to_array`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString)
 * `split_part`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString) + array subscript
 * `trim_array`: [arrayResize](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayResize)
@@ -1078,19 +1078,19 @@ equivalents as follows:
 * `array_shuffle`: [arrayShuffle](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayShuffle)
 * `array_sample`: [arrayRandomSample](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRandomSample)
 * `array_sort`: [arraySort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySort) / [arrayReverseSort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverseSort)
-* `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimBoth)
-* `ltrim`: [trimLeft](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimLeft)
-* `rtrim`: [trimRight](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimRight)
-* `concat_ws`: [concatWithSeparator](https://clickhouse.com/docs/sql-reference/functions/string-functions#concatWithSeparator)
-* `lower(text)`: [lowerUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lowerUTF8)
-* `upper(text)`: [upperUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#upperUTF8)
-* `substring(text, ...)` & `substr(text, ...)`: [substringUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#substringUTF8)
+* `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
+* `ltrim`: [ltrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#ltrim)
+* `rtrim`: [rtrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#rtrim)
+* `concat_ws`: [concatWithSeparator](https://clickhouse.com/docs/sql-reference/functions/string-functions#concatwithseparator)
+* `lower(text)`: [lowerUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lowerutf8)
+* `upper(text)`: [upperUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#upperutf8)
+* `substring(text, ...)` & `substr(text, ...)`: [substringUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#substringutf8)
 * `substring(bytea, ...)` & `substr(bytea, ...)`: [substring](https://clickhouse.com/docs/sql-reference/functions/string-functions#substring)
-* `length(text)`: [lengthUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lengthUTF8)
+* `length(text)`: [lengthUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lengthutf8)
 * `length(bytea)` & `octet_length`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
-* `reverse(text)`: [reverseUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverseUTF8)
-* `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/array-functions#reverse)
-* `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionUTF8)
+* `reverse(text)`: [reverseUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverseutf8)
+* `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverse)
+* `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionutf8)
 * `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 * `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 * `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
@@ -1099,7 +1099,7 @@ equivalents as follows:
 * `json_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 * `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 * `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
-* `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitCount)
+* `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitcount)
 * `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
 * `to_char(timestamp[tz], fmt)`: [formatDateTime](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime)
   when `fmt` is a string constant whose every keyword has a faithful
@@ -1146,9 +1146,7 @@ These custom functions created by `pg_clickhouse` provide foreign query
 pushdown for select ClickHouse functions with no PostgreSQL equivalents. If
 any of these functions can't be pushed down they will raise an exception.
 
-* [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGet)
-* [dictGetOrDefault](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGetOrDefault)
-* [dictGetOrNull](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGetOrNull)
+* [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictget-dictgetordefault-dictgetornull)
 
 ### Extension pushdown {#extension-pushdown}
 
@@ -1162,7 +1160,7 @@ All [re2 extension] functions push down 1:1 to ClickHouse:
 * `re2match` → [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 * `re2extract` → [extract](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extract)
 * `re2extractall` → [extractAll](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractAll)
-* `re2regexpextract` → [regexpExtract](https://clickhouse.com/docs/sql-reference/functions/string-functions#regexpExtract)
+* `re2regexpextract` → [regexpExtract](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#regexpExtract)
 * `re2extractgroups` → [extractGroups](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractGroups)
 * `re2replaceregexpone` → [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne)
 * `re2replaceregexpall` → [replaceRegexpAll](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll)
@@ -1195,11 +1193,11 @@ In order to push down casts to incompatible data types, pg_clickhouse provides
 the following functions. They raise an exception in PostgreSQL if they're not
 pushed down.
 
-* [toUInt8](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt8)
-* [toUInt16](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt16)
-* [toUInt32](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt32)
-* [toUInt64](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt64)
-* [toUInt128](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt128)
+* [toUInt8](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint8)
+* [toUInt16](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint16)
+* [toUInt32](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint32)
+* [toUInt64](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint64)
+* [toUInt128](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint128)
 
 ### Pushdown aggregates {#pushdown-aggregates}
 
@@ -1265,17 +1263,17 @@ These PostgreSQL [window functions] push down to ClickHouse with `OVER
 (PARTITION BY ... ORDER BY ...)` clauses, including frame specifications where
 applicable.
 
-* [row_number](https://clickhouse.com/docs/sql-reference/window-functions/row_number)
-* [rank](https://clickhouse.com/docs/sql-reference/window-functions/rank)
-* [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions/dense_rank)
-* [ntile](https://clickhouse.com/docs/sql-reference/window-functions/ntile)
-* [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions/cume_dist)
-* [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions/percent_rank)
-* [lead](https://clickhouse.com/docs/sql-reference/window-functions/lead)
-* [lag](https://clickhouse.com/docs/sql-reference/window-functions/lag)
-* [first_value](https://clickhouse.com/docs/sql-reference/window-functions/first_value)
-* [last_value](https://clickhouse.com/docs/sql-reference/window-functions/last_value)
-* [nth_value](https://clickhouse.com/docs/sql-reference/window-functions/nth_value)
+* [row_number](https://clickhouse.com/docs/sql-reference/window-functions#row_number)
+* [rank](https://clickhouse.com/docs/sql-reference/window-functions#rank)
+* [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions#dense_rank)
+* [ntile](https://clickhouse.com/docs/sql-reference/window-functions#ntile)
+* [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions#cume_dist)
+* [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions#percent_rank)
+* [lead](https://clickhouse.com/docs/sql-reference/window-functions#lead)
+* [lag](https://clickhouse.com/docs/sql-reference/window-functions#lag)
+* [first_value](https://clickhouse.com/docs/sql-reference/window-functions#first_value)
+* [last_value](https://clickhouse.com/docs/sql-reference/window-functions#last_value)
+* [nth_value](https://clickhouse.com/docs/sql-reference/window-functions#nth_value)
 * `min` / `max` (with `OVER` clause)
 
 Ranking functions (`row_number`, `rank`, `dense_rank`, `ntile`, `cume_dist`,

--- a/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
+++ b/docs/integrations/tools/data-integration/pg_clickhouse/reference.md
@@ -1069,7 +1069,7 @@ equivalents as follows:
 * `array_prepend`: [arrayPushFront](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushFront)
 * `array_remove`: [arrayRemove](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRemove)
 * `array_length` & `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
-* `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayStringConcat)
+* `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#arrayStringConcat)
 * `string_to_array`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString)
 * `split_part`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString) + array subscript
 * `trim_array`: [arrayResize](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayResize)
@@ -1078,19 +1078,19 @@ equivalents as follows:
 * `array_shuffle`: [arrayShuffle](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayShuffle)
 * `array_sample`: [arrayRandomSample](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRandomSample)
 * `array_sort`: [arraySort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySort) / [arrayReverseSort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverseSort)
-* `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
-* `ltrim`: [ltrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#ltrim)
-* `rtrim`: [rtrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#rtrim)
-* `concat_ws`: [concatWithSeparator](https://clickhouse.com/docs/sql-reference/functions/string-functions#concatwithseparator)
-* `lower(text)`: [lowerUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lowerutf8)
-* `upper(text)`: [upperUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#upperutf8)
-* `substring(text, ...)` & `substr(text, ...)`: [substringUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#substringutf8)
+* `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimBoth)
+* `ltrim`: [trimLeft](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimLeft)
+* `rtrim`: [trimRight](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimRight)
+* `concat_ws`: [concatWithSeparator](https://clickhouse.com/docs/sql-reference/functions/string-functions#concatWithSeparator)
+* `lower(text)`: [lowerUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lowerUTF8)
+* `upper(text)`: [upperUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#upperUTF8)
+* `substring(text, ...)` & `substr(text, ...)`: [substringUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#substringUTF8)
 * `substring(bytea, ...)` & `substr(bytea, ...)`: [substring](https://clickhouse.com/docs/sql-reference/functions/string-functions#substring)
-* `length(text)`: [lengthUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lengthutf8)
+* `length(text)`: [lengthUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lengthUTF8)
 * `length(bytea)` & `octet_length`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
-* `reverse(text)`: [reverseUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverseutf8)
-* `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverse)
-* `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionutf8)
+* `reverse(text)`: [reverseUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverseUTF8)
+* `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/array-functions#reverse)
+* `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionUTF8)
 * `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 * `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 * `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
@@ -1099,7 +1099,7 @@ equivalents as follows:
 * `json_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 * `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 * `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
-* `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitcount)
+* `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitCount)
 * `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
 * `to_char(timestamp[tz], fmt)`: [formatDateTime](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime)
   when `fmt` is a string constant whose every keyword has a faithful
@@ -1146,7 +1146,9 @@ These custom functions created by `pg_clickhouse` provide foreign query
 pushdown for select ClickHouse functions with no PostgreSQL equivalents. If
 any of these functions can't be pushed down they will raise an exception.
 
-* [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictget-dictgetordefault-dictgetornull)
+* [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGet)
+* [dictGetOrDefault](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGetOrDefault)
+* [dictGetOrNull](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictGetOrNull)
 
 ### Extension pushdown {#extension-pushdown}
 
@@ -1160,7 +1162,7 @@ All [re2 extension] functions push down 1:1 to ClickHouse:
 * `re2match` → [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 * `re2extract` → [extract](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extract)
 * `re2extractall` → [extractAll](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractAll)
-* `re2regexpextract` → [regexpExtract](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#regexpExtract)
+* `re2regexpextract` → [regexpExtract](https://clickhouse.com/docs/sql-reference/functions/string-functions#regexpExtract)
 * `re2extractgroups` → [extractGroups](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractGroups)
 * `re2replaceregexpone` → [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne)
 * `re2replaceregexpall` → [replaceRegexpAll](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll)
@@ -1193,11 +1195,11 @@ In order to push down casts to incompatible data types, pg_clickhouse provides
 the following functions. They raise an exception in PostgreSQL if they're not
 pushed down.
 
-* [toUInt8](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint8)
-* [toUInt16](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint16)
-* [toUInt32](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint32)
-* [toUInt64](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint64)
-* [toUInt128](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint128)
+* [toUInt8](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt8)
+* [toUInt16](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt16)
+* [toUInt32](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt32)
+* [toUInt64](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt64)
+* [toUInt128](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toUInt128)
 
 ### Pushdown aggregates {#pushdown-aggregates}
 
@@ -1263,17 +1265,17 @@ These PostgreSQL [window functions] push down to ClickHouse with `OVER
 (PARTITION BY ... ORDER BY ...)` clauses, including frame specifications where
 applicable.
 
-* [row_number](https://clickhouse.com/docs/sql-reference/window-functions#row_number)
-* [rank](https://clickhouse.com/docs/sql-reference/window-functions#rank)
-* [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions#dense_rank)
-* [ntile](https://clickhouse.com/docs/sql-reference/window-functions#ntile)
-* [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions#cume_dist)
-* [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions#percent_rank)
-* [lead](https://clickhouse.com/docs/sql-reference/window-functions#lead)
-* [lag](https://clickhouse.com/docs/sql-reference/window-functions#lag)
-* [first_value](https://clickhouse.com/docs/sql-reference/window-functions#first_value)
-* [last_value](https://clickhouse.com/docs/sql-reference/window-functions#last_value)
-* [nth_value](https://clickhouse.com/docs/sql-reference/window-functions#nth_value)
+* [row_number](https://clickhouse.com/docs/sql-reference/window-functions/row_number)
+* [rank](https://clickhouse.com/docs/sql-reference/window-functions/rank)
+* [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions/dense_rank)
+* [ntile](https://clickhouse.com/docs/sql-reference/window-functions/ntile)
+* [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions/cume_dist)
+* [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions/percent_rank)
+* [lead](https://clickhouse.com/docs/sql-reference/window-functions/lead)
+* [lag](https://clickhouse.com/docs/sql-reference/window-functions/lag)
+* [first_value](https://clickhouse.com/docs/sql-reference/window-functions/first_value)
+* [last_value](https://clickhouse.com/docs/sql-reference/window-functions/last_value)
+* [nth_value](https://clickhouse.com/docs/sql-reference/window-functions/nth_value)
 * `min` / `max` (with `OVER` clause)
 
 Ranking functions (`row_number`, `rank`, `dense_rank`, `ntile`, `cume_dist`,

--- a/knowledgebase/Insert_select_settings_tuning.mdx
+++ b/knowledgebase/Insert_select_settings_tuning.mdx
@@ -19,28 +19,28 @@ How can I solve this?
 Below are some of the settings to tune to avoid this error, this is expert level tuning of ClickHouse and these values should be set only after understanding the specifications of the ClickHouse cloud service or on-prem cluster where these will be used, so do not take these values as "one size fits all".
 
 
-[max_insert_block_size](https://clickhouse.com/docs/operations/settings/settings#settings-max_insert_block_size) = `100_000_000` (default `1_048_576`)
+[max_insert_block_size](https://clickhouse.com/docs/operations/settings/settings#max_insert_block_size) = `100_000_000` (default `1_048_576`)
 
 Increase from ~1M to 100M would allow larger blocks to form
 
 Note: This setting only applies when the server forms the blocks. i.e. INSERT via the HTTP interface, and not for clickhouse-client
 
 
-[min_insert_block_size_rows](https://clickhouse.com/docs/operations/settings/settings#min-insert-block-size-rows) = `100_000_000` (default `1_048_576`)
+[min_insert_block_size_rows](https://clickhouse.com/docs/operations/settings/settings#min_insert_block_size_rows) = `100_000_000` (default `1_048_576`)
 
 Increase from ~1M to 100M would allow larger blocks to form.
 
 
-[min_insert_block_size_bytes](https://clickhouse.com/docs/operations/settings/settings#min-insert-block-size-bytes) = `500_000_000` (default `268_435_456`)
+[min_insert_block_size_bytes](https://clickhouse.com/docs/operations/settings/settings#min_insert_block_size_bytes) = `500_000_000` (default `268_435_456`)
 
 Increase from 268.44 MB to 500 MB would allow larger blocks to form.
 
 
-[parts_to_delay_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts-to-delay-insert) = `500` (default `150`)
+[parts_to_delay_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts_to_delay_insert) = `500` (default `150`)
 
 Increasing this so that INSERTs are not artificially slowed down when the number of active parts in a single partition is reached.
 
 
-[parts_to_throw_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts-to-throw-insert) = `1500` (default `3000`)
+[parts_to_throw_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts_to_throw_insert) = `1500` (default `3000`)
 
 Increasing this would generally affect query performance to the table, but this would be fine for data migration.

--- a/knowledgebase/Insert_select_settings_tuning.mdx
+++ b/knowledgebase/Insert_select_settings_tuning.mdx
@@ -19,28 +19,28 @@ How can I solve this?
 Below are some of the settings to tune to avoid this error, this is expert level tuning of ClickHouse and these values should be set only after understanding the specifications of the ClickHouse cloud service or on-prem cluster where these will be used, so do not take these values as "one size fits all".
 
 
-[max_insert_block_size](https://clickhouse.com/docs/operations/settings/settings#max_insert_block_size) = `100_000_000` (default `1_048_576`)
+[max_insert_block_size](/operations/settings/settings#max_insert_block_size) = `100_000_000` (default `1_048_576`)
 
 Increase from ~1M to 100M would allow larger blocks to form
 
 Note: This setting only applies when the server forms the blocks. i.e. INSERT via the HTTP interface, and not for clickhouse-client
 
 
-[min_insert_block_size_rows](https://clickhouse.com/docs/operations/settings/settings#min_insert_block_size_rows) = `100_000_000` (default `1_048_576`)
+[min_insert_block_size_rows](/operations/settings/settings#min_insert_block_size_rows) = `100_000_000` (default `1_048_576`)
 
 Increase from ~1M to 100M would allow larger blocks to form.
 
 
-[min_insert_block_size_bytes](https://clickhouse.com/docs/operations/settings/settings#min_insert_block_size_bytes) = `500_000_000` (default `268_435_456`)
+[min_insert_block_size_bytes](/operations/settings/settings#min_insert_block_size_bytes) = `500_000_000` (default `268_435_456`)
 
 Increase from 268.44 MB to 500 MB would allow larger blocks to form.
 
 
-[parts_to_delay_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts_to_delay_insert) = `500` (default `150`)
+[parts_to_delay_insert](/operations/settings/merge-tree-settings#parts_to_delay_insert) = `500` (default `150`)
 
 Increasing this so that INSERTs are not artificially slowed down when the number of active parts in a single partition is reached.
 
 
-[parts_to_throw_insert](https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts_to_throw_insert) = `1500` (default `3000`)
+[parts_to_throw_insert](/operations/settings/merge-tree-settings#parts_to_throw_insert) = `1500` (default `3000`)
 
 Increasing this would generally affect query performance to the table, but this would be fine for data migration.

--- a/knowledgebase/async_vs_optimize_read_in_order.mdx
+++ b/knowledgebase/async_vs_optimize_read_in_order.mdx
@@ -18,7 +18,7 @@ import optimize_read from "@site/static/images/knowledgebase/optimize_read.png";
 
 The new setting allow_asynchronous_read_from_io_pool_for_merge_tree allows the number of reading threads (streams) to be higher than the number of threads in the rest of the query execution pipeline.
 
-Normally the [max_threads](https://clickhouse.com/docs/operations/settings/settings/#settings-max_threads) setting [controls](https://clickhouse.com/company/events/query-performance-introspection) the number of parallel reading threads and parallel query processing threads:
+Normally the [max_threads](https://clickhouse.com/docs/operations/settings/settings/#max_threads) setting [controls](https://clickhouse.com/company/events/query-performance-introspection) the number of parallel reading threads and parallel query processing threads:
 
 <Image img={sync_read} size="md" alt="Synchronous data reading diagram" />
 

--- a/knowledgebase/async_vs_optimize_read_in_order.mdx
+++ b/knowledgebase/async_vs_optimize_read_in_order.mdx
@@ -18,7 +18,7 @@ import optimize_read from "@site/static/images/knowledgebase/optimize_read.png";
 
 The new setting allow_asynchronous_read_from_io_pool_for_merge_tree allows the number of reading threads (streams) to be higher than the number of threads in the rest of the query execution pipeline.
 
-Normally the [max_threads](https://clickhouse.com/docs/operations/settings/settings/#max_threads) setting [controls](https://clickhouse.com/company/events/query-performance-introspection) the number of parallel reading threads and parallel query processing threads:
+Normally the [max_threads](/operations/settings/settings/#max_threads) setting [controls](https://clickhouse.com/company/events/query-performance-introspection) the number of parallel reading threads and parallel query processing threads:
 
 <Image img={sync_read} size="md" alt="Synchronous data reading diagram" />
 

--- a/knowledgebase/compare_resultsets.mdx
+++ b/knowledgebase/compare_resultsets.mdx
@@ -37,7 +37,7 @@ WITH
     ) AS q2_resultset_hash
 SELECT equals(q1_resultset_hash,q2_resultset_hash) as Q1_equals_Q2
 ```
-The example uses a [CTE](https://clickhouse.com/docs/sql-reference/statements/select/with) to calculate sums of the [cityHash](https://clickhouse.com/docs/sql-reference/functions/hash-functions#cityhash64) value of each row in these two queries and will return `1` if the two resultsets are identical.
+The example uses a [CTE](https://clickhouse.com/docs/sql-reference/statements/select/with) to calculate sums of the [cityHash](https://clickhouse.com/docs/sql-reference/functions/hash-functions#cityHash64) value of each row in these two queries and will return `1` if the two resultsets are identical.
 
 
 Using some integers sequence data and some pretty formatting:

--- a/knowledgebase/compare_resultsets.mdx
+++ b/knowledgebase/compare_resultsets.mdx
@@ -37,7 +37,7 @@ WITH
     ) AS q2_resultset_hash
 SELECT equals(q1_resultset_hash,q2_resultset_hash) as Q1_equals_Q2
 ```
-The example uses a [CTE](https://clickhouse.com/docs/sql-reference/statements/select/with) to calculate sums of the [cityHash](https://clickhouse.com/docs/sql-reference/functions/hash-functions#cityHash64) value of each row in these two queries and will return `1` if the two resultsets are identical.
+The example uses a [CTE](/sql-reference/statements/select/with) to calculate sums of the [cityHash](/sql-reference/functions/hash-functions#cityHash64) value of each row in these two queries and will return `1` if the two resultsets are identical.
 
 
 Using some integers sequence data and some pretty formatting:

--- a/knowledgebase/finding_expensive_queries_by_memory_usage.mdx
+++ b/knowledgebase/finding_expensive_queries_by_memory_usage.mdx
@@ -52,7 +52,7 @@ The response looks like:
 ```
 
 :::note
-If you do not have a `system.query_log` table, then you likely do not have query logging enabled. View the details of the [`query_log` setting](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#server_configuration_parameters-query-log) for details on how to enable it.
+If you do not have a `system.query_log` table, then you likely do not have query logging enabled. View the details of the [`query_log` setting](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#query_log) for details on how to enable it.
 :::
 
 If you do not have a cluster, use can just query your one `system.query_log` table directly:

--- a/knowledgebase/finding_expensive_queries_by_memory_usage.mdx
+++ b/knowledgebase/finding_expensive_queries_by_memory_usage.mdx
@@ -52,7 +52,7 @@ The response looks like:
 ```
 
 :::note
-If you do not have a `system.query_log` table, then you likely do not have query logging enabled. View the details of the [`query_log` setting](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#query_log) for details on how to enable it.
+If you do not have a `system.query_log` table, then you likely do not have query logging enabled. View the details of the [`query_log` setting](/operations/server-configuration-parameters/settings#query_log) for details on how to enable it.
 :::
 
 If you do not have a cluster, use can just query your one `system.query_log` table directly:

--- a/knowledgebase/how-to-increase-thread-pool-size.mdx
+++ b/knowledgebase/how-to-increase-thread-pool-size.mdx
@@ -31,4 +31,4 @@ You can also free up resources if your server has a lot of idle threads - using 
 <max_thread_pool_free_size>2000</max_thread_pool_free_size>
 ```
 
-Check out the [docs](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#max_thread_pool_size) for more details on the settings above and other settings that affect the Global Thread pool.
+Check out the [docs](/operations/server-configuration-parameters/settings#max_thread_pool_size) for more details on the settings above and other settings that affect the Global Thread pool.

--- a/knowledgebase/how-to-increase-thread-pool-size.mdx
+++ b/knowledgebase/how-to-increase-thread-pool-size.mdx
@@ -31,4 +31,4 @@ You can also free up resources if your server has a lot of idle threads - using 
 <max_thread_pool_free_size>2000</max_thread_pool_free_size>
 ```
 
-Check out the [docs](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#max-thread-pool-size) for more details on the settings above and other settings that affect the Global Thread pool.
+Check out the [docs](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#max_thread_pool_size) for more details on the settings above and other settings that affect the Global Thread pool.

--- a/knowledgebase/importing-geojason-with-nested-object-array.mdx
+++ b/knowledgebase/importing-geojason-with-nested-object-array.mdx
@@ -174,7 +174,7 @@ ARRAY JOIN features
 ```
 
 It can be fixed by casting `multipolygon.properties.coordinates` to `Array(Array(Array(Tuple(Float64,Float64))))`.
-To do so, we can use the function [arrayMap(func,arr1,...)](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayMap).
+To do so, we can use the function [arrayMap(func,arr1,...)](/sql-reference/functions/array-functions#arrayMap).
 
 ```sql
 SELECT distinct

--- a/knowledgebase/importing-geojason-with-nested-object-array.mdx
+++ b/knowledgebase/importing-geojason-with-nested-object-array.mdx
@@ -174,7 +174,7 @@ ARRAY JOIN features
 ```
 
 It can be fixed by casting `multipolygon.properties.coordinates` to `Array(Array(Array(Tuple(Float64,Float64))))`.
-To do so, we can use the function [arrayMap(func,arr1,...)](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraymapfunc-arr1-).
+To do so, we can use the function [arrayMap(func,arr1,...)](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayMap).
 
 ```sql
 SELECT distinct


### PR DESCRIPTION
## Summary

A broken-link sweep of the upcoming Mintlify-rendered docs surfaced ~30 link fragments that point at anchors that never existed on the target heading. All of them are author typos in source content (verified against each target heading's explicit `{#id}` ID); none are caused by Docusaurus → Mintlify slugifier divergence.

Three patterns are involved:

- **Docusaurus-namespaced prefixes that were never valid IDs.** Links use `#server_configuration_parameters-user_files_path`, `#server_configuration_parameters-logger`, `#server_configuration_parameters-openssl`, `#server_configuration_parameters-query-log`, and `#settings-max_threads` / `#settings-max_insert_block_size`. The corresponding target headings are plain `## user_files_path {#user_files_path}`, `## logger {#logger}`, `## openSSL {#openssl}`, `## query_log {#query_log}`, `## max_threads {#max_threads}`, `## max_insert_block_size {#max_insert_block_size}`.
- **Hyphens where the setting ID uses underscores.** Links use `#parts-to-delay-insert`, `#parts-to-throw-insert`, `#min-insert-block-size-rows`, `#min-insert-block-size-bytes`, `#max-thread-pool-size`. The actual heading IDs are underscore form (`#parts_to_delay_insert`, etc.).
- **Wrong case on function-name anchors.** `#cityhash64` → `#cityHash64`; the malformed `#arraymapfunc-arr1-` → `#arrayMap`.

## Files changed

- `docs/guides/best-practices/sparse-primary-indexes.md`
- `docs/guides/sre/tls/configuring-tls.md`
- `docs/integrations/language-clients/rust.md`
- `knowledgebase/Insert_select_settings_tuning.mdx`
- `knowledgebase/async_vs_optimize_read_in_order.mdx`
- `knowledgebase/compare_resultsets.mdx`
- `knowledgebase/finding_expensive_queries_by_memory_usage.mdx`
- `knowledgebase/how-to-increase-thread-pool-size.mdx`
- `knowledgebase/importing-geojason-with-nested-object-array.mdx`

## Test plan

- [ ] Each rewritten anchor matches an `{#id}` on the linked target page (verified by grep against `docs/operations/settings/*.md`, `docs/operations/server-configuration-parameters/settings.md`, `docs/sql-reference/functions/hash-functions.md`, `docs/sql-reference/functions/array-functions.md`).
- [ ] No other instances of these typo patterns remain in `docs/` or `knowledgebase/` (broad grep, see commit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and anchor updates with no impact on application code, security, or data handling.
> 
> **Overview**
> This PR fixes **broken in-page link fragments** across guides and knowledge base articles so anchors match the real `{#id}` values on target docs (for Mintlify / post–Docusaurus cleanup).
> 
> **Anchor fixes:** Docusaurus-style prefixes like `#server_configuration_parameters-user_files_path`, `#server_configuration_parameters-logger`, `#settings-max_insert_block_size`, and `#settings-max_threads` are replaced with the actual IDs (e.g. `#user_files_path`, `#logger`, `#max_insert_block_size`, `#max_threads`). Hyphenated setting fragments (`#parts-to-delay-insert`, `#min-insert-block-size-rows`, `#max-thread-pool-size`, etc.) are corrected to underscore forms (`#parts_to_delay_insert`, …). Function links are fixed for case and slug (`#cityhash64` → `#cityHash64`, malformed `#arraymapfunc-arr1-` → `#arrayMap`).
> 
> **Link style:** Several `https://clickhouse.com/docs/...` URLs are switched to **site-relative** paths with the corrected fragments (e.g. Rust client `max_insert_block_size`, TLS guide OpenSSL section as `/operations/server-configuration-parameters/settings/#openssl`).
> 
> **Scope:** Nine files under `docs/guides/`, `docs/integrations/`, and `knowledgebase/`—documentation-only; no runtime or config behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c60430a95b80b0c83d9716b42025b33e5d61f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->