### PR TITLE
example prompt and skill for clickstack onboarding

### DIFF
--- a/docs/use-cases/observability/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector.md
@@ -19,6 +19,19 @@ import ConfirmInUI from '@site/docs/use-cases/observability/clickstack/managed-o
 
 This guide walks you through deploying an OpenTelemetry collector against an existing Managed ClickStack service, or adapting your existing collector, before verifying that data is flowing through.
 
+<AgentPrompt
+  prompt="Use curl to download, read and follow: https://clickhouse.com/docs/skills/clickstack-otel-collector/SKILL.md"
+  description="Your agent will set up the ClickStack OpenTelemetry collector for you. Works with Claude Code, Cursor, Codex, and other coding agents."
+  outline={[
+    "Install clickhousectl if missing and authenticate it (asks you for a ClickHouse Cloud API key — paste in chat or run the login command yourself).",
+    "Ask you for the target ClickHouse Cloud service ID or name, then fetch its HTTPS endpoint.",
+    "Create a hyperdx_ingest SQL user on the service (generates a strong password, or uses one you provide).",
+    "Run the ClickStack OpenTelemetry collector locally in Docker, pointed at your service.",
+    "Send a short burst of synthetic logs, traces, and metrics through the collector to prove the pipeline works.",
+    "Verify the data has landed in the otel database, and hand you the ClickStack UI URL where you can view it."
+  ]}
+/>
+
 The collector runs as a **gateway**: a single OTLP endpoint that your applications, SDKs, and agent collectors send to. The gateway batches events, applies any processing you've configured, and writes them to ClickHouse via the [ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter). This pattern keeps collection logic out of your application code and lets you scale ingestion independently of the workloads producing data. For background on gateway versus agent roles, see [Collector roles](/use-cases/observability/clickstack/ingesting-data/otel-collector#collector-roles).
 
 :::note Existing collector

--- a/src/components/AgentPrompt/AgentPrompt.tsx
+++ b/src/components/AgentPrompt/AgentPrompt.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback, useState } from 'react';
+import styles from './styles.module.scss';
+
+interface AgentPromptProps {
+  prompt: string;
+  title?: string;
+  description?: React.ReactNode;
+  outline?: string[];
+  outlineLabel?: string;
+}
+
+const CopyIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const AgentPrompt: React.FC<AgentPromptProps> = ({
+  prompt,
+  title = 'Agent-Assisted Setup',
+  description,
+  outline,
+  outlineLabel = 'What the agent will do',
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(prompt);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = prompt;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* swallow — fallback already attempted */
+    }
+  }, [prompt]);
+
+  return (
+    <div className={styles.wrapper} data-mdast="ignore">
+      <div className={styles.mainRow}>
+        <div className={styles.left}>
+          <span className={styles.title}>{title}</span>
+        </div>
+        <div className={styles.promptArea}>
+          <code className={styles.promptText}>{prompt}</code>
+        </div>
+        <button
+          type="button"
+          className={styles.copyButton}
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied' : 'Copy prompt'}
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+          <span>{copied ? 'Copied' : 'Copy Prompt'}</span>
+        </button>
+      </div>
+      {description && (
+        <div className={styles.subRow}>
+          <span className={styles.description}>{description}</span>
+        </div>
+      )}
+      {outline && outline.length > 0 && (
+        <details className={styles.outline}>
+          <summary className={styles.outlineSummary}>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 15 15"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className={styles.outlineChevron}
+              aria-hidden="true"
+            >
+              <path
+                d="M6.1584 3.13508C6.35985 2.94621 6.67627 2.95642 6.86514 3.15788L10.6151 7.15788C10.7954 7.3502 10.7954 7.64949 10.6151 7.84182L6.86514 11.8418C6.67627 12.0433 6.35985 12.0535 6.1584 11.8646C5.95694 11.6757 5.94673 11.3593 6.1356 11.1579L9.565 7.49985L6.1356 3.84182C5.94673 3.64036 5.95694 3.32394 6.1584 3.13508Z"
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span>{outlineLabel}</span>
+          </summary>
+          <ol className={styles.outlineList}>
+            {outline.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ol>
+        </details>
+      )}
+    </div>
+  );
+};
+
+export default AgentPrompt;

--- a/src/components/AgentPrompt/index.ts
+++ b/src/components/AgentPrompt/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AgentPrompt';

