### PR TITLE
doc: clarify DialTimeout and Cloud idle behavior

### DIFF
--- a/docs/integrations/language-clients/go/config-reference.md
+++ b/docs/integrations/language-clients/go/config-reference.md
@@ -101,8 +101,14 @@ GetJWT: func(ctx context.Context) (string, error) {
 
 | Option | Type | Default | DSN param | Description | Best practice | When misconfigured |
 |--------|------|---------|-----------|-------------|---------------|-------------------|
-| `DialTimeout` | `time.Duration` | `30s` | `dial_timeout` | Max time to establish a new connection. Also controls pool acquisition wait when `MaxOpenConns` is reached. | 5-10s on LAN, 15-30s on WAN/cloud. Never below 1s. | Too short: `"clickhouse: acquire conn timeout"` during congestion. Too long (> 60s): app hangs during outages. |
+| `DialTimeout` | `time.Duration` | `30s` | `dial_timeout` | Max time to establish a new connection. Also controls pool acquisition wait when `MaxOpenConns` is reached. | 5-10s on LAN, 15-30s on WAN/cloud, 1-2m if connecting to an idled ClickHouse Cloud service. Never below 1s. | Too short: `"clickhouse: acquire conn timeout"` during congestion, or connection failure before an idled Cloud service finishes waking. Too long (> 60s): app hangs during outages. |
 | `ReadTimeout` | `time.Duration` | `5m` (300s) | `read_timeout` | Max time to wait for a server response per read call. Applied per block, not entire query. Context deadline takes precedence. | 10-30s for short interactive queries; 5-30m for long analytical queries. | Too short: `"i/o timeout"` or `"read: connection reset by peer"` mid-query; server continues executing. Too long: dead connections not detected. |
+
+:::note[ClickHouse Cloud idle services]
+A ClickHouse Cloud service that has been idle is paused, and wakes on the first incoming connection. Wake-up typically takes a few tens of seconds, during which the dial blocks. If `DialTimeout` is lower than the wake time, the first query after an idle period fails with a dial timeout instead of running.
+
+Set `DialTimeout` to `1m`–`2m` for clients that may be the first to reach an idled service. The tradeoff is slower failure detection during a real outage — dials block for the full timeout before erroring — so prefer scoping the higher timeout to the first connect, or use context deadlines on individual queries to cap end-to-end latency.
+:::
 
 ---
 

--- a/docs/integrations/language-clients/go/configuration.md
+++ b/docs/integrations/language-clients/go/configuration.md
@@ -24,7 +24,7 @@ When opening a connection, an Options struct can be used to control client behav
 | `Auth` | `Auth` | — | Authentication credentials (`Database`, `Username`, `Password`). See [Authentication](#authentication). |
 | `TLS` | `*tls.Config` | `nil` | TLS configuration. A non-nil value enables TLS. See [TLS](#using-tls). |
 | `DialContext` | `func(ctx, addr) (net.Conn, error)` | — | Custom dial function to control how TCP connections are established. |
-| `DialTimeout` | `time.Duration` | `30s` | Maximum time to wait when opening a new connection. |
+| `DialTimeout` | `time.Duration` | `30s` | Maximum time to wait when opening a new connection. Raise to `1m`–`2m` when connecting to a ClickHouse Cloud service that may be idle — see [Timeouts](/integrations/language-clients/go/config-reference#timeouts). |
 | `MaxOpenConns` | `int` | `MaxIdleConns + 5` | Maximum number of connections open at any time. |
 | `MaxIdleConns` | `int` | `5` | Number of idle connections to keep in the pool. |
 | `ConnMaxLifetime` | `time.Duration` | `1h` | Maximum lifetime of a pooled connection. See [Connection pooling](#connection-pooling). |


### PR DESCRIPTION
DialTimeout with bigger value can overcome failing when talking to cloud idle instance.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Go client integration guides; no runtime or security impact.
> 
> **Overview**
> Documentation for the Go `clickhouse-go` client now explains how **`DialTimeout`** interacts with **ClickHouse Cloud idle (paused) services**, which can take tens of seconds to wake on the first connection.
> 
> In **`config-reference.md`**, the `DialTimeout` row recommends **1–2 minutes** when the target may be idled, and the failure modes call out dial timeouts during wake-up. A new admonition describes pause/wake behavior, suggests **`1m`–`2m`** for first-connect clients, and notes the tradeoff (slower outage detection) plus mitigations (scoped higher timeout, per-query context deadlines).
> 
> In **`configuration.md`**, the options table **`DialTimeout`** description points readers to the timeouts section for the same Cloud idle guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e21891796f97c44d49d6f727fed645d30e4f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->