### PR TITLE
docs(clickpipes/mysql): FAQ for binlog event exceeding max_allowed_packet

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -25,6 +25,27 @@ It's also possible for an inactive database to rotate the log file without allow
 
 At the start of an initial load we record the binlog offset to start at. This offset must still be valid when the initial load finishes in order for CDC to progress. If you're ingesting a large amount of data be sure to configure an appropriate binlog retention period. While setting up tables you can speed up initial load by configuring *Use a custom partitioning key for initial load* for large tables under advanced settings so that we can load a single table in parallel.
 
+### Why is my pipe failing with "log event entry exceeded max_allowed_packet"? {#binlog-event-exceeded-max-allowed-packet}
+
+If your pipe fails with an error similar to:
+
+```
+MySQL execute error: ERROR 1236 (HY000): log event entry exceeded max_allowed_packet;
+Increase max_allowed_packet on source
+```
+
+it means a single binlog event (corresponding to one row change) is larger than your MySQL server's [`max_allowed_packet`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) setting. Because the server cannot send an event that exceeds this limit, the binlog stream read aborts and CDC cannot progress.
+
+This is most often caused by rows containing large `BLOB`, `TEXT`, or `JSON` values. To resolve it:
+
+- **Increase `max_allowed_packet` on the source.** Raise it above the size of your largest row change — setting it to the maximum of `1G` is usually safe:
+  ```sql
+  SET GLOBAL max_allowed_packet = 1073741824; -- 1 GiB
+  ```
+  Set it in your server configuration (e.g. `my.cnf`) as well so it persists across restarts. Existing connections must be re-established for the new value to take effect.
+- **If a single large row is the cause,** [resync the affected table](./table_resync.md) once `max_allowed_packet` has been increased so the pipe can move past it.
+- **If you expect values larger than `1G`,** exclude the large column(s) from replication, as `max_allowed_packet` cannot be raised beyond `1G`. See [Can I include columns I initially excluded from replication?](#include-excluded-columns).
+
 ### Why am I getting a TLS certificate validation error when connecting to MySQL? {#tls-certificate-validation-error}
 
 When connecting to MySQL, you may encounter certificate errors like `x509: certificate is not valid for any names` or `x509: certificate signed by unknown authority`. These occur because ClickPipes enables TLS encryption by default.

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -42,9 +42,8 @@ This is most often caused by rows containing large `BLOB`, `TEXT`, or `JSON` val
   ```sql
   SET GLOBAL max_allowed_packet = 1073741824; -- 1 GiB
   ```
-  Set it in your server configuration (e.g. `my.cnf`) as well so it persists across restarts. Existing connections must be re-established for the new value to take effect.
-- **If a single large row is the cause,** [resync the affected table](./table_resync.md) once `max_allowed_packet` has been increased so the pipe can move past it.
-- **If you expect values larger than `1G`,** exclude the large columns from replication, as `max_allowed_packet` can't be raised beyond `1G`. See [Can I include columns I initially excluded from replication?](#include-excluded-columns).
+  Set it in your server configuration (e.g. `my.cnf` or the DB Parameter Group) as well so it persists across restarts.
+- **If a single row is larger than 1G:** resync the pipe.
 
 ### Why am I getting a TLS certificate validation error when connecting to MySQL? {#tls-certificate-validation-error}
 

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -25,7 +25,7 @@ It's also possible for an inactive database to rotate the log file without allow
 
 At the start of an initial load we record the binlog offset to start at. This offset must still be valid when the initial load finishes in order for CDC to progress. If you're ingesting a large amount of data be sure to configure an appropriate binlog retention period. While setting up tables you can speed up initial load by configuring *Use a custom partitioning key for initial load* for large tables under advanced settings so that we can load a single table in parallel.
 
-### Why is my pipe failing with "log event entry exceeded max_allowed_packet"? {#binlog-event-exceeded-max-allowed-packet}
+### Why is my pipe failing with a max_allowed_packet binlog error? {#binlog-event-exceeded-max-allowed-packet}
 
 If your pipe fails with an error similar to:
 
@@ -34,7 +34,7 @@ MySQL execute error: ERROR 1236 (HY000): log event entry exceeded max_allowed_pa
 Increase max_allowed_packet on source
 ```
 
-it means a single binlog event (corresponding to one row change) is larger than your MySQL server's [`max_allowed_packet`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) setting. Because the server cannot send an event that exceeds this limit, the binlog stream read aborts and CDC cannot progress.
+it means a single binlog event (corresponding to one row change) is larger than your MySQL server's [`max_allowed_packet`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) setting. Because the server can't send an event that exceeds this limit, the binlog stream read aborts and CDC can't progress.
 
 This is most often caused by rows containing large `BLOB`, `TEXT`, or `JSON` values. To resolve it:
 
@@ -44,7 +44,7 @@ This is most often caused by rows containing large `BLOB`, `TEXT`, or `JSON` val
   ```
   Set it in your server configuration (e.g. `my.cnf`) as well so it persists across restarts. Existing connections must be re-established for the new value to take effect.
 - **If a single large row is the cause,** [resync the affected table](./table_resync.md) once `max_allowed_packet` has been increased so the pipe can move past it.
-- **If you expect values larger than `1G`,** exclude the large column(s) from replication, as `max_allowed_packet` cannot be raised beyond `1G`. See [Can I include columns I initially excluded from replication?](#include-excluded-columns).
+- **If you expect values larger than `1G`,** exclude the large columns from replication, as `max_allowed_packet` can't be raised beyond `1G`. See [Can I include columns I initially excluded from replication?](#include-excluded-columns).
 
 ### Why am I getting a TLS certificate validation error when connecting to MySQL? {#tls-certificate-validation-error}
 

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -29,7 +29,7 @@ At the start of an initial load we record the binlog offset to start at. This of
 
 If your pipe fails with an error similar to:
 
-```
+```text
 MySQL execute error: ERROR 1236 (HY000): log event entry exceeded max_allowed_packet;
 Increase max_allowed_packet on source
 ```


### PR DESCRIPTION
## Context

The MySQL ClickPipe can fail with:

```
MySQL execute error: ERROR 1236 (HY000): log event entry exceeded max_allowed_packet;
Increase max_allowed_packet on source; ...
```

This happens when a single binlog event (one row change) is larger than the source server's `max_allowed_packet`, aborting the binlog stream read. It's distinct from binlog corruption/purge and has its own mitigation.

## Change

Add a MySQL FAQ entry under `#binlog-event-exceeded-max-allowed-packet` explaining:
- **what's happening** (oversized binlog event, commonly large `BLOB`/`TEXT`/`JSON` rows)
- **increase `max_allowed_packet`** on the source (up to `1G`)
- **resync the table** if it's a one-off large row
- **exclude the large column(s)** if values are expected to exceed `1G`

This anchor is referenced by the new ClickPipes notification mitigation link for the `NOTIFY_BINLOG_EVENT_EXCEEDED_MAX_ALLOWED_PACKET` error class.

## Related

- PeerDB-io/peerdb#4417 — classifier change
- ClickHouse/clickpipes-platform#6505 — notification payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the MySQL ClickPipes FAQ; no runtime, auth, or data-path code is modified.
> 
> **Overview**
> Adds a **MySQL ClickPipes FAQ** entry (`#binlog-event-exceeded-max-allowed-packet`) for pipes that fail with **ERROR 1236** when a binlog event exceeds the source **`max_allowed_packet`**.
> 
> The new section explains that CDC stops because the server cannot send oversized events (often from large **`BLOB`/`TEXT`/`JSON`** rows), and documents fixes: raise **`max_allowed_packet`** on the source (example **`SET GLOBAL`** to **1 GiB** plus persistent **`my.cnf`/parameter group** config), and **resync the pipe** when a single row change is larger than **1G**.
> 
> This anchor is intended to back **ClickPipes notification** mitigation links for the **`NOTIFY_BINLOG_EVENT_EXCEEDED_MAX_ALLOWED_PACKET`** error class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5880ab7faab6be208334980b3bc8d04e376d9615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->