### PR TITLE
Mark Cloud executable UDFs as public beta; note symlink restriction

### DIFF
--- a/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
+++ b/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
@@ -127,7 +127,7 @@ Now compress the file into a ZIP archive:
 zip is_business_hours.zip main.py
 ```
 
-:::warning Symlinks are not allowed
+:::warning[Symlinks are not allowed]
 ClickHouse Cloud rejects UDF archives that contain symbolic links. Make sure your ZIP bundle contains only regular files and directories — uploads with symlinks will fail validation.
 :::
 

--- a/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
+++ b/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
@@ -7,13 +7,13 @@ doc_type: 'guide'
 keywords: ['user defined function', 'UDF']
 ---
 
-import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
+import BetaBadge from '@theme/badges/BetaBadge';
 
 User-defined functions (UDF) allow users to extend the behavior of ClickHouse beyond what is offered by over a thousand different out-of-box [functions](/sql-reference/functions/regular-functions).
 
 In ClickHouse Cloud, there are two ways to create user-defined functions:
 1. Using SQL
-2. Using the UI and your own code (private preview)
+2. Using the UI and your own code (public beta)
 
 ## SQL user-defined functions {#sql-udfs}
 
@@ -60,13 +60,9 @@ This means:
 
 ## User-defined functions created via UI {#ui-udfs}
 
-<PrivatePreviewBadge/>
+<BetaBadge/>
 
 ClickHouse Cloud offers a UI configuration experience for creating user-defined functions.
-
-:::note
-If you are interested in trying out this feature, please contact [support](https://clickhouse.com/support/program) to enroll in private preview.
-:::
 
 In this example we'll create the same simple executable user-defined function `isBusinessHours` that checks if a certain timestamp falls inside of regular business hours.
 Previously we created it using SQL, but this time we will create it using Python and configure it via the UI.
@@ -130,6 +126,10 @@ Now compress the file into a ZIP archive:
 ```bash
 zip is_business_hours.zip main.py
 ```
+
+:::warning Symlinks are not allowed
+ClickHouse Cloud rejects UDF archives that contain symbolic links. Make sure your ZIP bundle contains only regular files and directories — uploads with symlinks will fail validation.
+:::
 
 ### Create a UDF via the UI {#create-udf-via-ui}
 

--- a/docs/cloud/guides/cloud-compatibility.md
+++ b/docs/cloud/guides/cloud-compatibility.md
@@ -80,7 +80,7 @@ Federated queries with some external database and table engines, such as SQLite,
 
 ### User defined functions {#user-defined-functions}
 
-User-defined functions in ClickHouse Cloud are in [private preview](https://clickhouse.com/docs/sql-reference/functions/udf).
+User-defined functions in ClickHouse Cloud are in [public beta](https://clickhouse.com/docs/sql-reference/functions/udf).
 
 #### Settings behavior {#udf-settings-behavior}
 


### PR DESCRIPTION
## Summary
- Updates the Cloud user-defined functions page (`docs/cloud/features/03_sql_console_features/05_user_defined_functions.md`) and the cloud-compatibility guide (`docs/cloud/guides/cloud-compatibility.md`) to reflect that executable UDFs in ClickHouse Cloud have graduated from **private preview** to **public beta**.
- Swaps the `PrivatePreviewBadge` for the `BetaBadge` on the UI-based UDF section, and drops the "contact support to enroll in private preview" note since the feature is no longer gated.
- Adds a warning callout near the ZIP bundling step noting that ClickHouse Cloud rejects UDF archives containing symbolic links.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documentation now states that **executable / UI-based user-defined functions** in ClickHouse Cloud are in **public beta** instead of private preview.
> 
> The UDF guide swaps `PrivatePreviewBadge` for `BetaBadge`, updates the intro bullet to “public beta”, and removes the callout to contact support for private preview enrollment. The **cloud compatibility** guide updates the same lifecycle wording and link text.
> 
> A new **warning** on the ZIP bundling step documents that Cloud **rejects UDF archives containing symbolic links** and that uploads with symlinks fail validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bee4770a32163b834192973277dd7441d3d2a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->