### PR TITLE
Remove a stray ` from query-endpoints h3

### DIFF
--- a/docs/cloud/guides/SQL_console/query-endpoints.md
+++ b/docs/cloud/guides/SQL_console/query-endpoints.md
@@ -538,7 +538,7 @@ fetch(
 </TabItem>
 </Tabs>
 
-### Request and parse the response as a stream` {#request-and-parse-the-response-as-a-stream}
+### Request and parse the response as a stream {#request-and-parse-the-response-as-a-stream}
 
 **Query API Endpoint SQL:**
 


### PR DESCRIPTION
## Summary

https://clickhouse.com/docs/cloud/get-started/query-endpoints#request-and-parse-the-response-as-a-stream

<img width="446" height="52" alt="image" src="https://github.com/user-attachments/assets/08428f23-8df0-48fa-bff9-9873536c12ec" />


## Checklist
- [x] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markdown fix with no runtime or API behavior changes.
> 
> **Overview**
> Fixes a **documentation heading** in `query-endpoints.md` for the streaming example section by removing an extra `` ` `` before the `{#...}` anchor.
> 
> The heading was incorrectly written as `` ### ... ` {#anchor} `` which could break how the section title and anchor render on the docs site; it now matches the same `` ### Title {#anchor} `` pattern used elsewhere in the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd00580515a12b107a6fc0f94e6d97ae972007c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->