--- a/src/components/AgentPrompt/styles.module.scss
+++ b/src/components/AgentPrompt/styles.module.scss
@@ -1,0 +1,195 @@
+// AgentPrompt — ClickStack yellow agent-prompt callout.
+// Mirrors the principle of Sentry's "Agent-Assisted Setup" widget but
+// rebranded to ClickStack's brand yellow (--palette_brand_350 / 300 / 50).
+
+.wrapper {
+  --agent-accent: var(--palette_brand_350);     // #FBFF46
+  --agent-accent-soft: var(--palette_brand_300); // #FCFF74
+  --agent-accent-bg: var(--palette_brand_50);    // #FFFFE8
+  --agent-accent-bg-strong: var(--palette_brand_100); // #FEFFBA
+  --agent-text: var(--palette_slate_900);
+  --agent-text-muted: var(--palette_slate_600);
+  --agent-prompt-bg: #FFFFFF;
+  --agent-prompt-border: var(--palette_brand_300);
+  --agent-button-bg: var(--palette_brand_350);
+  --agent-button-bg-hover: var(--palette_brand_400);
+  --agent-button-text: var(--palette_slate_900);
+
+  border: 1px solid var(--agent-accent);
+  background: var(--agent-accent-bg);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin: 1.25rem 0 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+}
+
+.mainRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+}
+
+.left {
+  flex-shrink: 0;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--agent-text);
+  white-space: nowrap;
+}
+
+.promptArea {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: var(--agent-prompt-bg);
+  border: 1px solid var(--agent-prompt-border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  overflow-x: auto;
+
+  // Hide scrollbar but keep scrollability
+  scrollbar-width: thin;
+  &::-webkit-scrollbar { height: 6px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--palette_brand_300);
+    border-radius: 3px;
+  }
+}
+
+.promptText {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8125rem;
+  color: var(--agent-text);
+  background: transparent;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
+  display: block;
+}
+
+.copyButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--agent-button-bg);
+  color: var(--agent-button-text);
+  border: 1px solid var(--agent-accent);
+  border-radius: 6px;
+  padding: 7px 12px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 120ms ease, transform 80ms ease;
+
+  &:hover {
+    background: var(--agent-button-bg-hover);
+  }
+  &:active {
+    transform: translateY(1px);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--palette_info_400);
+    outline-offset: 2px;
+  }
+}
+
+.subRow {
+  padding-left: 2px;
+}
+
+.description {
+  font-size: 0.8125rem;
+  color: var(--agent-text-muted);
+  line-height: 1.4;
+}
+
+.outline {
+  border-top: 1px dashed var(--agent-prompt-border);
+  padding-top: 8px;
+  margin-top: 2px;
+}
+
+.outlineSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--agent-text);
+  list-style: none;
+  user-select: none;
+  padding: 2px 0;
+
+  &::-webkit-details-marker { display: none; }
+  &:hover { opacity: 0.85; }
+  &:focus-visible {
+    outline: 2px solid var(--palette_info_400);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+}
+
+.outlineChevron {
+  transition: transform 150ms ease;
+  flex-shrink: 0;
+}
+
+details[open] > .outlineSummary > .outlineChevron {
+  transform: rotate(90deg);
+}
+
+.outlineList {
+  margin: 8px 0 2px 0;
+  padding-left: 1.4rem;
+  font-size: 0.8125rem;
+  color: var(--agent-text-muted);
+  line-height: 1.5;
+
+  li {
+    margin: 2px 0;
+    padding-left: 2px;
+  }
+  li::marker {
+    color: var(--agent-text);
+    font-weight: 600;
+  }
+}
+
+@media (max-width: 768px) {
+  .mainRow {
+    flex-wrap: wrap;
+  }
+  .promptArea {
+    order: 3;
+    width: 100%;
+    flex-basis: 100%;
+  }
+  .copyButton {
+    margin-left: auto;
+  }
+  .promptText {
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+}
+
+[data-theme='dark'] .wrapper {
+  --agent-accent: var(--palette_brand_300);
+  --agent-accent-bg: rgba(251, 255, 70, 0.06);
+  --agent-text: var(--palette_neutral_0);
+  --agent-text-muted: var(--palette_neutral_200);
+  --agent-prompt-bg: var(--palette_neutral_800);
+  --agent-prompt-border: rgba(251, 255, 70, 0.35);
+  --agent-button-bg: var(--palette_brand_300);
+  --agent-button-bg-hover: var(--palette_brand_350);
+  --agent-button-text: var(--palette_neutral_900);
+}
+

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -7,10 +7,12 @@ import MDXComponents from '@theme-original/MDXComponents';
 import VStepper from '@site/src/components/Stepper/Stepper';
 import GlossaryTooltip from '@site/src/components/GlossaryTooltip/GlossaryTooltip';
 import KapaLink from '@site/src/components/KapaAI/KapaLink';
+import AgentPrompt from '@site/src/components/AgentPrompt';
 
 // Define the enhanced components
 const enhancedComponents = {
     ...MDXComponents,
+    AgentPrompt,
     KapaLink,
     GlossaryTooltip,
     ul: (props) => <ul className="custom-ul" {...props} />,

--- a/static/skills/clickstack-otel-collector/SKILL.md
+++ b/static/skills/clickstack-otel-collector/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: clickstack-otel-collector
+description: Use when a user wants to set up the OpenTelemetry collector for Managed ClickStack on a ClickHouse Cloud service, send logs/traces/metrics, and verify the data lands in ClickStack.
+license: Apache-2.0
+metadata:
+  author: ClickHouse Inc
+  version: "0.1.0"
+---
+
+# Set up the ClickStack OpenTelemetry collector
+
+This skill walks an agent through wiring an OpenTelemetry collector into a Managed ClickStack service running on ClickHouse Cloud. It uses [`clickhousectl`](https://clickhouse.com/docs/interfaces/cli) for all cloud and SQL operations.
+
+The end state is:
+
+- A dedicated `hyperdx_ingest` SQL user on the target service.
+- A ClickStack-distribution OpenTelemetry collector running locally, accepting OTLP on `4317`/`4318` and writing into the `otel` database on the target service.
+- Synthetic telemetry exercising the pipeline.
+- A URL the user can open to view the data in ClickStack.
+
+Follow these steps in order. Do not skip ahead — each step depends on state established by the previous one.
+
+---
+
+## Before you begin: heads-up on permissions
+
+Coding agents typically ask the user to approve each shell command the first time they see it. To keep this run smooth, tell the user up front what categories of commands you'll need to run, and ask them to grant the permissions in one batch — "allow always" / "approve for session" in their agent — for each category below. That way you won't have to interrupt them every few steps.
+
+You will run, in order:
+
+1. **`openssl rand …`** — to generate a random OTLP auth token and a SQL password.
+2. **`clickhousectl …`** — to authenticate, look up the service, and run SQL via the Query API. Specifically: `cloud auth status`, `cloud auth login`, `cloud service get`, `cloud service query`.
+3. **`docker info`, `docker run`, `docker ps`, `docker logs`** — to deploy and observe the OpenTelemetry collector container.
+4. **`otelgen …`** — to send synthetic logs, traces, and metrics through the collector.
+5. **`jq …`** and **`curl …`** — small text/JSON utilities and one local HTTP healthcheck.
+
+Tell the user: *"If your agent supports it, choose 'always allow' for each command class above the first time it asks — there are no destructive operations and no commands targeting anything outside this project / your ClickHouse Cloud service."*
+
+Then continue.
+
+---
+
+## Step 1: Confirm the target service
+
+The user's prompt contains a service identifier — either a service ID (UUID) or a service name. Treat that value as `SERVICE_REF`.
+
+**Ask the user to confirm**, and capture three values in your working memory:
+
+1. `SERVICE_REF` — what they gave you.
+2. `OTLP_AUTH_TOKEN` — a shared secret the collector will require on inbound OTLP requests. Generate a random one (e.g. `openssl rand -hex 16`) unless the user provides one.
+3. `HYPERDX_PASSWORD` — the password for the `hyperdx_ingest` SQL user. Generate a strong random password (e.g. `openssl rand -base64 32`) unless the user provides one.
+
+Echo the values back to the user with a one-line note that the OTLP token and the SQL password are sensitive. Do **not** print the password again after this confirmation.
+
+---
+
+## Step 2: Install and authenticate `clickhousectl`
+
+Check `clickhousectl` is on `PATH`:
+
+```bash
+which clickhousectl
+```
+
+If it is missing, install it:
+
+```bash
+curl -fsSL https://clickhouse.com/cli | sh
+```
+
+Then verify authentication:
+
+```bash
+clickhousectl cloud auth status
+```
+
+The skill needs **API key authentication** (OAuth is read-only and cannot create users or run write queries). If the `API key` row is not `Active`, ask the user for credentials:
+
+> I need a ClickHouse Cloud API key to create the ingestion user and verify the data.
+>
+> **To get one**, open the [ClickHouse Cloud console](https://console.clickhouse.cloud), open the **Organization** menu on the left nav, choose **API keys**, then **New API key**. Select the **Admin** role — Developer-scoped keys can't auto-provision the per-service query endpoint that `cloud service query` uses.
+>
+> **Then, either:**
+>
+> - **Paste them in your next message** and I'll authenticate from this session, **or**
+> - **Authenticate yourself in a separate terminal** with:
+>
+>   ```bash
+>   clickhousectl cloud auth login --api-key <key-id> --api-secret <key-secret>
+>   ```
+>
+>   …and tell me when you're done — I'll poll `clickhousectl cloud auth status` until the API key row shows `Active`.
+
+If the user pastes credentials, run the login command yourself (do not echo the secret back) and then verify:
+
+```bash
+clickhousectl cloud auth status
+```
+
+Do not continue until the API key row is `Active`.
+
+---
+
+## Step 3: Resolve the service and capture the HTTPS endpoint
+
+Find the target service. If `SERVICE_REF` looks like a UUID, use it directly; otherwise, look it up by name:
+
+```bash
+# UUID form
+clickhousectl cloud service get "$SERVICE_REF" --json
+
+# Name form (search across orgs)
+clickhousectl cloud service list --json | jq '.[] | select(.name=="<name>")'
+```
+
+From the JSON, extract:
+
+- `id` → `SERVICE_ID`
+- `name` → `SERVICE_NAME`
+- `state` — must be `running`. If it is `stopped` or `starting`, ask the user to start the service or wait; do not proceed.
+- The `endpoints` array entry with `"protocol": "https"` → `HTTPS_ENDPOINT_HOST` and `HTTPS_ENDPOINT_PORT` (typically `8443`).
+
+Note: `port` in the JSON is a number that may serialize as a float (`8443.0`). Coerce it to an integer when building the URL — for example with `jq`:
+
+```bash
+HTTPS_ENDPOINT=$(jq -r '.endpoints[] | select(.protocol=="https") | "https://\(.host):\(.port | tonumber | floor)"' /tmp/svc.json)
+```
+
+That produces:
+
+```
+CLICKHOUSE_ENDPOINT=https://<host>:8443
+```
+
+Do not let `:8443.0` leak through — the OTel collector's ClickHouse exporter will fail to dial it.
+
+Sanity-check the service is reachable via the query API:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query "SELECT version()"
+```
+
+A successful response confirms both the service and the per-service query endpoint key were provisioned. If this is the first time, `clickhousectl` will print `Provisioning Query API endpoint + key for service '<name>'...` — that is expected.
+
+---
+
+## Step 4: Create the `hyperdx_ingest` SQL user
+
+Create the user and grant it the minimum privileges the ClickStack OTel collector needs to create the `otel` database and write into it:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query \
+  "CREATE USER hyperdx_ingest IDENTIFIED WITH sha256_password BY '$HYPERDX_PASSWORD'"
+
+clickhousectl cloud service query --id "$SERVICE_ID" --query \
+  "GRANT SELECT, INSERT, CREATE DATABASE, CREATE TABLE, CREATE VIEW ON otel.* TO hyperdx_ingest"
+```
+
+If `CREATE USER` fails with `already exists`, rotate the password instead so this run uses a known value:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query \
+  "ALTER USER hyperdx_ingest IDENTIFIED WITH sha256_password BY '$HYPERDX_PASSWORD'"
+```
+
+Verify the grants:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query "SHOW GRANTS FOR hyperdx_ingest"
+```
+
+You should see `GRANT SELECT, INSERT, CREATE DATABASE, CREATE TABLE, CREATE VIEW ON otel.* TO hyperdx_ingest`.
+
+---
+
+## Step 5: Deploy the ClickStack OpenTelemetry collector
+
+Run the ClickStack-distribution collector locally. It is preconfigured for Managed ClickStack — it creates the `otel.*` schema on first use and routes Session Replay events to `otel.hyperdx_sessions`.
+
+Make sure Docker is running:
+
+```bash
+docker info > /dev/null
+```
+
+Start the collector:
+
+```bash
+docker run -d \
+  --name clickstack-otel-collector \
+  -e OTLP_AUTH_TOKEN="$OTLP_AUTH_TOKEN" \
+  -e CLICKHOUSE_ENDPOINT="$CLICKHOUSE_ENDPOINT" \
+  -e CLICKHOUSE_USER=hyperdx_ingest \
+  -e CLICKHOUSE_PASSWORD="$HYPERDX_PASSWORD" \
+  -e HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=otel \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  clickhouse/clickstack-otel-collector:latest
+```
+
+Confirm it is healthy:
+
+```bash
+docker ps --filter name=clickstack-otel-collector --format '{{.Status}}'
+docker logs --tail 30 clickstack-otel-collector 2>&1 | tail -30
+```
+
+The logs should contain `Everything is ready. Begin running and processing data.` (or equivalent), and no repeated `clickhouseexporter` connection errors. If you see TLS or auth errors, the most common cause is a malformed `CLICKHOUSE_ENDPOINT` (must include `https://` and the `:8443` port).
+
+---
+
+## Step 6: Send synthetic telemetry and verify ingestion
+
+Install [`otelgen`](https://github.com/krzko/otelgen). On macOS:
+
+```bash
+brew install krzko/tap/otelgen
+```
+
+Otherwise, with Go:
+
+```bash
+go install github.com/krzko/otelgen@latest
+```
+
+### Time-box every otelgen call
+
+`otelgen`'s flag handling is inconsistent — `--duration` is honored on some subcommands and silently ignored on others (notably `metrics`, but in practice not reliable on `logs multi` / `traces multi` either, depending on the build). So **do not trust `--duration`** to terminate the process. Instead, wrap every call in a small bash helper that backgrounds it, waits a bounded number of seconds, and then sends `SIGINT` (followed by `SIGKILL` if it ignores the interrupt):
+
+```bash
+run_otelgen() {
+  # usage: run_otelgen <wall-clock-seconds> <otelgen-subcommand-args...>
+  local secs="$1"; shift
+  otelgen --otel-exporter-otlp-endpoint localhost:4317 --insecure --protocol grpc \
+          --header "authorization=$OTLP_AUTH_TOKEN" --rate 5 "$@" &
+  local pid=$!
+  ( sleep "$secs" && kill -INT "$pid" 2>/dev/null \
+    && sleep 3 && kill -KILL "$pid" 2>/dev/null ) &
+  local watchdog=$!
+  wait "$pid" 2>/dev/null || true
+  kill "$watchdog" 2>/dev/null || true
+}
+```
+
+Define this once, then send a short burst of each signal:
+
+```bash
+run_otelgen 20 logs multi
+run_otelgen 20 traces multi
+run_otelgen 15 metrics sum
+```
+
+Each call returns when the wall-clock budget expires — no hung processes, no stalled scripts.
+
+Notes on the synthetic data:
+
+- `logs multi` and `traces multi` emit several events per tick; 20 seconds is plenty to populate `otel_logs` and `otel_traces`.
+- `metrics sum` only emits one data point every few seconds — 15 seconds yields 2–3 points, which is enough to verify the metrics path.
+- See the [otelgen synthetic-data guide](/use-cases/observability/clickstack/getting-started/otelgen) for the other `metrics` subcommands (`gauge`, `histogram`, `exponential-histogram`).
+
+Wait ~15 seconds for the collector batch flush. The ClickStack collector creates its tables on first write — confirm they exist:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query \
+  "SELECT name FROM system.tables WHERE database='otel' ORDER BY name"
+```
+
+Expect at minimum `otel_logs`, `otel_traces`, and one or more `otel_metrics_*` tables. Then confirm rows are landing in each signal. The schema uses standard upstream ClickHouse-exporter column names (`Timestamp` on logs/traces, `TimeUnix` on metrics) — but rather than hard-coding column names, count by `parts.rows` on the underlying parts which is signal-agnostic:
+
+```bash
+clickhousectl cloud service query --id "$SERVICE_ID" --query \
+  "SELECT table, sum(rows) AS rows
+   FROM system.parts
+   WHERE database='otel' AND active
+     AND table IN ('otel_logs','otel_traces',
+                   'otel_metrics_sum','otel_metrics_gauge',
+                   'otel_metrics_histogram','otel_metrics_exponential_histogram',
+                   'otel_metrics_summary')
+   GROUP BY table
+   ORDER BY table"
+```
+
+You should see non-zero `rows` for `otel_logs`, `otel_traces`, and at least one `otel_metrics_*` table (`otel_metrics_sum` if you used the `metrics sum` command above). If any signal is missing:
+
+1. Tail the collector logs (`docker logs --tail 50 clickstack-otel-collector`) for export errors.
+2. Confirm the `authorization` header sent by `otelgen` matches `$OTLP_AUTH_TOKEN`.
+3. Re-check `CLICKHOUSE_ENDPOINT` includes the `:8443` port and `https://` scheme.
+4. Some metric kinds take longer to flush — re-run the query after another 30 seconds before declaring failure.
+
+Do not proceed until every expected signal has non-zero rows.
+
+---
+
+## Step 7: Summarize the result and hand off
+
+The collector is running as a local Docker container on this machine. The ClickStack UI is reached most directly at:
+
+```
+https://hyperdx.clickhouse.cloud/search?chcServiceId=<SERVICE_ID>
+```
+
+(There is also a Cloud-console route — `https://console.clickhouse.cloud/services/<SERVICE_ID>/clickstack` — which redirects to the same UI after auth. Either works; prefer the direct HyperDX URL.)
+
+Print a summary to the user, formatted exactly like this:
+
+```
+✅ ClickStack is set up and ingesting telemetry for service <SERVICE_NAME> (<SERVICE_ID>).
+
+Local OpenTelemetry collector
+  ▸ Container: clickstack-otel-collector (Docker)
+  ▸ Send OTLP gRPC to: localhost:4317
+  ▸ Send OTLP HTTP to: localhost:4318
+  ▸ Required header:   authorization: <OTLP_AUTH_TOKEN>
+
+ClickHouse target
+  ▸ Endpoint: <CLICKHOUSE_ENDPOINT>
+  ▸ SQL user: hyperdx_ingest
+  ▸ Database: otel
+
+Open ClickStack:
+  ▸ https://hyperdx.clickhouse.cloud/search?chcServiceId=<SERVICE_ID>
+```
+
+Then tell the user, in your own words, that:
+
+1. The collector keeps running until they stop the container — `docker stop clickstack-otel-collector` shuts it down; `docker start clickstack-otel-collector` brings it back.
+2. Any application, SDK, or agent collector on this host can now send OTLP to `localhost:4317` (gRPC) or `localhost:4318` (HTTP), with the `authorization` header above.
+3. Synthetic data is already flowing — they can open the HyperDX URL above to see logs / traces / metrics under the `otelgen` service.
+
+---
+
+## Cleanup (only if the user explicitly asks)
+
+```bash
+docker rm -f clickstack-otel-collector
+
+clickhousectl cloud service query --id "$SERVICE_ID" --query "DROP USER IF EXISTS hyperdx_ingest"
+```
+
+Do **not** drop the `otel` database — it contains telemetry the user may want to retain.


### PR DESCRIPTION
## Summary

This is an example skill that we're going to use during our onboarding for ClickStack. The skill is exposed through a widget in the UI where the user can just simply copy the prompt to pull the skill.

Example at:

/use-cases/observability/clickstack/setting-up-your-opentelemetry-collector


## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and front-end UI only; no runtime auth or ingestion code changes in the site itself.
> 
> **Overview**
> Adds **agent-assisted ClickStack OTel onboarding**: a new **`AgentPrompt`** MDX callout (copyable prompt, short description, expandable step outline) and wires it into the OpenTelemetry collector setup guide so readers can paste a prompt that fetches the hosted skill.
> 
> Also publishes **`static/skills/clickstack-otel-collector/SKILL.md`**, a step-by-step agent playbook (via `clickhousectl`, Docker collector, `otelgen`, and ingestion checks) aligned with the manual guide, and registers **`AgentPrompt`** in `MDXComponents.js` for reuse on other pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889943e5fbf1485c6c23e0e138554d56904e3e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->