### PR TITLE
Add June 3 2026 Cloud changelog (Open House 2026 launches)

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,64 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## June 3, 2026 {#2026-06-03}
+
+Open House 2026 week brought a wave of launches centered on running ClickHouse where your data lives and bringing agentic, AI-assisted workflows into the platform.
+
+### ClickPipes now runs natively on GCP with Private Service Connect {#clickpipes-gcp-psc}
+
+ClickPipes infrastructure now runs in the same GCP region as your ClickHouse Cloud service for all new GCP services created after May 26, including support for Private Service Connect (PSC). This removes cross-cloud egress costs, reduces latency, keeps data local, and lets you connect to GCP sources over GCP-native private networking instead of workarounds like SSH tunneling. Existing services can be migrated with help from our team.
+
+For more details, see the [ClickPipes static IP list](/integrations/clickpipes#list-of-static-ips).
+
+### ClickPipes for GCP Pub/Sub (private preview) {#clickpipes-gcp-pubsub}
+
+ClickPipes can now stream data from GCP Pub/Sub topics directly into ClickHouse Cloud, giving GCP-native teams a direct path for analytics on data from Cloud Logging, Cloud Monitoring, GKE, and more. Available via the ClickPipes UI, OpenAPI, and Terraform; [sign-up](https://clickhouse.com/cloud/clickpipes#pubsub-private-preview) is required during private preview.
+
+See the [ClickPipes for GCP Pub/Sub docs](/integrations/clickpipes/pubsub) for setup and configuration details.
+
+### ClickHouse Agents: Claude-powered agentic analytics (public beta) {#clickhouse-agents}
+
+ClickHouse Agents is now in public beta at [ai.clickhouse.cloud](http://ai.clickhouse.cloud) — a first-party agent platform powered by Claude for conversational, schema-aware analysis over your ClickHouse Cloud data. Build custom agents with a no-code AgentBuilder, plug in MCP servers (Slack, Linear, Notion, and more), compose subagent workflows, and generate queries, pipelines, and apps without leaving the conversation. Includes AWS Bedrock AgentCore integration and managed LibreChat foundations.
+
+Learn more in the [ClickHouse Agents documentation](/cloud/features/ai-ml/agents).
+
+### ClickHouse Postgres (public beta) {#clickhouse-postgres-public-beta}
+
+Fully managed Postgres on local NVMe storage is now in public beta, delivering 5x+ more TPS than AWS RDS and bridging OLTP and OLAP in one managed stack. A native CDC pipeline streams data directly into ClickHouse with no intermediate infrastructure, and the open-source `pg_clickhouse` extension lets you query ClickHouse tables from standard Postgres sessions.
+
+Read more in [Open House 2026 Day 1: Real-time data without lock-in and what teams can build next](https://clickhouse.com/blog/open-house-2026-day-1#postgres-announcements).
+
+### ClickStack Cloud: serverless observability (private preview) {#clickstack-cloud}
+
+ClickStack Cloud is a fully managed, serverless observability platform powered by ClickHouse Cloud. Point your OpenTelemetry Collector at a managed OTLP endpoint and immediately explore logs, metrics, and traces in the ClickStack UI — with ingestion, buffering, scaling, storage, query serving, authentication, and RBAC all handled for you. Available in limited private preview on AWS us-east-1.
+
+For more details see [ClickStack Cloud private preview](https://clickhouse.com/blog/clickstack-cloud-private-preview) and the [ClickStack Cloud waitlist](https://clickhouse.com/cloud/clickstack-cloud-waitlist).
+
+### AI Notebooks for Managed ClickStack (beta) {#clickstack-ai-notebooks}
+
+AI Notebooks bring a persistent, transparent workspace for AI-assisted incident investigation to Managed ClickStack. Capture structured sequences of prompts, queries, charts, and reasoning, branch to explore multiple hypotheses, and share investigations as collaborative team artifacts — with all generated queries and results visible and editable. Accessible from the left navigation in the ClickStack UI.
+
+For more details, see:
+- [ClickStack AI Notebooks docs](/use-cases/observability/clickstack/notebooks)
+- [AI Notebooks in beta (blog)](https://clickhouse.com/blog/observability-mcp-server-ai-notebooks#ai-notebooks-in-beta)
+
+### Horizontal autoscaling (private preview) {#horizontal-autoscaling}
+
+Horizontal autoscaling automatically adjusts the number of replicas in a ClickHouse Cloud cluster, scaling out aggressively when demand spikes and scaling in gradually as load drops — so teams with variable, high-concurrency workloads no longer need to manually right-size clusters. Private preview scales on concurrent query count; CPU and memory signals are planned for public beta. Available to Enterprise and Scale tier customers on ClickHouse 26.2+.
+
+### ClickStack MCP Server (open source) {#clickstack-mcp-server}
+
+The new open-source ClickStack MCP server gives external AI agents structured observability investigation tools built on ClickStack and ClickHouse. It exposes semantic primitives for logs, metrics, and traces — supporting log pattern analysis, trace outlier investigation, correlation analysis, and cross-signal debugging — and can persist dashboards, searches, and alerts, while retaining native SQL access for deeper exploration. Connect agents like Claude Code, Cursor, Codex, or custom frameworks.
+
+For more details see the [ClickStack MCP server docs](/use-cases/observability/clickstack/mcp) and the [Observability MCP server + AI Notebooks blog post](https://clickhouse.com/blog/observability-mcp-server-ai-notebooks#clickstack-mcp-server).
+
+### Open House 2026: a roadmap of UX improvements for humans and agents {#open-house-2026-ux-roadmap}
+
+At Open House 2026 we previewed a set of upcoming console capabilities, including Monitoring v2 and Materialized View pipeline visualization (phased rollout in progress), the ClickHouse CLI for agentic workflows (beta), cross-region replication (private preview later this year), and AI-assisted schema management, Query API endpoints, an AI-enhanced query builder, and MCP-as-a-Service (coming soon). These features were announced and are not yet generally available.
+
+For more details, see [Open House 2026 Day 1: Improving the UX for humans and agents](https://clickhouse.com/blog/open-house-2026-day-1#improving-the-ux-for-humans-and-agents).
+
 ## May 25, 2026 {#2026-05-25}
 
 ### GA release of organization spend alerts {#spend-alerts-ga}

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -71,7 +71,9 @@ The new open-source ClickStack MCP server gives external AI agents structured ob
 
 For more details see the [ClickStack MCP server docs](/use-cases/observability/clickstack/mcp) and the [Observability MCP server + AI Notebooks blog post](https://clickhouse.com/blog/observability-mcp-server-ai-notebooks#clickstack-mcp-server).
 
-### Executable Usere Defined Functions {#executable-udfs}
+<!-- vale off -->
+### Executable User Defined Functions {#executable-udfs}
+<!-- vale on -->
 
 You can now write a function in Python, zip it up, upload it to your cluster, and call it from SQL like any built-in function. ClickHouse runs a pool of long-lived sandboxed processes and pipes rows through them at query speed, so you can call your function anywhere SQL works: ad-hoc queries, joins, even materialized views that fire on every insert. Your model code lives right next to the data, and deploying it is just one upload screen in the Cloud console.
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -71,11 +71,13 @@ The new open-source ClickStack MCP server gives external AI agents structured ob
 
 For more details see the [ClickStack MCP server docs](/use-cases/observability/clickstack/mcp) and the [Observability MCP server + AI Notebooks blog post](https://clickhouse.com/blog/observability-mcp-server-ai-notebooks#clickstack-mcp-server).
 
-### Open House 2026: a roadmap of UX improvements for humans and agents {#open-house-2026-ux-roadmap}
+### Executable Usere Defined Functions {#executable-udfs}
 
-At Open House 2026 we previewed a set of upcoming console capabilities, including Monitoring v2 and Materialized View pipeline visualization (phased rollout in progress), the ClickHouse CLI for agentic workflows (beta), cross-region replication (private preview later this year), and AI-assisted schema management, Query API endpoints, an AI-enhanced query builder, and MCP-as-a-Service (coming soon). These features were announced and are not yet generally available.
+You can now write a function in Python, zip it up, upload it to your cluster, and call it from SQL like any built-in function. ClickHouse runs a pool of long-lived sandboxed processes and pipes rows through them at query speed, so you can call your function anywhere SQL works: ad-hoc queries, joins, even materialized views that fire on every insert. Your model code lives right next to the data, and deploying it is just one upload screen in the Cloud console.
 
-For more details, see [Open House 2026 Day 1: Improving the UX for humans and agents](https://clickhouse.com/blog/open-house-2026-day-1#improving-the-ux-for-humans-and-agents).
+To show what it can do, we built a [demo](https://github.com/ClickHouse/stock-anomaly-udf). Based on our real-time stock trade data in StockHouse, we trained a small PyTorch autoencoder to score equity trade ticks for anomalies as they get ingested. It's one UDF and one DDL statement, and everything else is plain SQL. We also snuck in a preview of network-access UDFs (private beta), which enable UDFs to make outbound HTTPS calls. We use that to pull in news and SEC filings and have Claude classify why a given trade looks anomalous.
+
+For more details, read the [announcement blog](https://clickhouse.com/blog/executable-udfs-clickhouse-cloud-beta) or the [docs](/cloud/features/user-defined-functions)
 
 ## May 25, 2026 {#2026-05-25}
 

--- a/static/cloud/changelog-rss.xml
+++ b/static/cloud/changelog-rss.xml
@@ -7,6 +7,95 @@
     <language>en-us</language>
     <atom:link href="https://clickhouse.com/docs/cloud/changelog-rss.xml" rel="self" type="application/rss+xml" />
     <item>
+      <title>ClickHouse Cloud - June 3, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-03</link>
+      <description>ClickPipes now runs natively on GCP with Private Service Connect:
+
+ClickPipes for GCP Pub/Sub (private preview):
+
+ClickHouse Agents: Claude-powered agentic analytics (public beta):
+
+ClickHouse Postgres (public beta):
+
+ClickStack Cloud: serverless observability (private preview):
+
+AI Notebooks for Managed ClickStack (beta):
+- ClickStack AI Notebooks docs
+- AI Notebooks in beta (blog)
+
+Horizontal autoscaling (private preview):
+
+ClickStack MCP Server (open source):
+
+Open House 2026: a roadmap of UX improvements for humans and agents:</description>
+      <pubDate>Wed, 03 Jun 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-03</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - May 25, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-25</link>
+      <description>GA release of organization spend alerts:
+
+New ClickPipes AWS regions:
+
+Primary service idling for compute-compute separation now generally available:</description>
+      <pubDate>Mon, 25 May 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-25</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - May 18, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-18</link>
+      <description>Python client v1.0.0:
+- First-class SQLAlchemy dialect with deeper support for ClickHouse-specific SQL
+- Native async client built on aiohttp with full feature parity, including streaming
+- Significant performance improvements for DateTime, DateTime64, fixed-width numeric inserts, Maps, Decimals, and BigDecimals
+- Timezone handling redesign with new tzmode and tzsource parameters
+- Native Variant column writes
+- Lazy imports for optional dependencies (numpy, pandas, pyarrow, polars), speeding up bare import by 4x
+- Experimental Python 3.14 free-threading support
+
+SQL-based charting and alerting in ClickStack:
+
+New region support:
+- AWS Mexico (mx-central-1) — Private Region, PCI
+- Azure Australia East — Private Region
+
+Protobuf support for Kafka ClickPipes:</description>
+      <pubDate>Mon, 18 May 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-18</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - May 8, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-08</link>
+      <description>Postgres query insights (private preview):
+- Overview: — one-screen database health
+- Patterns: — table sortable by runtime, CPU, errors, and P95
+- Per-pattern flyout: — latency percentiles, CPU vs I/O, cache vs disk, temp spills, parallel-worker shortfalls, and WAL volume
+
+Data catalog integration expansions:
+- IAM support for AWS Glue Catalog
+- BigLake Metastore support for data catalog integration
+- Delta Tables support on Unity Catalog</description>
+      <pubDate>Fri, 08 May 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-08</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - May 2, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-02</link>
+      <description>New GCP London region (europe-west2):</description>
+      <pubDate>Sat, 02 May 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-05-02</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - April 25, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-04-25</link>
+      <description>Index sharding (private preview):
+
+Terraform &amp; OpenAPI for ClickPipes (general access):</description>
+      <pubDate>Sat, 25 Apr 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-04-25</guid>
+    </item>
+    <item>
       <title>ClickHouse Cloud - April 17, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#april-17-2026</link>
       <description>Refunds visible in billing UI:
@@ -14,8 +103,20 @@
 Organization spend alerts (Private Preview):
 
 ClickPipes region parity on AWS:</description>
-      <pubDate>Fri, 17 Apr 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 17 Apr 2026 00:00:00 +0200</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#april-17-2026</guid>
+    </item>
+    <item>
+      <title>ClickHouse Cloud - April 10, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-04-10</link>
+      <description>Centralized marketplace billing:
+- Marketplace Subscription Sharing:: Switch an organization from credit card billing to an existing marketplace subscription from another organization, removing the need to set up an additional marketplace subscription. Only PAYG usage is consolidated (not prepaid credits).
+- Update Marketplace Subscriptions:: Swap an organization&apos;s marketplace subscription to one used by a different organization.
+- Backup Payment Method:: Organizations on marketplace billing can now add a credit card as a fallback if the primary marketplace subscription is cancelled or expires.
+
+clickhousectl CLI (public beta):</description>
+      <pubDate>Fri, 10 Apr 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-04-10</guid>
     </item>
     <item>
       <title>ClickHouse Cloud - April 3, 2026</title>
@@ -26,21 +127,21 @@ ClickPipes region parity on AWS:</description>
 - Data Catalog integration:: ClickHouse Cloud now supports Iceberg REST Catalog and Microsoft OneLake as data lake catalog integrations in the data sources UI. Once connected, the catalog appears as a database, allowing you to read Iceberg tables directly, without duplicating data.
 - Bring Your Own Cloud (BYOC) on GCP is now generally available:: ClickHouse BYOC is now GA on Google Cloud, allowing you to deploy ClickHouse services in your own GCP project, and comply with strict data residency requirements. Read the documentation and the blog post for more details. You can contact us to request access.
 - Billing notifications for prepaid credits and payment method changes:: ClickHouse Cloud now sends notifications when prepaid credits are added to your organization following a committed contract, or when a payment method is updated (credit card or marketplace subscription). Notifications are enabled by default for UI and email, and can be configured to also send to Slack.</description>
-      <pubDate>Fri, 03 Apr 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 03 Apr 2026 00:00:00 +0200</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#april-3-2026</guid>
     </item>
     <item>
       <title>ClickHouse Cloud - March 20, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#march-20-2026</link>
       <description>- Custom date range for Usage Breakdown:: You can now view your usage costs across all billing dimensions on the usage breakdown screen using a custom date range.</description>
-      <pubDate>Fri, 20 Mar 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 20 Mar 2026 00:00:00 +0100</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#march-20-2026</guid>
     </item>
     <item>
       <title>ClickHouse Cloud - February 20, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#february-20-2026</link>
       <description>- ClickPipes:: Reverse private endpoints in an inactive state will now be automatically removed after a defined grace period. This ensures unused or misconfigured endpoints are not persisted indefinitely in the backend. See the automatic clean up documentation for more details.</description>
-      <pubDate>Fri, 20 Feb 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 20 Feb 2026 00:00:00 +0100</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#february-20-2026</guid>
     </item>
     <item>
@@ -52,14 +153,14 @@ ClickPipes region parity on AWS:</description>
 - GCP us-central1 (Iowa)
 - GCP us-east1 (South Carolina)
 - Crash report collection preferences can now be configured at the organization level. This setting was previously available only at the service level. When disabled at the organization level, all existing and future services will be opted out automatically.</description>
-      <pubDate>Fri, 13 Feb 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 13 Feb 2026 00:00:00 +0100</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#february-13-2026</guid>
     </item>
     <item>
       <title>ClickHouse Cloud - January 23, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#january-23-2026</link>
       <description>- ClickPipes is now available in AWS eu-west-1. For new ClickHouse Cloud services created from January 20 in that region, the matching region will be used for ClickPipes. For older services, ClickPipes defaults to eu-central-1. See the documentation for more details.</description>
-      <pubDate>Fri, 23 Jan 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 23 Jan 2026 00:00:00 +0100</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#january-23-2026</guid>
     </item>
     <item>
@@ -70,7 +171,7 @@ ClickPipes region parity on AWS:</description>
 - ClickPipes:
 - The MongoDB connector has been promoted to Public Beta, and is now available to new and existing ClickHouse Cloud customers, in all service tiers. Read the blogpost for an overview of new features and head to the documentation to get started.
 - The S3 ClickPipe is now compatible with OVH Object Storage, the S3 API-compatible object storage service in OVHcloud.</description>
-      <pubDate>Fri, 16 Jan 2026 00:00:00 +0900</pubDate>
+      <pubDate>Fri, 16 Jan 2026 00:00:00 +0100</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#january-16-2026</guid>
     </item>
 


### PR DESCRIPTION
Add the week-of-2026-05-24 Open House 2026 entries to the 2026 Cloud changelog and regenerate the RSS feed.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and RSS-only updates with no product code or configuration changes.
> 
> **Overview**
> Adds a **June 3, 2026** Open House 2026 section at the top of the 2026 Cloud changelog in `2026.md`, documenting regional ClickPipes on GCP (PSC), GCP Pub/Sub ClickPipes, ClickHouse Agents, managed Postgres, ClickStack Cloud, AI Notebooks, horizontal autoscaling, the ClickStack MCP server, and **executable UDFs** (with a network-access UDF preview).
> 
> Regenerates `static/cloud/changelog-rss.xml` with a new feed item for that date, backfills RSS items for several May–April 2026 changelog entries, and normalizes `pubDate` timezones on older items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b34f7453d044a799cd251932ae7d1d9c6c38ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->