### PR TITLE
Update Managed postgres settings page for Beta.

### DIFF
--- a/docs/cloud/managed-postgres/scaling.md
+++ b/docs/cloud/managed-postgres/scaling.md
@@ -36,6 +36,10 @@ Different workloads benefit from different resource configurations:
 | **Memory optimized** (large working set)          | Medium | High   | Medium  | Memory-optimized (high memory-to-CPU ratio) |
 | **Storage optimized** (large datasets, heavy I/O) | Medium | Medium | High    | Storage-optimized (high NVMe capacity)      |
 
+:::tip
+For safety reasons, you may not be able to switch to instance types whose storage is close to your current used storage capacity. Always opt for instance types with headroom over your current used capacity to avoid any issues.
+:::
+
 ## How scaling works {#how-scaling-works}
 
 When you change instance types, Managed Postgres performs a vertical scaling operation that provisions new infrastructure and migrates your database with minimal downtime.

--- a/docs/cloud/managed-postgres/security.md
+++ b/docs/cloud/managed-postgres/security.md
@@ -23,7 +23,12 @@ IP filters control which source IP addresses are permitted to connect to your Ma
 
 ### Configuring IP filters {#configuring-ip-filters}
 
-For detailed information on configuring IP filters, see the [Settings](/cloud/managed-postgres/settings#ip-filters) page.
+To configure IP filters:
+
+1. Navigate to the **Settings** tab
+2. Under **IP Filters**, click **Edit**
+3. Add IP addresses or CIDR ranges that should be allowed to connect
+4. Click **Save** to apply the changes
 
 You can specify:
 - Individual IP addresses (e.g., `203.0.113.5`)

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -38,4 +38,4 @@ To modify a parameter, select the **Edit parameters** button. Select the paramet
 
 All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
 
-Refer to https://www.postgresql.org/docs/current/runtime-config.html for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) for specific parameters support requests.
+Refer to https://www.postgresql.org/docs/current/runtime-config.html for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -17,14 +17,6 @@ import ipFilters from '@site/static/images/managed-postgres/ip-filters.png';
 
 You can modify configuration parameters and manage instance settings for your Managed Postgres instance through the **Settings** tab in the sidebar.
 
-## Changing configuration parameters {#changing-configuration}
-
-<Image img={postgresParameters} alt="Postgres parameters configuration" size="md" border/>
-
-To modify a parameter, select the **Edit parameters** button. Select the parameters you need to modify and change their values accordingly. Once you're satisfied with your changes, press the **Save Changes** button.
-
-All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
-
 ## Service actions and scaling {#service-actions}
 
 <Image img={serviceActions} alt="Service actions and scaling" size="md" border/>
@@ -35,27 +27,15 @@ The **Service actions** toolbar provides controls for managing your Managed Post
 - **Restart**: Restart the database instance (only when the instance is `Running`)
 - **Delete**: Delete the instance
 
-The **Scaling** section allows you to change the instance types of your primary and standbys to increase or decrease computing resources and storage capacity. Behind the scenes, new instances will be provisioned and then take over after they've caught up with the current primary. The failover process will interrupt all current connections and lead to brief downtime.
+The **Scaling** section allows you to change the instance types of your primary and standbys to increase or decrease computing resources and storage capacity. 
+See [scaling page](/cloud/managed-postgres/scaling) for more details.
 
-:::tip
-For safety reasons, you may not be able to switch to instance types whose storage is close to your current used storage capacity. Always opt for instance types with headroom over your current used capacity to avoid any issues.
-:::
+## Changing configuration parameters {#changing-configuration}
 
-## IP filters {#ip-filters}
+<Image img={postgresParameters} alt="Postgres parameters configuration" size="md" border/>
 
-IP filters control which source IP addresses are permitted to connect to your Managed Postgres instance.
+To modify a parameter, select the **Edit parameters** button. Select the parameters you need to modify and change their values accordingly. Once you're satisfied with your changes, press the **Save Changes** button.
 
-<Image img={ipFilters} alt="IP Access List configuration" size="md" border/>
+All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
 
-To configure IP filters:
-
-1. Navigate to the **Settings** tab
-2. Under **IP Filters**, click **Edit**
-3. Add IP addresses or CIDR ranges that should be allowed to connect
-4. Click **Save** to apply the changes
-
-You can specify individual IP addresses or use CIDR notation for IP ranges (e.g., `192.168.1.0/24`). You can also select **Anywhere** or **Nowhere** as a shortcut for fully opening or closing the instance to the world.
-
-:::note
-If no IP filters are configured, connections from all IP addresses are permitted. For production workloads, we recommend restricting access to known IP addresses.
-:::
+Refer to https://www.postgresql.org/docs/current/runtime-config.html for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) for specific parameters support requests.

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -3,7 +3,7 @@ slug: /cloud/managed-postgres/settings
 sidebar_label: 'Settings'
 title: 'Settings'
 description: 'Configure PostgreSQL and PgBouncer parameters and manage instance settings for Managed Postgres'
-keywords: ['postgres configuration', 'postgresql settings', 'pgbouncer', 'ip filters']
+keywords: ['postgres configuration', 'postgresql settings', 'pgbouncer']
 doc_type: 'guide'
 ---
 

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -11,7 +11,6 @@ import BetaBadge from '@theme/badges/BetaBadge';
 import Image from '@theme/IdealImage';
 import postgresParameters from '@site/static/images/managed-postgres/postgres-parameters.png';
 import serviceActions from '@site/static/images/managed-postgres/service-actions.png';
-import ipFilters from '@site/static/images/managed-postgres/ip-filters.png';
 
 <BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.settings-beta" />
 

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -37,4 +37,4 @@ To modify a parameter, select the **Edit parameters** button. Select the paramet
 
 All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
 
-Refer to https://www.postgresql.org/docs/current/runtime-config.html for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.
+Refer to the official [documentation](https://www.postgresql.org/docs/current/runtime-config.html) for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.

--- a/docs/cloud/managed-postgres/settings.md
+++ b/docs/cloud/managed-postgres/settings.md
@@ -37,4 +37,4 @@ To modify a parameter, select the **Edit parameters** button. Select the paramet
 
 All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
 
-Refer to the official [documentation](https://www.postgresql.org/docs/current/runtime-config.html) for the official documentation on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.
+Refer to the official [documentation](https://www.postgresql.org/docs/current/runtime-config.html) on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.


### PR DESCRIPTION
Highlighting that scaling and IP filters already moved to separate pages

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reorganization with no product or API behavior changes.
> 
> **Overview**
> The **Settings** doc is narrowed for Beta: it now centers on **service actions** (password, restart, delete) and **Postgres/PgBouncer parameters**, with scaling described briefly and linked to the dedicated [scaling](/cloud/managed-postgres/scaling) page instead of in-page failover detail. **IP filters** and the storage headroom tip are removed from Settings so they are not duplicated elsewhere.
> 
> **Scaling** gains the storage-capacity **tip** (choose instance types with headroom) that used to live on Settings. **Security** replaces the old “see Settings for IP filters” link with the full **Edit → Save** steps and allowed address formats, so network access control is documented on the security page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872bcd5fe3e5e8fe56f861947c3c91050cc0a428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->