### PR TITLE
Reworked "upgrades" section of the Managed Postgres docs for Beta

### DIFF
--- a/docs/cloud/managed-postgres/upgrades.md
+++ b/docs/cloud/managed-postgres/upgrades.md
@@ -35,4 +35,4 @@ For Enterprise Tier organizations, Managed Postgres supports maintenance windows
 ## Major version upgrades {#major-version-upgrades}
 
 Major version upgrades (e.g., 17.x to 18.x) via UI and API are coming soon.
-In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
+In the meantime, contact [support](https://clickhouse.com/support/program) to upgrade your Managed Postgres instance.

--- a/docs/cloud/managed-postgres/upgrades.md
+++ b/docs/cloud/managed-postgres/upgrades.md
@@ -30,9 +30,9 @@ For instances with [standbys](/cloud/managed-postgres/high-availability) enabled
 Default maintenance window is 14:00 to 16:00 UTC on Sunday.
 Expected downtime is less than 1 minute within the window.
 
-For the Enterprise Tier organizations, Managed Postgres supports maintenance windows so that upgrades and other maintenance operations can be scheduled at a time that's least disruptive to your workload. UI and API support for configuring maintenance windows are coming soon. In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
+For Enterprise Tier organizations, Managed Postgres supports maintenance windows so that upgrades and other maintenance operations can be scheduled at a time that's least disruptive to your workload. UI and API support for configuring maintenance windows is coming soon. In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
 
 ## Major version upgrades {#major-version-upgrades}
 
-Major version upgrades (e.g., 17.x to 18.x) via UI and API is coming soon.
+Major version upgrades (e.g., 17.x to 18.x) via UI and API are coming soon.
 In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.

--- a/docs/cloud/managed-postgres/upgrades.md
+++ b/docs/cloud/managed-postgres/upgrades.md
@@ -13,16 +13,26 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 Managed Postgres handles PostgreSQL version upgrades to keep your instances secure and up to date. Both minor and major version upgrades are supported with minimal disruption.
 
-## Minor version upgrades {#minor-version-upgrades}
+## Maintenance updates {#maintenance-updates}
 
-Minor version upgrades (e.g., 16.4 to 16.5) include bug fixes and security patches. These are performed via failover and typically result in only a brief disconnect, often lasting just a few seconds.
+Regular maintenance in the PostgreSQL instances includes the following:
+
+-   Minor version upgrades (e.g., 17.4 to 17.5) include bug fixes and PostgreSQL engine security patches.
+-   Managed Service features. Improvements to native CDC, observability, pg_clickhouse, and other extensions.
+-   Operating system and system components patches. Including security fixes, efficiency, and other improvements.
+
+These are performed via failover and typically result in only a brief disconnect, often lasting just a few seconds.
 
 For instances with [standbys](/cloud/managed-postgres/high-availability) enabled, the upgrade is applied to the standby first, followed by a failover to minimize downtime.
 
-## Major version upgrades {#major-version-upgrades}
-
-Major version upgrades (e.g., 16.x to 17.x) also involve only a few seconds of downtime, following a similar failover-based approach.
-
 ## Maintenance windows {#maintenance-windows}
 
-Managed Postgres supports maintenance windows so that upgrades and other maintenance operations can be scheduled at a time that's least disruptive to your workload. UI support for configuring maintenance windows is coming soon. In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
+Default maintenance window is 14:00 to 16:00 UTC on Sunday.
+Expected downtime is less than 1 minute within the window.
+
+For the Enterprise Tier organizations, Managed Postgres supports maintenance windows so that upgrades and other maintenance operations can be scheduled at a time that's least disruptive to your workload. UI and API support for configuring maintenance windows are coming soon. In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
+
+## Major version upgrades {#major-version-upgrades}
+
+Major version upgrades (e.g., 17.x to 18.x) via UI and API is coming soon.
+In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.


### PR DESCRIPTION
## Summary
Reworked "upgrades" section of the Managed Postgres docs for Beta

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the upgrades guide with no application or infrastructure code impact.
> 
> **Overview**
> Restructures the Managed Postgres **upgrades** guide for beta by replacing the old **minor version upgrades** section with a broader **maintenance updates** section that covers minor PG bumps, managed-service feature rollouts, and OS/system patches, still described as failover-based with brief downtime and standby-first behavior.
> 
> Documents a **default maintenance window** (Sunday 14:00–16:00 UTC, under 1 minute expected downtime) and limits **custom maintenance windows** to **Enterprise** tier, noting upcoming UI/API while support handles setup today.
> 
> Moves **major version upgrades** to the end of the page: examples updated to 17.x→18.x, UI/API marked coming soon, and upgrades directed to support instead of implying the same automatic failover flow as maintenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3de52136825b71be8d66dc65e365d557028edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->