### PR TITLE
clickpipes: patch Private Preview annotation for Pub/Sub

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/pubsub/01_overview.md
+++ b/docs/integrations/data-ingestion/clickpipes/pubsub/01_overview.md
@@ -27,8 +27,8 @@ import Image from '@theme/IdealImage';
 
 # Integrating Google Pub/Sub with ClickHouse Cloud
 
-:::note Public Beta
-ClickPipes for GCP Pub/Sub is in Public Beta.
+:::note
+You can sign up for the Private Preview waitlist [here](https://clickhouse.com/cloud/clickpipes#pubsub-private-preview).
 :::
 
 Pub/Sub ClickPipes can be deployed and managed manually using the ClickPipes UI, as well as programmatically using [OpenAPI](/integrations/clickpipes/programmatic-access/openapi) and [Terraform](/integrations/clickpipes/programmatic-access/terraform).


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no product or security impact.
> 
> **Overview**
> Updates the availability callout at the top of the **GCP Pub/Sub ClickPipes** overview so it no longer states the connector is in **Public Beta**. The admonition is now a generic note that directs readers to the **Private Preview waitlist** on the ClickPipes product page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb570e98fb3837a071fce7c0927d85697b3bd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->