### PR TITLE
Cloud changelog: Week of 2026-06-01 (Agent generated)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,48 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## May 28, 2026 {#2026-05-28}
+
+### ClickStack Cloud private preview {#clickstack-cloud}
+
+ClickStack Cloud is a fully managed, serverless observability platform built on ClickHouse Cloud. Teams can send OpenTelemetry data to a managed endpoint and immediately explore logs, metrics, and traces without operating observability infrastructure. Available in private preview on AWS us-east-1. Read the [blog post](https://clickhouse.com/blog/clickstack-cloud-private-preview) for more details and join the [waitlist](https://clickhouse.com/cloud/clickstack-cloud-waitlist) for access.
+
+### AI Notebooks for Managed ClickStack (beta) {#ai-notebooks-clickstack}
+
+AI Notebooks are now available in beta for Managed ClickStack, providing SREs and engineering teams with persistent, transparent workspaces for AI-assisted incident investigation. Notebooks support structured sequences of prompts, queries, charts, reasoning steps, and findings with branching workflows for exploring multiple hypotheses. See the [documentation](/use-cases/observability/clickstack/notebooks) for more details.
+
+### ClickStack MCP Server {#clickstack-mcp-server}
+
+The new open-source ClickStack MCP Server gives external AI agents structured observability investigation tools built on ClickStack and ClickHouse. It exposes semantic investigation primitives for logs, metrics, and traces as well as bi-directional orchestration primitives for creating dashboards, persisting searches, and alerts. See the [documentation](/use-cases/observability/clickstack/mcp) and the [blog post](https://clickhouse.com/blog/observability-mcp-server-ai-notebooks#clickstack-mcp-server) for more details.
+
+## May 27, 2026 {#2026-05-27}
+
+### Executable UDFs (public beta) {#executable-udfs}
+
+Executable UDFs are now in public beta on ClickHouse Cloud. You can write a function in Python, upload it to your cluster, and call it from SQL like any built-in function. ClickHouse runs a pool of long-lived sandboxed processes and pipes rows through them at query speed, so you can use your function anywhere SQL works — ad-hoc queries, joins, and even materialized views that fire on every insert. Read the [announcement blog](https://clickhouse.com/blog/executable-udfs-clickhouse-cloud-beta) for more details.
+
+### ClickPipes runs natively on GCP {#clickpipes-gcp-native}
+
+ClickPipes infrastructure now runs natively on GCP for all new ClickHouse Cloud services hosted on GCP (created after May 26), including support for Private Service Connect (PSC). This eliminates cross-cloud egress costs, enables GCP-native private networking, reduces latency, and provides data locality guarantees. See the [list of supported GCP regions](/integrations/clickpipes#list-of-static-ips).
+
+### ClickPipes for GCP Pub/Sub (private preview) {#clickpipes-pubsub}
+
+ClickPipes now supports streaming data from GCP Pub/Sub topics directly into ClickHouse Cloud. Available in private preview — [sign up](https://clickhouse.com/cloud/clickpipes#pubsub-private-preview) for access. See the [documentation](/integrations/clickpipes/pubsub) for more details.
+
+### ClickHouse Agents — agentic analytics (public beta) {#clickhouse-agents}
+
+ClickHouse Agents is now in public beta — a first-party agentic analytics surface powered by Claude that lets users build, run, and orchestrate agents against their ClickHouse data. Features include schema-aware conversational analysis, AgentBuilder with MCP support, subagent topologies, and code generation. Available at [ai.clickhouse.cloud](https://ai.clickhouse.cloud).
+
+### ClickHouse Postgres (public beta) {#clickhouse-postgres}
+
+Fully managed Postgres on local NVMe storage is now in public beta, delivering 5x+ more TPS than AWS RDS. A native CDC pipeline streams data directly into ClickHouse with no intermediate infrastructure. The open-source pg_clickhouse extension lets developers query ClickHouse tables from standard Postgres sessions. Read the [blog post](https://clickhouse.com/blog/postgres-managed-by-clickhouse-beta) for more details.
+
+## May 26, 2026 {#2026-05-26}
+
+### Horizontal autoscaling (private preview) {#horizontal-autoscaling}
+
+Horizontal autoscaling automatically adjusts the number of replicas in a ClickHouse Cloud cluster based on the number of concurrent queries, scaling out when demand spikes and scaling in when load drops. Available in private preview for Enterprise and Scale tier customers on ClickHouse 26.2+. Contact support with your organization ID to enable.
+
 ## May 25, 2026 {#2026-05-25}
 
 ### GA release of organization spend alerts {#spend-alerts-ga}


### PR DESCRIPTION
## Summary

This PR adds Cloud changelog entries for the week of May 26 – June 1, 2026, sourced from the #shipped Slack channel.

### Included changes

**May 28, 2026:**
- **ClickStack Cloud** — Private preview of fully managed serverless observability on ClickHouse Cloud
- **AI Notebooks for Managed ClickStack** — Beta: persistent AI-assisted investigation workspaces
- **ClickStack MCP Server** — OSS release of structured observability tools for external AI agents

**May 27, 2026:**
- **Executable UDFs** — Public beta: write Python functions, call them from SQL
- **ClickPipes runs natively on GCP** — GA with Private Service Connect support
- **ClickPipes for GCP Pub/Sub** — Private preview
- **ClickHouse Agents** — Public beta: Claude-powered agentic analytics at ai.clickhouse.cloud
- **ClickHouse Postgres** — Public beta: fully managed Postgres with native CDC to ClickHouse

**May 26, 2026:**
- **Horizontal Autoscaling** — Private preview for Enterprise and Scale tier customers

### Needs review

- **Open House 2026 announcements** (posted by karolina.ruiz.rogelj): A set of features were *announced* at Open House but explicitly marked as **not yet generally available** (Cross-Region Replication, Monitoring v2, MV Pipeline Visualization, Schema Management, ClickHouse CLI, Query API Endpoints, AI-Enhanced Query Builder, MCP-as-a-Service). These were excluded from the changelog since they are not shipped yet. Please add any that should be included.
- **Executable UDFs**: The #shipped post was made on June 1 but the feature was announced at Open House (May 27). Grouped under May 27. Adjust the date if needed.
- **Network-access UDFs** were mentioned as a private beta alongside Executable UDFs but not broken out separately. Add if warranted.

---
*This PR was generated automatically by the Cloud changelog bot.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog additions with no runtime or configuration impact.
> 
> **Overview**
> Adds three new dated sections at the top of the **2026 Cloud changelog** (`2026.md`), ahead of the existing May 25 entry.
> 
> **May 28** documents ClickStack Cloud (private preview), AI Notebooks for Managed ClickStack (beta), and the open-source ClickStack MCP Server.
> 
> **May 27** covers Executable UDFs (public beta), native GCP ClickPipes with PSC, ClickPipes for GCP Pub/Sub (private preview), ClickHouse Agents (public beta), and ClickHouse Postgres (public beta).
> 
> **May 26** adds horizontal autoscaling (private preview) for Enterprise/Scale on ClickHouse 26.2+.
> 
> Each item follows the existing changelog pattern: heading anchors, short product description, and links to blogs, docs, or waitlists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42415ae0ad07e0f06ca838d55944a59e5cf1e89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->