### PR TITLE
fix typo

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/02_clickhouse-private.md
@@ -24,7 +24,7 @@ The following features differentiate ClickHouse Private from self-managed open s
 - Native separation of compute and storage
 - Proprietary cloud features such as [shared merge tree](/cloud/reference/shared-merge-tree) and [warehouse](/cloud/reference/warehouses) functionality
 - ClickHouse database and operator versions fully tested and validated in ClickHouse Cloud
-- API for prgrammatic operations, including backups and scaling operations
+- API for programmatic operations, including backups and scaling operations
 
 ## Architecture {#architecture}
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fix typo

## Checklist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spelling fix with no runtime or behavioral impact.
> 
> **Overview**
> Corrects a spelling error in the **ClickHouse Private** deployment options doc: the benefits bullet now reads **programmatic** instead of **prgrammatic** for API operations (backups and scaling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 582ff79350f4c1bf4ed10e154023d683cc8e39df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->