### PR TITLE
Add note on IP allow list to automatic idling page

### DIFF
--- a/docs/cloud/features/04_automatic_scaling/05_automatic_idling.md
+++ b/docs/cloud/features/04_automatic_scaling/05_automatic_idling.md
@@ -11,6 +11,10 @@ doc_type: 'guide'
 ## Automatic idling {#automatic-idling}
 In the **Settings** page, you can also choose whether or not to allow automatic idling of your service when it is inactive for a certain duration (i.e. when the service isn't executing any user-submitted queries).  Automatic idling reduces the cost of your service, as you're not billed for compute resources when the service is paused.
 
+:::warning[Configure the IP access list for your service]
+When you create a ClickHouse Cloud service, the default setting for the IP allow list is 'Allow from anywhere.' We strongly recommend restricting access to specific IP addresses or ranges as soon as possible. Services set to `Allow from anywhere` may be periodically moved from an idle to an active state by internet crawlers and scanners that look for public IPs, which may result in unexpected costs.
+:::
+
 ### Adaptive Idling {#adaptive-idling}
  ClickHouse Cloud implements adaptive idling to prevent disruptions while optimizing cost savings. The system evaluates several conditions before transitioning a service to idle. Adaptive idling overrides the idling duration setting when any of the below listed conditions are met:
 - When the number of parts exceeds the maximum idle parts threshold (default: 10,000), the service isn't idled so that background maintenance can continue


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Adds a note that if you don't configure the IP allow list your service can still get woken up by crawlers, for instance.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, auth, or infrastructure impact.
> 
> **Overview**
> Adds a **warning** on the automatic idling guide recommending that customers restrict the **IP allow list** instead of leaving the default **Allow from anywhere**.
> 
> The note explains that public scanners and crawlers can wake an otherwise idle service, which can lead to **unexpected compute costs** even when automatic idling is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90a7041250ef9fe922eb4884ffce5a3be5bd788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->