### PR TITLE
Fix typo in 07_saml-sso-setup.md

### DIFF
--- a/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
@@ -22,7 +22,7 @@ import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge
 
 ClickHouse Cloud supports single-sign on (SSO) via security assertion markup language (SAML). This enables you to sign in securely to your ClickHouse Cloud organization by authenticating with your identity provider (IdP).
 
-We currently support service provider-initiated SSO SSO, multiple organizations using separate connections, and just-in-time provisioning. We don't yet support a system for cross-domain identity management (SCIM) or attribute mapping.
+We currently support service provider-initiated SSO, multiple organizations using separate connections, and just-in-time provisioning. We don't yet support a system for cross-domain identity management (SCIM) or attribute mapping.
 
 Customers enabling SAML integrations can also designate the default role that will be assigned to new users and adjust session timeout settings.
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fix typo

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no product or security behavior changes.
> 
> **Overview**
> Corrects a duplicated word in the SAML SSO setup guide: **service provider-initiated SSO SSO** is now **service provider-initiated SSO** in the supported-capabilities sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c476bc96986c151bcc0c12871fc8b437645c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->