### PR TITLE
docs(managed-postgres): document slow query patterns API

### DIFF
--- a/docs/cloud/managed-postgres/monitoring/query-insights.md
+++ b/docs/cloud/managed-postgres/monitoring/query-insights.md
@@ -176,6 +176,17 @@ the time went:
 Everything you need to diagnose a slow pattern is in one place, on one
 screen.
 
+## Query insights API {#api}
+
+The same telemetry is available programmatically through the
+[ClickHouse Cloud OpenAPI](/cloud/managed-postgres/openapi#query-insights).
+The [Slow patterns](#slow-patterns) table maps to the
+[list slow query patterns](https://clickhouse.com/docs/cloud/manage/api/swagger#tag/Postgres/operation/slowQueryPatternsGetList)
+endpoint, and the [detail flyout](#detail) maps to the
+[get slow query pattern](https://clickhouse.com/docs/cloud/manage/api/swagger#tag/Postgres/operation/slowQueryPatternGet)
+endpoint, which returns one pattern's aggregate metrics together with its
+recent executions.
+
 ## How it works {#how-it-works}
 
 ### Normalized in Postgres, before the wire {#how-normalized}
@@ -217,5 +228,6 @@ ClickHouse. Source and issues live at
 
 - [Monitoring dashboard](/cloud/managed-postgres/monitoring/dashboard) — built-in resource and activity charts
 - [Prometheus endpoint](/cloud/managed-postgres/monitoring/prometheus) — scrape host-level metrics into your own observability stack
+- [Managed Postgres OpenAPI](/cloud/managed-postgres/openapi#query-insights) — query slow patterns and recent executions programmatically
 - [Extensions](/cloud/managed-postgres/extensions) — the extensions available on Managed Postgres instances
 - [`pg_stat_ch` on GitHub](https://github.com/clickhouse/pg_stat_ch) — the open-source extension that powers Query Insights

--- a/docs/cloud/managed-postgres/openapi.md
+++ b/docs/cloud/managed-postgres/openapi.md
@@ -357,6 +357,10 @@ durations reported in microseconds:
 }
 ```
 
+The `queryId` is a signed 64-bit hash of the normalized statement, so it's
+often negative. Pass it back verbatim — leading `-` and all — to fetch a
+single pattern.
+
 ### Get a slow query pattern {#get-slow-query-pattern}
 
 Pass a `queryId` from the list response to the [slow pattern API] to get that

--- a/docs/cloud/managed-postgres/openapi.md
+++ b/docs/cloud/managed-postgres/openapi.md
@@ -3,7 +3,7 @@ slug: /cloud/managed-postgres/openapi
 sidebar_label: 'OpenAPI'
 title: 'Managed Postgres OpenAPI'
 description: 'Control your Managed Postgres services with our OpenAPI'
-keywords: ['managed postgres', 'openapi', 'api', 'curl', 'tutorial', 'command line']
+keywords: ['managed postgres', 'openapi', 'api', 'curl', 'tutorial', 'command line', 'query insights', 'slow queries']
 doc_type: 'guide'
 ---
 
@@ -295,6 +295,127 @@ every service in the organization, the other for a single service. See the
 [Prometheus endpoint] page for setup and the [metrics reference] for the full
 list of metrics.
 
+## Query insights {#query-insights}
+
+The per-statement telemetry behind the [Query Insights] tab in the cloud
+console is also available programmatically. Two endpoints expose the slowest
+query patterns on a service: one lists every pattern ranked by impact, the
+other returns a single pattern with its recent executions.
+
+### List slow query patterns {#list-slow-query-patterns}
+
+The [slow patterns API] returns aggregate metrics for the slowest query
+patterns observed over a time window. The window is required — pass
+`from_date` and `to_date` as RFC 3339 timestamps:
+
+```bash
+FROM=2026-05-25T00:00:00Z
+TO=2026-05-26T00:00:00Z
+
+curl -s --user "$KEY_ID:$KEY_SECRET" \
+    "https://api.clickhouse.cloud/v1/organizations/$ORG_ID/postgres/$PG_ID/slowQueryPatterns?from_date=$FROM&to_date=$TO" \
+    | jq
+```
+
+Results default to the costliest patterns first, sorted by `total_duration`
+descending. Sort by a different counter with `sort_by` (for example
+`p99_duration`, `call_count`, or `total_wal_bytes`) and flip the direction
+with `sort_order`. Narrow the set with the `db_name`, `db_user`,
+`db_operation`, and `app` filters, and page through it with `limit` and
+`offset`.
+
+Each result is one normalized pattern, with literals stripped out and
+durations reported in microseconds:
+
+```json
+{
+  "result": [
+    {
+      "queryId": "-4748036479882663975",
+      "queryText": "SELECT * FROM orders WHERE customer_id = $1 ORDER BY created_at DESC LIMIT $2",
+      "dbName": "sales",
+      "dbUser": "orders_service",
+      "dbOperation": "SELECT",
+      "app": "orders-api",
+      "callCount": 84213,
+      "errorCount": 0,
+      "totalDurationUs": 1012384556,
+      "avgDurationUs": 12021,
+      "maxDurationUs": 482915,
+      "p50DurationUs": 9874,
+      "p95DurationUs": 28431,
+      "p99DurationUs": 41200,
+      "totalRows": 842130,
+      "totalSharedBlksRead": 19284,
+      "totalSharedBlksHit": 48217734,
+      "totalCpuTimeUs": 938472113,
+      "totalWalBytes": 0
+    }
+  ],
+  "requestId": "c128d830-5769-4c82-8235-f79aa69d1ebf",
+  "status": 200
+}
+```
+
+### Get a slow query pattern {#get-slow-query-pattern}
+
+Pass a `queryId` from the list response to the [slow pattern API] to get that
+pattern's aggregate metrics alongside its most recent individual executions.
+The `db_name`, `db_user`, and `db_operation` that identify the pattern are
+required:
+
+```bash
+QUERY_ID=-4748036479882663975
+
+curl -s --user "$KEY_ID:$KEY_SECRET" \
+    "https://api.clickhouse.cloud/v1/organizations/$ORG_ID/postgres/$PG_ID/slowQueryPatterns/$QUERY_ID?db_name=sales&db_user=orders_service&db_operation=SELECT" \
+    | jq
+```
+
+The response carries the same aggregate as the list endpoint under
+`aggregate`, plus a `recentExecutions` array. Each execution includes the
+full per-execution counters — shared and temp block I/O, CPU user and system
+time, parallel workers, JIT, and WAL — the same counters the
+[detail flyout] breaks down in the console:
+
+```json
+{
+  "result": {
+    "aggregate": {
+      "queryId": "-4748036479882663975",
+      "queryText": "SELECT * FROM orders WHERE customer_id = $1 ORDER BY created_at DESC LIMIT $2",
+      "dbName": "sales",
+      "dbUser": "orders_service",
+      "dbOperation": "SELECT",
+      "callCount": 84213,
+      "avgDurationUs": 12021,
+      "p99DurationUs": 41200
+    },
+    "recentExecutions": [
+      {
+        "timestamp": "2026-05-25T16:42:09Z",
+        "durationUs": 41200,
+        "rows": 10,
+        "sharedBlksHit": 412,
+        "sharedBlksRead": 3,
+        "tempBlksWritten": 0,
+        "cpuUserTimeUs": 38211,
+        "cpuSysTimeUs": 1044,
+        "parallelWorkersPlanned": 0,
+        "parallelWorkersLaunched": 0,
+        "walBytes": 0,
+        "serverRole": "primary"
+      }
+    ]
+  },
+  "requestId": "a5957990-dbe5-46fd-b5ce-a7f8f79e50fe",
+  "status": 200
+}
+```
+
+The example trims both objects for brevity; the API returns the complete
+counter set documented under [per-execution counters].
+
 [ClickHouse OpenAPI]: /cloud/manage/cloud-api "Cloud API"
 [OpenAPI]: https://www.openapis.org "OpenAPI Initiative"
 [API keys]: /cloud/manage/openapi "Managing API Keys"
@@ -319,3 +440,13 @@ list of metrics.
   "Managed Postgres Prometheus endpoint"
 [metrics reference]: /cloud/managed-postgres/monitoring/metrics
   "Managed Postgres metrics reference"
+[Query Insights]: /cloud/managed-postgres/monitoring/query-insights
+  "Postgres query insights"
+[detail flyout]: /cloud/managed-postgres/monitoring/query-insights#detail
+  "Query insights detail flyout"
+[per-execution counters]: /cloud/managed-postgres/monitoring/query-insights#counters
+  "Query insights per-execution counters"
+[slow patterns API]: https://clickhouse.com/docs/cloud/manage/api/swagger#tag/Postgres/operation/slowQueryPatternsGetList
+  "List Postgres slow query patterns"
+[slow pattern API]: https://clickhouse.com/docs/cloud/manage/api/swagger#tag/Postgres/operation/slowQueryPatternGet
+  "Get a Postgres slow query pattern with recent executions"


### PR DESCRIPTION
## Summary

- Document the two new Postgres slow query pattern endpoints (`slowQueryPatternsGetList`, `slowQueryPatternGet`) on the Managed Postgres OpenAPI page, with curl examples, query parameters, and representative JSON responses.
- Add a **Query insights API** section to the Query Insights monitoring page that maps the Slow patterns table and detail flyout to their API endpoints, plus a Related pages link.
- Cross-link the OpenAPI page and the Query Insights page so the concept/UI docs and the programmatic reference point at each other.

Scope is limited to the Managed Postgres service docs — no other Cloud sections or sidebar changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Managed Postgres guides; no runtime, API, or auth behavior is modified.
> 
> **Overview**
> Documents how to call **Managed Postgres slow query pattern** APIs from the same telemetry as the Query Insights console.
> 
> The **OpenAPI** guide gains a **Query insights** section with `curl` examples for listing patterns (`from_date` / `to_date`, `sort_by`, filters, paging) and fetching one pattern by `queryId` (required `db_name`, `db_user`, `db_operation`), plus sample JSON and links to Swagger operations.
> 
> The **Query insights** monitoring page adds a short **Query insights API** section mapping the Slow patterns table and detail flyout to those endpoints, and **Related pages** / frontmatter keywords are updated for cross-navigation between UI docs and the programmatic reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe4332b2ed25c92fd957972a2c488bf2a301768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->