### PR TITLE
ClickStack NurtureFlows - Better Titles

### DIFF
--- a/docs/use-cases/observability/clickstack/managed-onboarding/instrument-application.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/instrument-application.md
@@ -1,6 +1,6 @@
 ---
 slug: /use-cases/observability/clickstack/instrument-application
-title: 'Instrument an application in 5 mins with ClickStack'
+title: 'Instrument an application in 5 mins with Managed ClickStack'
 description: 'Instrument a Node.js application with OpenTelemetry and send its logs, metrics, and traces into Managed ClickStack'
 doc_type: 'guide'
 keywords: ['clickstack', 'instrumentation', 'opentelemetry', 'managed', 'observability', 'sdk', 'nodejs']

--- a/docs/use-cases/observability/clickstack/managed-onboarding/instrument-application.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/instrument-application.md
@@ -1,6 +1,6 @@
 ---
 slug: /use-cases/observability/clickstack/instrument-application
-title: 'Instrument an application'
+title: 'Instrument an application in 5 mins with ClickStack'
 description: 'Instrument a Node.js application with OpenTelemetry and send its logs, metrics, and traces into Managed ClickStack'
 doc_type: 'guide'
 keywords: ['clickstack', 'instrumentation', 'opentelemetry', 'managed', 'observability', 'sdk', 'nodejs']

--- a/docs/use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs.md
@@ -1,6 +1,6 @@
 ---
 slug: /use-cases/observability/clickstack/monitoring-aws-cloudwatch-logs
-title: 'Monitoring AWS CloudWatch logs'
+title: 'Monitoring AWS CloudWatch logs with Managed ClickStack'
 description: 'Forward AWS CloudWatch logs into Managed ClickStack via the OpenTelemetry CloudWatch receiver'
 doc_type: 'guide'
 keywords: ['clickstack', 'aws', 'cloudwatch', 'logs', 'managed', 'observability', 'otel']

--- a/docs/use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 slug: /use-cases/observability/clickstack/monitoring-kubernetes
-title: 'Monitoring Kubernetes'
+title: 'Monitoring Kubernetes with Managed ClickStack'
 description: 'Collect logs, infrastructure metrics, and events from a Kubernetes cluster into Managed ClickStack'
 doc_type: 'guide'
 keywords: ['clickstack', 'kubernetes', 'k8s', 'managed', 'observability', 'logs', 'metrics', 'events', 'daemonset', 'helm']

--- a/docs/use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
@@ -1,6 +1,6 @@
 ---
 slug: /use-cases/observability/clickstack/tuning-clickstack-schema
-title: 'Tuning ClickStack: refining your schema'
+title: 'Tuning Managed ClickStack - refining your schema'
 description: 'Refine your ClickStack schema for improved query performance and storage efficiency in Managed ClickStack'
 doc_type: 'guide'
 keywords: ['clickstack', 'tuning', 'schema', 'managed', 'observability', 'performance', 'optimization', 'storage']


### PR DESCRIPTION
## Summary

just some title changes. Please just merge.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter title changes with no slug or content edits; no runtime or security impact.
> 
> **Overview**
> Updates **page titles** in four unlisted Managed ClickStack nurture/onboarding guides so they clearly mention **Managed ClickStack** (and, for instrumentation, a **5-minute** hook).
> 
> **`instrument-application.md`**: `Instrument an application` → `Instrument an application in 5 mins with Managed ClickStack`.
> 
> **`monitoring-aws-cloudwatch-logs.md`** and **`monitoring-kubernetes.md`**: titles gain the suffix `with Managed ClickStack`.
> 
> **`tuning-clickstack-schema.md`**: `Tuning ClickStack: refining your schema` → `Tuning Managed ClickStack - refining your schema`.
> 
> Slugs, descriptions, and guide bodies are unchanged—navigation URLs and content stay the same; only how titles render in the docs UI (and related metadata) changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f1122928d7e26d79288f48cc9e47ee11fbfc48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->