### PR TITLE
Document clickhousectl Cloud Postgres support

### DIFF
--- a/docs/cloud/features/02b_cli.md
+++ b/docs/cloud/features/02b_cli.md
@@ -8,7 +8,7 @@ doc_type: 'reference'
 ---
 
 
-The ClickHouse CLI (`clickhousectl`) is a unified command-line tool for managing ClickHouse Cloud resources and local development with ClickHouse.
+The ClickHouse CLI (`clickhousectl`) is a unified command-line tool for managing ClickHouse Cloud resources and local development with ClickHouse. It also manages [ClickHouse Cloud Postgres](/cloud/managed-postgres) services.
 
 ## Installation {#installation}
 
@@ -63,6 +63,38 @@ clickhousectl cloud service stop <service-id>
 
 # Delete a service
 clickhousectl cloud service delete <service-id>
+```
+
+### Postgres services (beta) {#postgres-services}
+
+Create and manage [ClickHouse Cloud Postgres](/cloud/managed-postgres) services.
+
+```bash
+# List Postgres services
+clickhousectl cloud postgres list
+
+# Create a Postgres service
+clickhousectl cloud postgres create \
+  --name my-pg \
+  --region us-east-1 \
+  --size c6gd.xlarge \
+  --pg-version 18
+
+# Get service details
+clickhousectl cloud postgres get <pg-id>
+
+# Update a service
+clickhousectl cloud postgres update <pg-id> --size c6gd.2xlarge --add-tag env=prod
+
+# Reset the password
+clickhousectl cloud postgres reset-password <pg-id> --generate
+
+# Read replicas and point-in-time restore
+clickhousectl cloud postgres read-replica create <pg-id> --name replica-1
+clickhousectl cloud postgres restore <pg-id> --name restored --restore-target 2026-04-16T12:00:00Z
+
+# Delete a service
+clickhousectl cloud postgres delete <pg-id>
 ```
 
 ### Organizations {#organizations}


### PR DESCRIPTION
## Summary

`clickhousectl` now supports managing ClickHouse Cloud Postgres services (in addition to ClickHouse). This adds a **Postgres services** section to the ClickHouse CLI Cloud features page (`/cloud/features/cli`) covering the new `clickhousectl cloud postgres` commands: `list`, `create`, `get`, `update`, `reset-password`, `read-replica create`, `restore`, and `delete`. The page intro is also updated to mention Cloud Postgres.

Command syntax was taken from the [clickhousectl README](https://github.com/ClickHouse/clickhousectl).

> Note: the equivalent local + cloud Postgres docs for the `/interfaces/cli` page live in the [`ClickHouse/ClickHouse`](https://github.com/ClickHouse/ClickHouse) repo (that path is synced in at build time) and are handled in a separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Cloud CLI reference page; no application or infrastructure code is modified.
> 
> **Overview**
> Documents **ClickHouse Cloud Postgres** management via `clickhousectl` on the Cloud CLI features page.
> 
> The intro now states that the CLI also manages [ClickHouse Cloud Postgres](/cloud/managed-postgres). A new **Postgres services (beta)** section adds example commands for `clickhousectl cloud postgres`: list, create, get, update, reset-password, read-replica create, restore, and delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104444688078354d5bbeed92ea888256168f75c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->