### PR TITLE
Wire BetaBadge tracking and drop inaccurate fallback disclaimer on Postgres pricing

### DIFF
--- a/docs/cloud/managed-postgres/pricing.md
+++ b/docs/cloud/managed-postgres/pricing.md
@@ -9,7 +9,7 @@ doc_type: 'reference'
 
 import BetaBadge from '@theme/badges/BetaBadge';
 
-<BetaBadge/>
+<BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.pricing-beta" />
 
 Postgres managed by ClickHouse is built on local NVMe storage, which allows it to offer production-grade performance and native ClickHouse integration without the pricing overhead of traditional network-attached storage architectures. This page covers the pricing model, available instance types, and tier comparison for the service.
 
@@ -127,5 +127,4 @@ As the product evolves during Beta, pricing and packaging may be refined ahead o
 - Additional backup charges may apply at GA for retention periods beyond a limit that is still being defined.
 - We expect Native CDC via ClickPipes to remain free or minimally priced at GA when Postgres and ClickHouse are colocated in the same region, aligning with the vision of a unified OLTP + OLAP platform.
 - Scaling, failover, and standby provisioning briefly run two instances in parallel to keep your database online — you may see overlapping charges for both instances while the transition completes. The duration of this window varies based on instance type and storage volume.
-- When your selected instance type is temporarily unavailable in the chosen region, we may provision a comparable instance type to keep your database online. You will be billed at the rate of the provisioned instance.
 - Existing pricing may evolve and be subject to change closer to GA as we learn more about real-world customer usage patterns, workload characteristics, and infrastructure requirements during the Beta period.


### PR DESCRIPTION
## Summary
- Wire the BetaBadge on the Managed Postgres pricing page with `link`, `galaxyTrack`, and `galaxyEvent` props so the badge becomes a tracked CTA to `clickhouse.com/cloud/postgres`.
- Drop the instance-fallback disclaimer bullet that was inadvertently merged in #6282 — the described behavior (provisioning a comparable instance type when the selected one is unavailable, and billing at the provisioned rate) does not accurately reflect how Managed Postgres handles capacity constraints today.

## Test plan
- [ ] Confirm the BetaBadge renders as a clickable link to `https://clickhouse.com/cloud/postgres` and fires the `docs.managed-postgres.pricing-beta` Galaxy event on click.
- [ ] Confirm the Disclaimers section on the Managed Postgres pricing page no longer contains the instance-fallback bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: badge props and removal of one disclaimer bullet; no product or security code changes.
> 
> **Overview**
> On the **Managed Postgres pricing** doc, the top **BetaBadge** is now a tracked CTA: it links to `https://clickhouse.com/cloud/postgres` and records Galaxy event `docs.managed-postgres.pricing-beta` on click (same pattern as other Managed Postgres pages).
> 
> The **Disclaimers** section drops the bullet that said unavailable instance types could be replaced with a comparable type and billed at the provisioned rate, because that behavior does not match current product handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7603b81542fb3921ddbd11c45655f4ff92c634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->