### PR TITLE
docs(gcs): remove note that multi object delete is not supported

### DIFF
--- a/docs/integrations/data-ingestion/gcs/index.md
+++ b/docs/integrations/data-ingestion/gcs/index.md
@@ -39,7 +39,7 @@ This part of the configuration is shown in the highlighted section and specifies
         <disks>
             <gcs>
             <!--highlight-start-->
-                <support_batch_delete>false</support_batch_delete>
+                <support_batch_delete>true</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/BUCKET NAME/FOLDER NAME/</endpoint>
                 <access_key_id>SERVICE ACCOUNT HMAC KEY</access_key_id>
@@ -69,7 +69,7 @@ The example configuration highlighted below enables a 10Gi memory cache for the 
     <storage_configuration>
         <disks>
             <gcs>
-                <support_batch_delete>false</support_batch_delete>
+                <support_batch_delete>true</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/BUCKET NAME/FOLDER NAME/</endpoint>
                 <access_key_id>SERVICE ACCOUNT HMAC KEY</access_key_id>
@@ -106,7 +106,7 @@ Storage configuration policies allow choosing where data is stored.  The policy 
     <storage_configuration>
         <disks>
             <gcs>
-                <support_batch_delete>false</support_batch_delete>
+                <support_batch_delete>true</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/BUCKET NAME/FOLDER NAME/</endpoint>
                 <access_key_id>SERVICE ACCOUNT HMAC KEY</access_key_id>
@@ -394,7 +394,7 @@ These substitutions are common across the two nodes:
     <storage_configuration>
         <disks>
             <gcs>
-                <support_batch_delete>false</support_batch_delete>
+                <support_batch_delete>true</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/REPLICA 1 BUCKET/REPLICA 1 FOLDER/</endpoint>
                 <access_key_id>SERVICE ACCOUNT HMAC KEY</access_key_id>

--- a/docs/integrations/data-ingestion/gcs/index.md
+++ b/docs/integrations/data-ingestion/gcs/index.md
@@ -28,7 +28,6 @@ To utilize a GCS bucket as a disk, we must first declare it within the ClickHous
 #### Storage configuration > disks > gcs {#storage_configuration--disks--gcs}
 
 This part of the configuration is shown in the highlighted section and specifies that:
-- Batch deletes aren't to be performed.  GCS doesn't currently support batch deletes, so the autodetect is disabled to suppress error messages.
 - The type of the disk is `s3` because the S3 API is in use.
 - The endpoint as provided by GCS
 - The service account HMAC key and secret


### PR DESCRIPTION
## Summary
XML Multi Object Delete is now GA for GCS, so the note stating that GCS doesn't support batch deletes is out of date and has been removed.

Reference: https://docs.cloud.google.com/storage/docs/xml-api/post-bucket

This re-submits the change from #6048

## Checklist
- [x] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to example XML and prose; no runtime or configuration code is modified.
> 
> **Overview**
> Updates the GCS-backed MergeTree integration guide to match **XML Multi-Object Delete** being generally available on Google Cloud Storage.
> 
> All sample disk configs in `docs/integrations/data-ingestion/gcs/index.md` now set **`support_batch_delete`** to **`true`** instead of **`false`**, and the outdated explanation that GCS does not support batch deletes (and that autodetect should be disabled to avoid errors) is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a93e235086e8818f0390bfc25ae7a45c880d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->