### PR TITLE
docs(notion): make Custom Agent connection steps more granular

### DIFF
--- a/docs/integrations/tools/data-integration/notion.md
+++ b/docs/integrations/tools/data-integration/notion.md
@@ -30,8 +30,8 @@ You can connect ClickHouse Cloud to a Notion [Custom Agent](https://www.notion.c
 
 ClickHouse ships as a preconfigured connection in Notion (currently in beta). No custom MCP server setup or URL pasting is required.
 
-1. In Notion, open the Custom Agent you want to extend and click **Settings**.
-2. Click **Add connection** and select **ClickHouse** from the list of available connections.
+1. In Notion, create a new Custom Agent from the **Agents** section in the sidebar.
+2. In your Agent's **Settings**, under **Tools and Access**, select **Add connection** and add **ClickHouse** from the list of available connections.
 
 <Image img={addClickHouseConnection} size="md" alt="Selecting ClickHouse in the Notion Add connection picker"/>
 


### PR DESCRIPTION
## Summary

Follow-up to #6323 addressing reviewer feedback on the Notion Custom Agent connection guide. The first two steps were a bit too terse — this expands them to be more granular about where in the Notion UI each action happens.

Before:
1. In Notion, open the Custom Agent you want to extend and click **Settings**.
2. Click **Add connection** and select **ClickHouse** from the list of available connections.

After:
1. In Notion, create a new Custom Agent from the **Agents** section in the sidebar.
2. In your Agent's **Settings**, under **Tools and Access**, select **Add connection** and add **ClickHouse** from the list of available connections.

Documentation-only change to `docs/integrations/tools/data-integration/notion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the Notion integration guide; no product or runtime behavior changes.
> 
> **Overview**
> The Notion Custom Agent connection guide now walks through **where** in the Notion UI to go, not just what to click.
> 
> Step 1 no longer assumes an existing agent (“open … and click **Settings**”); it tells readers to **create** a Custom Agent from the **Agents** sidebar section. Step 2 names **Settings → Tools and Access → Add connection** before picking **ClickHouse**. OAuth and tool-toggle steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa52fb369d6609bfe45385e9d1b59caa1e67708c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->