### PR TITLE
Make Helm the primary install method on ClickStack OTel collector page

### DIFF
--- a/docs/use-cases/observability/clickstack/ingesting-data/collector.md
+++ b/docs/use-cases/observability/clickstack/ingesting-data/collector.md
@@ -46,6 +46,56 @@ Users deploying OTel collectors in the agent role will typically use the [defaul
 
 We [recommend using the official ClickStack distribution of the collector](/use-cases/observability/clickstack/deployment/hyperdx-only#otel-collector) for the gateway role when sending to Managed ClickStack, where possible. If you choose to bring your own, ensure it includes the [ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter).
 
+The collector can be deployed either via Helm (recommended for Kubernetes) or via Docker. The official [ClickStack Helm chart](https://github.com/ClickHouse/ClickStack-helm-charts) embeds the upstream [OpenTelemetry collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts) as a subchart with the ClickStack distribution image preconfigured—see the [ClickStack Helm deployment guide](/use-cases/observability/clickstack/deployment/helm) if you want to install the full stack including HyperDX. For a standalone collector deployment, the upstream chart can be used directly with the ClickStack image, as shown below.
+
+<Tabs groupId="install-method">
+
+<TabItem value="helm" label="Helm" default>
+
+Add the upstream OpenTelemetry Helm repository:
+
+```shell
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+```
+
+Create a `values.yaml` configuring the ClickStack image and Managed ClickStack credentials:
+
+```yaml
+# values.yaml
+mode: deployment
+
+image:
+  repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
+  tag: "2.19.0"
+
+ports:
+  otlp:
+    enabled: true
+  otlp-http:
+    enabled: true
+
+extraEnvs:
+  - name: CLICKHOUSE_ENDPOINT
+    value: "https://your-instance.clickhouse.cloud:8443"
+  - name: CLICKHOUSE_USER
+    value: "default"
+  - name: CLICKHOUSE_PASSWORD
+    value: "<password>"
+```
+
+Install the chart:
+
+```shell
+helm install clickstack-otel-collector open-telemetry/opentelemetry-collector -f values.yaml
+```
+
+For production deployments, we recommend storing `CLICKHOUSE_PASSWORD` in a Kubernetes secret and referencing it via `extraEnvsFrom` instead of inlining the value.
+
+</TabItem>
+
+<TabItem value="docker" label="Docker">
+
 To deploy the ClickStack distribution of the OTel connector in a standalone mode, run the following docker command:
 
 ```shell
@@ -56,7 +106,11 @@ docker run -e CLICKHOUSE_ENDPOINT=${CLICKHOUSE_ENDPOINT} -e CLICKHOUSE_USER=defa
 ClickStack images are now published as `clickhouse/clickstack-*` (previously `docker.hyperdx.io/hyperdx/*`).
 :::
 
-Note that we can overwrite the target ClickHouse instance with environment variables for `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse Cloud HTTP endpoint, including the protocol and port—for example, `https://99rr6dm6v3.us-central1.gcp.clickhouse.cloud:8443`.
+</TabItem>
+
+</Tabs>
+
+The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse Cloud HTTP endpoint, including the protocol and port—for example, `https://99rr6dm6v3.us-central1.gcp.clickhouse.cloud:8443`.
 
 For details on retrieving your Managed ClickStack credentials, see [here](/cloud/guides/sql-console/gather-connection-details).
 
@@ -68,9 +122,34 @@ You should use a user with the [appropriate credentials](/use-cases/observabilit
 
 #### Configuring Managed ClickStack instance {#configuring-managed-clickstack}
 
-All docker images, which include the OpenTelemetry collector, can be configured to use a Managed ClickStack instance via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`:
+The OpenTelemetry collector can be configured to use a Managed ClickStack instance via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
 
-For example the all-in-one image:
+<Tabs groupId="install-method">
+
+<TabItem value="helm" label="Helm" default>
+
+Override the relevant entries under `extraEnvs` in your `values.yaml`, then upgrade the release:
+
+```yaml
+# values.yaml
+extraEnvs:
+  - name: CLICKHOUSE_ENDPOINT
+    value: "<HTTPS_ENDPOINT>"
+  - name: CLICKHOUSE_USER
+    value: "<CLICKHOUSE_USER>"
+  - name: CLICKHOUSE_PASSWORD
+    value: "<CLICKHOUSE_PASSWORD>"
+```
+
+```shell
+helm upgrade clickstack-otel-collector open-telemetry/opentelemetry-collector -f values.yaml
+```
+
+</TabItem>
+
+<TabItem value="docker" label="Docker">
+
+All docker images which include the OpenTelemetry collector can be configured via environment variables. For example the all-in-one image:
 
 ```shell
 export CLICKHOUSE_ENDPOINT=<HTTPS ENDPOINT>
@@ -81,6 +160,10 @@ export CLICKHOUSE_PASSWORD=<CLICKHOUSE_PASSWORD>
 ```shell
 docker run -e CLICKHOUSE_ENDPOINT=${CLICKHOUSE_ENDPOINT} -e CLICKHOUSE_USER=default -e CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD} -p 8080:8080 -p 4317:4317 -p 4318:4318 clickhouse/clickstack-otel-collector:latest
 ```
+
+</TabItem>
+
+</Tabs>
 
 <ExtendingConfig/>
 
@@ -115,6 +198,62 @@ With Docker Compose, modify the collector configuration using the same environme
 
 If you're managing your own OpenTelemetry collector in a standalone deployment - such as when using the HyperDX-only distribution - we [recommend still using the official ClickStack distribution of the collector](/use-cases/observability/clickstack/deployment/hyperdx-only#otel-collector) for the gateway role where possible, but if you choose to bring your own, ensure it includes the [ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter).
 
+The collector can be deployed either via Helm (recommended for Kubernetes) or via Docker. The official [ClickStack Helm chart](https://github.com/ClickHouse/ClickStack-helm-charts) embeds the upstream [OpenTelemetry collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts) as a subchart and auto-wires the OpAMP endpoint, ClickStack image, and HyperDX API key via a shared `clickstack-config` ConfigMap and `clickstack-secret` Secret—see the [ClickStack Helm deployment guide](/use-cases/observability/clickstack/deployment/helm) if you want to install the full stack including HyperDX. For a standalone collector deployment that connects to an existing HyperDX, the upstream chart can be used directly with the ClickStack image, as shown below.
+
+<Tabs groupId="install-method">
+
+<TabItem value="helm" label="Helm" default>
+
+Add the upstream OpenTelemetry Helm repository:
+
+```shell
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+```
+
+Create a `values.yaml` configuring the ClickStack image, ClickHouse credentials, and the OpAMP endpoint of your HyperDX deployment:
+
+```yaml
+# values.yaml
+mode: deployment
+
+image:
+  repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
+  tag: "2.19.0"
+
+ports:
+  otlp:
+    enabled: true
+  otlp-http:
+    enabled: true
+
+extraEnvs:
+  - name: CLICKHOUSE_ENDPOINT
+    value: "tcp://clickhouse.your-namespace.svc.cluster.local:9000?dial_timeout=10s"
+  - name: CLICKHOUSE_USER
+    value: "otelcollector"
+  - name: CLICKHOUSE_PASSWORD
+    value: "<password>"
+  - name: OPAMP_SERVER_URL
+    value: "http://hyperdx.your-namespace.svc.cluster.local:4320"
+  - name: HYPERDX_API_KEY
+    value: "<your-ingestion-api-key>"
+```
+
+Install the chart:
+
+```shell
+helm install clickstack-otel-collector open-telemetry/opentelemetry-collector -f values.yaml
+```
+
+The `OPAMP_SERVER_URL` should resolve to your HyperDX service. When HyperDX and the collector run in the same cluster, use the in-cluster service DNS name (e.g. `http://hyperdx.your-namespace.svc.cluster.local:4320`). HyperDX exposes the OpAMP API at `/v1/opamp` on port `4320` by default.
+
+For production deployments, we recommend storing `CLICKHOUSE_PASSWORD` and `HYPERDX_API_KEY` in a Kubernetes secret and referencing them via `extraEnvsFrom` instead of inlining the values.
+
+</TabItem>
+
+<TabItem value="docker" label="Docker">
+
 To deploy the ClickStack distribution of the OTel connector in a standalone mode, run the following docker command:
 
 ```shell
@@ -125,15 +264,19 @@ docker run -e OPAMP_SERVER_URL=${OPAMP_SERVER_URL} -e CLICKHOUSE_ENDPOINT=${CLIC
 ClickStack images are now published as `clickhouse/clickstack-*` (previously `docker.hyperdx.io/hyperdx/*`).
 :::
 
-Note that we can overwrite the target ClickHouse instance with environment variables for `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse HTTP endpoint, including the protocol and port—for example, `http://localhost:8123`.
-
-**These environment variables can be used with any of the docker distributions which include the connector.** 
-
 The `OPAMP_SERVER_URL` should point to your HyperDX deployment - for example, `http://localhost:4320`. HyperDX exposes an OpAMP (Open Agent Management Protocol) server at `/v1/opamp` on port `4320` by default. Make sure to expose this port from the container running HyperDX (e.g., using `-p 4320:4320`).
 
 :::note Exposing and connecting to the OpAMP port
 For the collector to connect to the OpAMP port it must be exposed by the HyperDX container e.g. `-p 4320:4320`. For local testing, OSX users can then set `OPAMP_SERVER_URL=http://host.docker.internal:4320`. Linux users can start the collector container with `--network=host`.
 :::
+
+</TabItem>
+
+</Tabs>
+
+The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse HTTP endpoint, including the protocol and port—for example, `http://localhost:8123`.
+
+**These environment variables can be used with any of the docker distributions which include the connector.**
 
 :::note Production user
 You should use a user with the [appropriate credentials](/use-cases/observability/clickstack/ingesting-data/otel-collector#creating-an-ingestion-user) in production.
@@ -143,9 +286,36 @@ You should use a user with the [appropriate credentials](/use-cases/observabilit
 
 #### Configuring ClickHouse instance {#configuring-clickhouse-instance}
 
-All docker images, which include the OpenTelemetry collector, can be configured to use a clickhouse instance via the environment variables `OPAMP_SERVER_URL` ,`CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`:
+The OpenTelemetry collector can be configured to use a ClickHouse instance via the environment variables `OPAMP_SERVER_URL`, `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
 
-For example the all-in-one image:
+<Tabs groupId="install-method">
+
+<TabItem value="helm" label="Helm" default>
+
+Override the relevant entries under `extraEnvs` in your `values.yaml`, then upgrade the release:
+
+```yaml
+# values.yaml
+extraEnvs:
+  - name: OPAMP_SERVER_URL
+    value: "<OPAMP_SERVER_URL>"
+  - name: CLICKHOUSE_ENDPOINT
+    value: "<HTTPS_ENDPOINT>"
+  - name: CLICKHOUSE_USER
+    value: "<CLICKHOUSE_USER>"
+  - name: CLICKHOUSE_PASSWORD
+    value: "<CLICKHOUSE_PASSWORD>"
+```
+
+```shell
+helm upgrade clickstack-otel-collector open-telemetry/opentelemetry-collector -f values.yaml
+```
+
+</TabItem>
+
+<TabItem value="docker" label="Docker">
+
+All docker images which include the OpenTelemetry collector can be configured via environment variables. For example the all-in-one image:
 
 ```shell
 export OPAMP_SERVER_URL=<OPAMP_SERVER_URL>
@@ -157,6 +327,10 @@ export CLICKHOUSE_PASSWORD=<CLICKHOUSE_PASSWORD>
 ```shell
 docker run -e OPAMP_SERVER_URL=${OPAMP_SERVER_URL} -e CLICKHOUSE_ENDPOINT=${CLICKHOUSE_ENDPOINT} -e CLICKHOUSE_USER=default -e CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD} -p 8080:8080 -p 4317:4317 -p 4318:4318 clickhouse/clickstack-otel-collector:latest
 ```
+
+</TabItem>
+
+</Tabs>
 
 <ExtendingConfig/>
 
@@ -196,7 +370,36 @@ With Docker Compose, modify the collector configuration using the same environme
 
 By default, the ClickStack OpenTelemetry collector isn't secured when deployed outside of the Open Source distributions and doesn't require authentication on its OTLP ports.
 
-To secure ingestion, specify an authentication token when deploying the collector using the `OTLP_AUTH_TOKEN` environment variable. For example:
+To secure ingestion, specify an authentication token when deploying the collector using the `OTLP_AUTH_TOKEN` environment variable. How this is set depends on your deployment method:
+
+<Tabs groupId="install-method">
+
+<TabItem value="helm" label="Helm" default>
+
+Add `OTLP_AUTH_TOKEN` to `extraEnvs` in your `values.yaml`, then upgrade the release:
+
+```yaml
+# values.yaml
+extraEnvs:
+  - name: OTLP_AUTH_TOKEN
+    value: "a_very_secure_string"
+  - name: CLICKHOUSE_ENDPOINT
+    value: "<HTTPS_ENDPOINT>"
+  - name: CLICKHOUSE_USER
+    value: "<CLICKHOUSE_USER>"
+  - name: CLICKHOUSE_PASSWORD
+    value: "<CLICKHOUSE_PASSWORD>"
+```
+
+```shell
+helm upgrade clickstack-otel-collector open-telemetry/opentelemetry-collector -f values.yaml
+```
+
+For production deployments, we recommend storing `OTLP_AUTH_TOKEN` and `CLICKHOUSE_PASSWORD` in a Kubernetes secret and referencing them via `extraEnvsFrom`.
+
+</TabItem>
+
+<TabItem value="docker" label="Docker">
 
 ```sh
 export CLICKHOUSE_ENDPOINT=<HTTPS_ENDPOINT>
@@ -213,6 +416,10 @@ docker run \
   -p 4318:4318 \
   clickhouse/clickstack-otel-collector:latest
 ```
+
+</TabItem>
+
+</Tabs>
 
 We additionally recommend:
 


### PR DESCRIPTION
## What changed

Reorganized the `Deploying the collector` and `Securing the collector` sections of [`/use-cases/observability/clickstack/ingesting-data/otel-collector`](https://clickhouse.com/docs/use-cases/observability/clickstack/ingesting-data/otel-collector) so **Helm is the primary install path**, with the existing Docker commands preserved in secondary tabs that aren't displayed by default.

Single file changed: `docs/use-cases/observability/clickstack/ingesting-data/collector.md` (+217 / −10).

## Why

Helm is the recommended install method for Kubernetes deployments and matches how the [ClickStack Helm chart](https://github.com/ClickHouse/ClickStack-helm-charts) actually ships the collector (as a subchart of the upstream [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) chart). The page previously had Docker-only instructions, which forced Kubernetes users to translate `docker run` flags into Helm values themselves.

## What the new content looks like

- **Helm tab (default)**: `helm repo add` + a focused `values.yaml` showing the ClickStack image (`docker.clickhouse.com/clickhouse/clickstack-otel-collector:2.19.0`), OTLP ports, and `extraEnvs` for `CLICKHOUSE_*` (plus `OPAMP_SERVER_URL` and `HYPERDX_API_KEY` for the Open Source ClickStack flow) + `helm install`.
- **Docker tab (not default)**: the original `docker run` block and associated notes, unchanged.
- The intro paragraph in each outer tab notes that the official ClickStack Helm chart embeds the upstream collector chart as a subchart, with an inline link to the main [ClickStack Helm deployment guide](/use-cases/observability/clickstack/deployment/helm).
- Same nested-tab split applied to the `Modifying configuration` subsection and to the Managed ClickStack tab of `Securing the collector` (Helm equivalent of `OTLP_AUTH_TOKEN` via `extraEnvs`).

Image tag and env var conventions (`CLICKHOUSE_USER=otelcollector`, `OPAMP_SERVER_URL`, `HYPERDX_API_KEY`) match the canonical [`charts/clickstack/values.yaml`](https://github.com/ClickHouse/ClickStack-helm-charts/blob/main/charts/clickstack/values.yaml) so the docs stay in sync with the chart.

## Out of scope

- The Open Source ClickStack tab of `Securing the collector` is unchanged — OpAMP-managed credentials work transparently for both install methods, and the existing prose is install-method-agnostic.
- Docker Compose YAML blocks are unchanged.
- The `_extending_config.md` snippet is unchanged (works for both install methods).
- i18n files (jp/ko/ru/zh) are unchanged — translations regenerated separately.

## Compatibility

All existing anchor IDs preserved:
- `#configuring-the-collector`
- `#modifying-otel-collector-configuration` and `#modifying-otel-collector-configuration-managed`
- `#configuring-managed-clickstack` and `#configuring-clickhouse-instance`
- `#docker-compose-otel` and `#docker-compose-otel-managed`
- `#securing-the-collector`
- `#creating-an-ingestion-user` and `#creating-an-ingestion-user-oss`

Inbound links from `production.md`, `vector.md`, `hyperdx-only.md`, `docker-compose.md`, `all-in-one.md`, and `migrating-agents.md` continue to resolve.

## Verification

- Tabs/TabItem nesting balanced programmatically (5 nested `<Tabs>` blocks, all opened and closed in order).
- 48 code fences total (even).
- YAML snippets parse cleanly through `js-yaml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring; no runtime, auth, or ingestion behavior changes.
> 
> **Overview**
> The ClickStack OTel collector guide now treats **Helm as the default install path** on Kubernetes, with existing **Docker** steps moved into secondary tabs.
> 
> For both **Managed** and **Open Source** flows, **Deploying the collector** adds intro text on the ClickStack vs upstream OpenTelemetry Helm charts, then nested **Helm / Docker** tabs: Helm covers `helm repo add`, a `values.yaml` with the ClickStack collector image and `extraEnvs` (`CLICKHOUSE_*`; OSS also documents `OPAMP_SERVER_URL` and `HYPERDX_API_KEY`), and `helm install`. Shared env-var guidance sits outside the tabs so it applies to either method.
> 
> **Modifying configuration** and **Managed ClickStack → Securing the collector** follow the same pattern—Helm shows `extraEnvs` / `helm upgrade` (including `OTLP_AUTH_TOKEN` for secured ingestion); Docker keeps the prior export/`docker run` examples. Docker Compose, OSS securing (OpAMP), anchors, and i18n are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251c1ef1c6489ff6fcc769002e97ecf439643fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->