### PR TITLE
chore: add specs floating page exception

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -18,3 +18,9 @@ use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs.md
 use-cases/observability/clickstack/managed-onboarding/instrument-application.md
 use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
+
+# NOTE(kavi): To be removed after core PRs are merged
+# https://github.com/ClickHouse/ClickHouse/pull/106723
+
+interfaces/specs/NativeProtocol.md
+interfaces/specs/NativeFormat.md


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
We have PRs in core that add new "specs" path in the docs to add two format specifications
1. Native ClickHouse Protocol
2. Native ClickHouse Format

This PR adds the exception as per the guide here
https://github.com/ClickHouse/clickhouse-docs/blob/main/contribute/style-guide.md#floating-pages to avoid CI failures on core repo.

Once the PRs are merged I will revert back this change
https://github.com/ClickHouse/ClickHouse/pull/106723
https://github.com/ClickHouse/ClickHouse/pull/106720

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the floating-pages exception list for CI; no user-facing docs or runtime behavior changes.
> 
> **Overview**
> Adds **temporary** entries to `plugins/floating-pages-exceptions.txt` so the floating-pages CI check does not fail while new spec docs land from ClickHouse core.
> 
> The exception list now skips `interfaces/specs/NativeProtocol.md` and `interfaces/specs/NativeFormat.md`, with a comment pointing at [ClickHouse#106723](https://github.com/ClickHouse/ClickHouse/pull/106723) and noting these lines should be removed once those core PRs merge and the pages are wired into `sidebars.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c017e5175efba799ba3a80c27d5e8b6e80bd801b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->