### PR TITLE
feat(postgres): add doc on branching, link migration gist

### DIFF
--- a/docs/cloud/managed-postgres/branching.md
+++ b/docs/cloud/managed-postgres/branching.md
@@ -13,39 +13,39 @@ A branch is a fully independent PostgreSQL deployment created from a specific po
 
 Unlike copy-on-write implementations that share storage with the primary database, Managed Postgres branches are restored from backups and operate as independent PostgreSQL deployments.
 
-## How branching works
+## How branching works {#branching}
 
-Branch creation is built on the same backup and recovery infrastructure used for [Point-in-Time Recovery (PITR)](/docs/cloud/managed-postgres/backup-and-restore).
+Branch creation is built on the same backup and recovery infrastructure used for [Point-in-Time Recovery (PITR)](/cloud/managed-postgres/backup-and-restore).
 
 When you create a branch, Managed Postgres restores a base backup from object storage, replays the required WAL segments to reach the requested recovery point, and provisions a new PostgreSQL deployment from the recovered state. Once recovery completes, the branch operates independently of the source database.
 
 The resulting branch is a complete copy of the source database at the selected point in time.
 
-## Common use cases
+## Common use cases {#common-use-cases}
 
-### Development and testing
+### Development and testing {#dev-and-testing}
 
 Create a branch from a production or staging database to validate application changes, migrations, or new features against realistic data.
 
-### Staging environments
+### Staging environments {#staging-environments}
 
 Maintain a staging environment that closely mirrors production without affecting production workloads.
 
-### Data validation
+### Data validation {#date-validation}
 
 Test schema changes, indexing strategies, and query optimizations before deploying them to production.
 
-### Recovery and investigation
+### Recovery and investigation {#recovery-and-investigation}
 
 Recover a database to a specific point in time for troubleshooting, auditing, or validating application behavior.
 
-## Branch sizing
+## Branch sizing {#branch-sizing}
 
 Branches are independent PostgreSQL deployments and can be sized separately from the source database.
 
 For example, a production deployment may run on a larger configuration while a development or staging branch can use a smaller compute profile to reduce costs. This lets teams create temporary environments without matching the compute resources of production.
 
-## Branch creation time
+## Branch creation time {#branch-creation-time}
 
 Because Managed Postgres uses NVMe-backed PostgreSQL storage, branches are restored from backups rather than created through storage-level copy-on-write mechanisms. As a result, branch creation isn't instantaneous.
 
@@ -61,7 +61,7 @@ For most deployments, branches are available within a few minutes. Larger databa
 
 If branch creation time becomes a bottleneck for your workflow, contact the ClickHouse team. In many cases, branch recovery performance can be optimized based on workload characteristics and recovery requirements.
 
-## Branches vs local development
+## Branches vs local development {#branches-v-local-dev}
 
 A common question is whether every developer should use a production branch as their development environment.
 
@@ -76,9 +76,9 @@ For most organizations, we recommend:
 
 This approach reduces load on production systems, improves development velocity, and helps ensure that production data remains appropriately protected.
 
-For guidance on creating local PostgreSQL development environments using Docker, see [Local development environments](/docs/cloud/managed-postgres/local-development).
+For guidance on creating local PostgreSQL development environments using Docker, see [Local development environments](/cloud/managed-postgres/local-development).
 
-## Recommended workflow
+## Recommended workflow {#recommended-workflow}
 
 A common workflow looks like:
 

