### PR TITLE
Adding callout for permissions requirements

### DIFF
--- a/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
@@ -57,7 +57,7 @@ Click the `Allow` button and select from Organization, Service, and/or Database 
 Ensure users who will log into the console have a minimum of Organization > Access organization permissions.
 :::
 
-:::note Data Sources tab access
+:::note[Data Sources tab access]
 To access the **Data Sources** tab, the role currently requires the `Manage and Delete Selected Services` permission.
 :::
 

--- a/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/03_manage-custom-roles.md
@@ -57,6 +57,10 @@ Click the `Allow` button and select from Organization, Service, and/or Database 
 Ensure users who will log into the console have a minimum of Organization > Access organization permissions.
 :::
 
+:::note Data Sources tab access
+To access the **Data Sources** tab, the role currently requires the `Manage and Delete Selected Services` permission.
+:::
+
 <Image img={step_5} size="md"/>
 
 ### Review your new role {#review-role}

--- a/docs/cloud/guides/security/05_audit_logging/03_byoc-security-playbook.md
+++ b/docs/cloud/guides/security/05_audit_logging/03_byoc-security-playbook.md
@@ -27,7 +27,7 @@ FROM clusterAllReplicas('default',system.crash_log)
 
 ClickHouse utilizes pre-created roles to enable system functions. This section assumes the customer is using AWS with CloudTrail and has access to the CloudTrail logs.
 
-If an incident may be the result of a compromised role, review activities in CloudTrail and CloudWatch related to the ClickHouse IAM roles and actions. Refer to the [CloudFormation](/cloud/reference/byoc/reference/privilege#cloudformation-iam-roles) stack or Terraform module provided as part of setup for a list of IAM roles.
+If an incident may be the result of a compromised role, review activities in CloudTrail and CloudWatch related to the ClickHouse IAM roles and actions. Refer to the [CloudFormation](/cloud/reference/byoc/reference/privilege#aws-iam-roles) stack or Terraform module provided as part of setup for a list of IAM roles.
 
 ## Unauthorized access to EKS cluster {#unauthorized-access-eks-cluster}
 

--- a/docs/cloud/reference/09_security/01_console-roles.md
+++ b/docs/cloud/reference/09_security/01_console-roles.md
@@ -76,7 +76,7 @@ The table below describes the ClickHouse console and SQL console permissions. Mo
 | control-plane:service:view-private-endpoints | View private endpoint configuration for a service. |
 | control-plane:service:manage-private-endpoints | Create and manage private endpoints and private networking. |
 | **ClickPipes** ([more info](/integrations/clickpipes)) | ClickPipes integration |
-| control-plane:service:manage-clickpipes | Manage ClickPipes integration and related settings. |
+| control-plane:service:manage-clickpipes | Manage ClickPipes integration and related settings. Accessing the **Data Sources** tab currently requires `control-plane:service:manage` ("Manage and Delete Selected Services"). |
 | **Scaling** ([more info](/manage/scaling)) | Scaling and autoscaling configuration |
 | control-plane:service:view-scaling-config | View scaling configuration and autoscaling settings for a service. |
 | control-plane:service:manage-scaling-config | Modify scaling configuration and trigger scaling operations. |


### PR DESCRIPTION
## Summary
Document that the Data Sources tab currently requires the Manage and Delete Selected Services permission. Also fixes a broken anchor in the BYOC security playbook.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security behavior changes.
> 
> **Overview**
> Documents that the **Data Sources** tab in the console currently needs **Manage and Delete Selected Services** (`control-plane:service:manage`), not only ClickPipes permissions.
> 
> A note was added in the custom roles guide when scoping permissions, and the ClickPipes row in the console roles reference was updated to state the same requirement.
> 
> The BYOC security playbook link to IAM role details was corrected from `#cloudformation-iam-roles` to `#aws-iam-roles`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a283e4d1dfa6aa3b3700b40277dc4fbc80b451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->