### PR TITLE
Document `reuse_connections` profile option for dbt-clickhouse

### DIFF
--- a/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
+++ b/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
@@ -51,6 +51,7 @@ your_profile_name:
       local_db_prefix: [<empty string>] # Database prefix of local tables on shards for distributed materializations. If empty, it uses the same database as the distributed table.
       allow_automatic_deduplication: [False] # Enable ClickHouse automatic deduplication for Replicated tables
       tcp_keepalive: [False] # Native client only, specify TCP keepalive configuration. Specify custom keepalive settings as [idle_time_sec, interval_sec, probes].
+      reuse_connections: [True] # Re-use the same connection across models. Set to `False` to close the connection at the end of each model — useful on multi-replica ClickHouse Cloud services where the load balancer routes by TCP connection.
       custom_settings: [{}] # A dictionary/mapping of custom ClickHouse settings for the connection - default is empty.
       database_engine: '' # Database engine to use when creating new ClickHouse schemas (databases).  If not set (the default), new databases will use the default ClickHouse database engine (usually Atomic).
       threads: [1] # Number of threads to use when running queries. Before setting it to a number higher than 1, make sure to read the [read-after-write consistency](#read-after-write-consistency) section.


### PR DESCRIPTION
## Summary

Documents the new `reuse_connections` option in the dbt-clickhouse adapter's `profiles.yml` configuration table. Follow-up to [ClickHouse/dbt-clickhouse#669](https://github.com/ClickHouse/dbt-clickhouse/issues/669) / [ClickHouse/dbt-clickhouse#670](https://github.com/ClickHouse/dbt-clickhouse/pull/670).

When set to `false`, dbt closes the underlying connection at the end of each model so the next model opens a fresh TCP connection — useful on multi-replica ClickHouse Cloud services where the load balancer routes by connection and a long-lived pool would otherwise pin a `dbt run` to a single replica. Default is `true`, preserving current behaviour.

Single-line addition next to the related `tcp_keepalive` setting in `docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md`.

## Checklist
- [x] Delete items not relevant to your PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes in this repo.
> 
> **Overview**
> Adds **`reuse_connections`** to the dbt ClickHouse **`profiles.yml`** reference in `features-and-configurations.md`, placed after **`tcp_keepalive`**.
> 
> The entry documents default **`True`** (reuse one connection across models) and **`False`** (close after each model for a new TCP connection), with guidance for **multi-replica ClickHouse Cloud** when the load balancer pins traffic by connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d298f2491cd2c60be08bb4edf109aa8fbfcf7d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->