--- a/docs/cloud/managed-postgres/branching.md
+++ b/docs/cloud/managed-postgres/branching.md
@@ -1,0 +1,102 @@
+---
+slug: /cloud/managed-postgres/branching
+sidebar_label: 'Branching'
+title: 'Branching'
+description: 'Create isolated database branches from point-in-time snapshots for development, staging, testing, and recovery workflows'
+keywords: ['managed postgres', 'branching', 'pitr', 'point-in-time recovery', 'staging', 'development', 'database branch']
+doc_type: 'guide'
+---
+
+Managed Postgres supports creating isolated database branches using Point-in-Time Recovery (PITR).
+
+A branch is a fully independent PostgreSQL deployment created from a specific point in time of an existing database. Branches can be used for development, staging, testing, debugging, data validation, or recovery workflows — without impacting the source database.
+
+Unlike copy-on-write implementations that share storage with the primary database, Managed Postgres branches are restored from backups and operate as independent PostgreSQL deployments.
+
+## How branching works
+
+Branch creation is built on the same backup and recovery infrastructure used for [Point-in-Time Recovery (PITR)](/docs/cloud/managed-postgres/backup-and-restore).
+
+When you create a branch, Managed Postgres restores a base backup from object storage, replays the required WAL segments to reach the requested recovery point, and provisions a new PostgreSQL deployment from the recovered state. Once recovery completes, the branch operates independently of the source database.
+
+The resulting branch is a complete copy of the source database at the selected point in time.
+
+## Common use cases
+
+### Development and testing
+
+Create a branch from a production or staging database to validate application changes, migrations, or new features against realistic data.
+
+### Staging environments
+
+Maintain a staging environment that closely mirrors production without affecting production workloads.
+
+### Data validation
+
+Test schema changes, indexing strategies, and query optimizations before deploying them to production.
+
+### Recovery and investigation
+
+Recover a database to a specific point in time for troubleshooting, auditing, or validating application behavior.
+
+## Branch sizing
+
+Branches are independent PostgreSQL deployments and can be sized separately from the source database.
+
+For example, a production deployment may run on a larger configuration while a development or staging branch can use a smaller compute profile to reduce costs. This lets teams create temporary environments without matching the compute resources of production.
+
+## Branch creation time
+
+Because Managed Postgres uses NVMe-backed PostgreSQL storage, branches are restored from backups rather than created through storage-level copy-on-write mechanisms. As a result, branch creation isn't instantaneous.
+
+Typical branch creation times range from several minutes to tens of minutes, depending on:
+
+- Database size
+- Backup size
+- Recovery point
+- Amount of WAL that must be replayed
+- Overall cluster configuration
+
+For most deployments, branches are available within a few minutes. Larger databases may require additional time.
+
+If branch creation time becomes a bottleneck for your workflow, contact the ClickHouse team. In many cases, branch recovery performance can be optimized based on workload characteristics and recovery requirements.
+
+## Branches vs local development
+
+A common question is whether every developer should use a production branch as their development environment.
+
+While branches are useful for testing, validation, and staging workflows, they're generally not the recommended approach for day-to-day application development. Each branch is a separate PostgreSQL deployment that must be restored from backups and maintained independently. Creating large numbers of branches can increase infrastructure costs and operational complexity.
+
+For most organizations, we recommend:
+
+- Using PostgreSQL branches for staging, testing, debugging, and validation workflows.
+- Using local PostgreSQL environments for day-to-day development.
+- Generating synthetic development datasets or using sanitized datasets where appropriate.
+- Avoiding routine development directly against production-derived branches.
+
+This approach reduces load on production systems, improves development velocity, and helps ensure that production data remains appropriately protected.
+
+For guidance on creating local PostgreSQL development environments using Docker, see [Local development environments](/docs/cloud/managed-postgres/local-development).
+
+## Recommended workflow
+
+A common workflow looks like:
+
+```
+Production Database
+        │
+        ├─────────────► Branch
+        │                  │
+        │                  ├── Staging
+        │                  ├── Validation
+        │                  ├── Migration Testing
+        │                  └── Incident Investigation
+        │
+        └─────────────► Local Development
+                               │
+                               ├── Docker PostgreSQL
+                               ├── Application Migrations
+                               └── Synthetic Test Data
+```
+
+Branches are best suited for environments that need a production-like copy of a database. For routine development, local PostgreSQL environments typically provide a faster, lower-cost, and more scalable workflow.

--- a/docs/cloud/managed-postgres/branching.md
+++ b/docs/cloud/managed-postgres/branching.md
@@ -82,7 +82,7 @@ For guidance on creating local PostgreSQL development environments using Docker,
 
 A common workflow looks like:
 
-```
+```text
 Production Database
         │
         ├─────────────► Branch

--- a/docs/cloud/managed-postgres/migrations/overview.md
+++ b/docs/cloud/managed-postgres/migrations/overview.md
@@ -67,3 +67,7 @@ Once data is moving, use [data validation](/cloud/managed-postgres/migrations/da
 to confirm row counts and content match between source and target before
 cutting over application traffic. The [migrations FAQ](/cloud/managed-postgres/migrations/faq)
 covers common errors and recovery steps.
+
+## Migrating from Supabase {#supabase}
+
+If you're migrating from Supabase, see the [Supabase to Managed Postgres migration guide](https://github.com/iskakaushik/supa-auth-migrate/blob/main/MIGRATION.md) for a step-by-step walkthrough.

--- a/sidebars.js
+++ b/sidebars.js
@@ -378,6 +378,7 @@ const sidebars = {
         'cloud/managed-postgres/read-replicas',
         'cloud/managed-postgres/scaling',
         'cloud/managed-postgres/backup-and-restore',
+        'cloud/managed-postgres/branching',
         'cloud/managed-postgres/security',
         'cloud/managed-postgres/rbac',
         'cloud/managed-postgres/local-development',

--- a/styles/ClickHouse/Headings.yml
+++ b/styles/ClickHouse/Headings.yml
@@ -647,5 +647,6 @@ exceptions:
   - I/O
   - JOIN
   - RESTORE
+  - Supabase
   - ClickHouse Connect
   - re2


### PR DESCRIPTION
## Summary
Adds doc on branching (PITR) for Managed Postgres and a link to migrating off of Supabase

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new page, sidebar entry, style exception, external link); no application or infrastructure code.
> 
> **Overview**
> Adds **Managed Postgres branching** documentation and wires it into the docs site, plus a **Supabase migration** pointer on the migrations overview.
> 
> The new **Branching** guide explains PITR-based branches as **independent PostgreSQL deployments** (backup restore + WAL replay, not copy-on-write), with sections on use cases, separate branch sizing, expected creation time, guidance to prefer **local dev** over per-developer production branches, and a recommended workflow diagram linking to **local development**.
> 
> The **Data migration** overview gains a **Migrating from Supabase** section that links to an external step-by-step guide on GitHub. Navigation adds `cloud/managed-postgres/branching` after **backup-and-restore**, and **Supabase** is added to heading capitalization exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193ea02b37f20d6179cc28e24de5f37ea720e1df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->