### PR TITLE
Add benchmark link and NVMe footnote to Managed Postgres overview

### DIFF
--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -34,7 +34,7 @@ For Postgres workloads that are primarily throttled by disk IOPS and latency, th
 
 For detailed benchmark results, see [Performance benchmarks](/docs/cloud/managed-postgres/benchmarks). 
 
-For <sup>\*</sup> see [AWS local NVMe limits for details](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
+For local NVMe limits on AWS see [Memory optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html#mo_instance-store), [Storage optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/so.html#so_instance-store), [CPU optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
 
 ## Native ClickHouse integration {#clickhouse-integration}
 

--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -32,7 +32,7 @@ Managed Postgres uses NVMe storage that is physically attached to the same serve
 
 For Postgres workloads that are primarily throttled by disk IOPS and latency, this translates to faster ingestion, quicker vacuums, lower tail latency, and more predictable performance under load.
 
-For detailed benchmark results, see [Performance benchmarks](/docs/cloud/managed-postgres/benchmarks). 
+For detailed benchmark results, see [Performance benchmarks](/cloud/managed-postgres/benchmarks). 
 
 For local NVMe limits on AWS see [Memory optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html#mo_instance-store), [Storage optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/so.html#so_instance-store), [CPU optimized](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
 

--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -27,10 +27,14 @@ Most managed Postgres services use network-attached storage like Amazon EBS, whi
 Managed Postgres uses NVMe storage that is physically attached to the same server as your database. This architectural difference delivers:
 
 - **Microsecond-level disk latency** instead of milliseconds
-- **Unlimited local IOPS** without network bottlenecks
+- **Unlimited local IOPS**<sup>[*](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store)</sup> without network bottlenecks 
 - **Up to 10x faster performance** for disk-bound workloads at the same cost
 
 For Postgres workloads that are primarily throttled by disk IOPS and latency, this translates to faster ingestion, quicker vacuums, lower tail latency, and more predictable performance under load.
+
+For detailed benchmark results, see [Performance benchmarks](/docs/cloud/managed-postgres/benchmarks). 
+
+For see [AWS local NVMe limits for details](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
 
 ## Native ClickHouse integration {#clickhouse-integration}
 

--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -27,14 +27,14 @@ Most managed Postgres services use network-attached storage like Amazon EBS, whi
 Managed Postgres uses NVMe storage that is physically attached to the same server as your database. This architectural difference delivers:
 
 - **Microsecond-level disk latency** instead of milliseconds
-- **Unlimited local IOPS**<sup>[*](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store)</sup> without network bottlenecks 
+- **Unlimited local IOPS**<sup>\*</sup> without network bottlenecks
 - **Up to 10x faster performance** for disk-bound workloads at the same cost
 
 For Postgres workloads that are primarily throttled by disk IOPS and latency, this translates to faster ingestion, quicker vacuums, lower tail latency, and more predictable performance under load.
 
 For detailed benchmark results, see [Performance benchmarks](/docs/cloud/managed-postgres/benchmarks). 
 
-For see [AWS local NVMe limits for details](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
+For <sup>\*</sup> see [AWS local NVMe limits for details](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store).
 
 ## Native ClickHouse integration {#clickhouse-integration}
 


### PR DESCRIPTION
## Summary
- Added a superscript footnote [*] on "Unlimited local IOPS" linking to the AWS EC2 instance store documentation
- Added a link to the Performance benchmarks page for readers who want detailed benchmark results
- Added a standalone line linking to AWS local NVMe limits for more details

<img width="1415" height="445" alt="image" src="https://github.com/user-attachments/assets/148afdc0-e779-4b52-80de-42e42de44e08" />



## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, security, or data-path impact.
> 
> **Overview**
> The Managed Postgres **overview** doc now qualifies the **“Unlimited local IOPS”** bullet with a footnote marker and adds reader-facing pointers instead of leaving that claim standalone.
> 
> It links to the internal **[Performance benchmarks](/cloud/managed-postgres/benchmarks)** page for detailed numbers, and adds a short line with **AWS EC2 instance store** documentation (memory-, storage-, and CPU-optimized families) so “unlimited” is understood in terms of **local NVMe limits** on AWS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f595461aed533e155c94fead180d002379feea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->