### PR TITLE
Document schema registry connectivity over private endpoints

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
+++ b/docs/integrations/data-ingestion/clickpipes/aws-privatelink.md
@@ -36,6 +36,10 @@ data source types:
 - MySQL
 - MongoDB
 
+:::note
+For Kafka, the [schema registry](/integrations/clickpipes/kafka/schema-registries) can be reached over the same reverse private endpoint as the brokers — it does not need to be publicly accessible — provided its hostname resolves to the endpoint's private IP addresses.
+:::
+
 ## Supported AWS PrivateLink endpoint types {#aws-privatelink-endpoint-types}
 
 ClickPipes reverse private endpoint can be configured with one of the following AWS PrivateLink approaches:

--- a/docs/integrations/data-ingestion/clickpipes/kafka/02_schema-registries.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/02_schema-registries.md
@@ -32,6 +32,17 @@ To integrate with a schema registry during ClickPipes configuration, you must us
 2. Provide a complete path to the schema ID (e.g. `https://registry.example.com/schemas/ids/1000`)
 3. Provide the root schema registry URL (e.g. `https://registry.example.com`)
 
+## Network connectivity {#network-connectivity}
+
+ClickPipes connects to the schema registry over HTTPS at the URL you provide. The schema registry does not need to be publicly accessible.
+
+If your Kafka brokers are reached through a [reverse private endpoint](/integrations/clickpipes/aws-privatelink) (AWS PrivateLink or GCP Private Service Connect), the schema registry can use the same private connectivity. ClickPipes resolves the registry hostname through the reverse private endpoint's private DNS, so a registry hosted privately alongside your brokers is reachable as long as its hostname resolves to the reverse private endpoint's private IP addresses (via the endpoint's private DNS support or a custom private DNS mapping).
+
+Keep the following in mind:
+
+- The schema registry URL must use `https://`.
+- If the registry hostname resolves to a private address, it must be reachable through a reverse private endpoint selected for the ClickPipe; otherwise the connectivity check during setup will fail.
+
 ## How it works {#how-schema-registries-work}
 
 ClickPipes dynamically retrieves and applies the schema from the configured schema registry.


### PR DESCRIPTION
## Summary

Clarifies that a Kafka ClickPipe's schema registry can be reached over the same reverse private endpoint (AWS PrivateLink / GCP PSC) as the brokers, and does not need to be publicly accessible. This is currently supported but undocumented, which leads customers to assume private schema registries are unsupported.

## What changed

- `kafka/02_schema-registries.md` — adds a **Network connectivity** section (reached over HTTPS, not public-only, resolves via the reverse private endpoint's private DNS / a custom private DNS mapping, https:// requirement).
- `aws-privatelink.md` — adds a note under *Supported data sources* cross-linking to the schema registries page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents that Kafka ClickPipes can reach a **schema registry** over the same **reverse private endpoint** as brokers (AWS PrivateLink / GCP PSC), so it does not need to be public.
> 
> Adds a **Network connectivity** section on the schema registries page (HTTPS, private DNS / custom mapping, `https://` requirement, setup connectivity check). Adds a cross-linked note under supported data sources on the AWS PrivateLink page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15809e880b9b1f38637def471a50bbe4f0b554a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->