### PR TITLE
docs: clarify Data Sources tab permission requirement for custom roles

### DIFF
--- a/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
@@ -57,6 +57,10 @@ Click the `Allow` button and select from Organization, Service, and/or Database 
 Ensure users who will log into the console have a minimum of Organization > Access organization permissions.
 :::
 
+:::note ClickPipes / Data Sources access
+To grant access to the **Data Sources** tab (used for ClickPipes, data lake integrations, and file uploads), the role must include `Manage and Delete Selected Services` in addition to any ClickPipes-specific permissions.
+:::
+
 <Image img={step_5} size="md"/>
 
 ### Review your new role {#review-role}

--- a/docs/cloud/reference/09_security/01_console-roles.md
+++ b/docs/cloud/reference/09_security/01_console-roles.md
@@ -84,3 +84,7 @@ The table below describes the ClickHouse console and SQL console permissions. Mo
 | control-plane:service:manage-clickstack-api | Manage ClickStack API access and related integrations. |
 | **SQL console role mapping** ([more info](/cloud/guides/sql-console/manage-sql-console-role-assignments)) | Manage SQL console role assignments |
 | sql-console:database:access | Passwordless access to the database via SQL console (may only be used with sql-console-admin or sql-console-readonly) |
+
+:::note Data Sources tab visibility
+Granting `control-plane:service:manage-clickpipes` alone doesn't make the **Data Sources** tab visible in the console. The Data Sources tab is gated on `control-plane:service:manage` (the "Manage and Delete Selected Services" permission), so custom roles intended to manage ClickPipes must include both permissions.
+:::


### PR DESCRIPTION
## What

Adds two `:::note` admonitions clarifying that the **Data Sources** tab in the ClickHouse Cloud console is gated on `control-plane:service:manage` ("Manage and Delete Selected Services" in the UI), not on `control-plane:service:manage-clickpipes`.

Custom roles built with only the ClickPipes permission won't see the Data Sources tab, which covers ClickPipes, data lake integrations, and file uploads.

## Changes

- `docs/cloud/reference/09_security/01_console-roles.md` — note after the Console Permissions table.
- `docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md` — note inside the permission-scope step, beside the existing `:::tip`.

## Notes for reviewers

- This describes current RBAC behavior, which is a known gap engineering is tracking (RBAC review pending). The copy avoids committing to a specific future change.
- ⚠️ **Please verify before merge:** the exact UI label `"Manage and Delete Selected Services"` could not be confirmed from the repo (not present in docs text; the permission-picker screenshot only shows top-level categories). Confirm against the live console.
- The reference-page note was placed *after* the table rather than mid-table (the requested line 79 is between rows) to avoid breaking Docusaurus table rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security behavior impact.
> 
> **Overview**
> Documents that the Cloud console **Data Sources** tab (ClickPipes, data lake integrations, file uploads) requires **`control-plane:service:manage`** (“Manage and Delete Selected Services”), not ClickPipes-only permissions.
> 
> Adds matching `:::note` blocks in the **custom roles** guide (permission-scope step) and **Console roles and permissions** reference (after the permissions table), so admins building roles with only `manage-clickpipes` know why the tab stays hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5c734d6fdd7d4760ccff0db5d2ca890c1ab677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->