### PR TITLE
Unlimited local IOPS to 10x sustained IOPS limit

### DIFF
--- a/docs/cloud/managed-postgres/overview.md
+++ b/docs/cloud/managed-postgres/overview.md
@@ -27,7 +27,7 @@ Most managed Postgres services use network-attached storage like Amazon EBS, whi
 Managed Postgres uses NVMe storage that is physically attached to the same server as your database. This architectural difference delivers:
 
 - **Microsecond-level disk latency** instead of milliseconds
-- **Unlimited local IOPS**<sup>\*</sup> without network bottlenecks
+- **10x sustained IOPS limits**<sup>\*</sup> without network bottlenecks
 - **Up to 10x faster performance** for disk-bound workloads at the same cost
 
 For Postgres workloads that are primarily throttled by disk IOPS and latency, this translates to faster ingestion, quicker vacuums, lower tail latency, and more predictable performance under load.


### PR DESCRIPTION
## Summary

- Updates the NVMe IOPS bullet from "Unlimited local IOPS" to
  "10x sustained IOPS limits" for accuracy

<img width="1278" height="248" alt="image" src="https://github.com/user-attachments/assets/df30d066-cf69-48ae-a441-bd5781385a22" />



## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation wording change with no code, config, or security impact.
> 
> **Overview**
> Updates the **NVMe-powered performance** bullet list in the Managed Postgres overview so the IOPS claim matches how local instance storage actually behaves.
> 
> **Unlimited local IOPS** is replaced with **10x sustained IOPS limits** (footnote unchanged), aligning the marketing copy with sustained IOPS characteristics rather than implying unbounded IOPS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4276b86017db8b2c82161c6535f82cf4a9807c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->