### PR TITLE
Update ClickPipes maximum message sizes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/kafka/04_best_practices.md
+++ b/docs/integrations/data-ingestion/clickpipes/kafka/04_best_practices.md
@@ -20,7 +20,7 @@ To learn more about message compression in Kafka, we recommend starting with thi
 ## Limitations {#limitations}
 
 - [`DEFAULT`](/sql-reference/statements/create/table#default) is not supported.
-- Individual messages are limited to 2MB (uncompressed) by default when running with the smallest (XS) replica size, and 8MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
+- Individual messages are limited to 16MB (uncompressed) by default when running with the smallest (XS) replica size, and 32MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
 
 ## Delivery semantics {#delivery-semantics}
 ClickPipes for Kafka provides `at-least-once` delivery semantics (as one of the most commonly used approaches). We'd love to hear your feedback on delivery semantics [contact form](https://clickhouse.com/company/contact?loc=clickpipes). If you need exactly-once semantics, we recommend using our official [`clickhouse-kafka-connect`](https://clickhouse.com/blog/real-time-event-streaming-with-kafka-connect-confluent-cloud-clickhouse) sink.

--- a/docs/integrations/data-ingestion/clickpipes/kinesis/01_overview.md
+++ b/docs/integrations/data-ingestion/clickpipes/kinesis/01_overview.md
@@ -159,7 +159,7 @@ view).  For such pipes, it may improve ClickPipes performance to delete all the 
 ## Limitations {#limitations}
 
 - [DEFAULT](/sql-reference/statements/create/table#default) isn't supported.
-- Individual messages are limited to 8MB (uncompressed) by default when running with the smallest (XS) replica size, and 16MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
+- Individual messages are limited to 16MB (uncompressed) by default when running with the smallest (XS) replica size, and 32MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
 
 ## Performance {#performance}
 

--- a/docs/integrations/data-ingestion/clickpipes/pubsub/01_overview.md
+++ b/docs/integrations/data-ingestion/clickpipes/pubsub/01_overview.md
@@ -185,7 +185,7 @@ The `_raw_message` field can be used in cases where only the full Pub/Sub messag
 ## Limitations {#limitations}
 
 - [DEFAULT](/sql-reference/statements/create/table#default) isn't supported.
-- Individual messages are limited to 8MB (uncompressed) by default when running with the smallest (XS) replica size, and 16MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
+- Individual messages are limited to 16MB (uncompressed) by default when running with the smallest (XS) replica size, and 32MB (uncompressed) with larger replicas.  Messages that exceed this limit will be rejected with an error.  If you have a need for larger messages, please contact support.
 - Pub/Sub subscription filters are immutable — changing the filter expression requires recreating the pipe.
 - Filters apply to message attributes only, not the message payload.
 


### PR DESCRIPTION
## Summary
Update maximum ClickPipes message sizes based on current production code.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or configuration changes.
> 
> **Overview**
> Updates **Limitations** docs for Kafka, Kinesis, and Pub/Sub ClickPipes so documented **uncompressed per-message** caps match current production behavior.
> 
> **Kafka** (`04_best_practices.md): XS replicas **2MB → 16MB**, larger replicas **8MB → 32MB**. **Kinesis** and **Pub/Sub** overviews: XS **8MB → 16MB**, larger replicas **16MB → 32MB**. Wording on rejection and contacting support is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afd4c361cdc2cbc822cbb0fd1ca6ebb265cdb81b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->