### PR TITLE
docs: fix ClickStack collector env var CLICKHOUSE_USERNAME -> CLICKHOUSE_USER

### DIFF
--- a/docs/use-cases/observability/clickstack/ingesting-data/collector.md
+++ b/docs/use-cases/observability/clickstack/ingesting-data/collector.md
@@ -110,7 +110,7 @@ ClickStack images are now published as `clickhouse/clickstack-*` (previously `do
 
 </Tabs>
 
-The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse Cloud HTTP endpoint, including the protocol and port—for example, `https://99rr6dm6v3.us-central1.gcp.clickhouse.cloud:8443`.
+The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse Cloud HTTP endpoint, including the protocol and port—for example, `https://99rr6dm6v3.us-central1.gcp.clickhouse.cloud:8443`.
 
 For details on retrieving your Managed ClickStack credentials, see [here](/cloud/guides/sql-console/gather-connection-details).
 
@@ -122,7 +122,7 @@ You should use a user with the [appropriate credentials](/use-cases/observabilit
 
 #### Configuring Managed ClickStack instance {#configuring-managed-clickstack}
 
-The OpenTelemetry collector can be configured to use a Managed ClickStack instance via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
+The OpenTelemetry collector can be configured to use a Managed ClickStack instance via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
 
 <Tabs groupId="install-method">
 
@@ -274,7 +274,7 @@ For the collector to connect to the OpAMP port it must be exposed by the HyperDX
 
 </Tabs>
 
-The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse HTTP endpoint, including the protocol and port—for example, `http://localhost:8123`.
+The target ClickHouse instance is configured via the environment variables `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD`. The `CLICKHOUSE_ENDPOINT` should be the full ClickHouse HTTP endpoint, including the protocol and port—for example, `http://localhost:8123`.
 
 **These environment variables can be used with any of the docker distributions which include the connector.**
 
@@ -286,7 +286,7 @@ You should use a user with the [appropriate credentials](/use-cases/observabilit
 
 #### Configuring ClickHouse instance {#configuring-clickhouse-instance}
 
-The OpenTelemetry collector can be configured to use a ClickHouse instance via the environment variables `OPAMP_SERVER_URL`, `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USERNAME` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
+The OpenTelemetry collector can be configured to use a ClickHouse instance via the environment variables `OPAMP_SERVER_URL`, `CLICKHOUSE_ENDPOINT`, `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD`. How these are set depends on your deployment method:
 
 <Tabs groupId="install-method">
 


### PR DESCRIPTION
## What

The ClickStack OpenTelemetry collector ingestion page describes the ClickHouse user env var as `CLICKHOUSE_USERNAME` in its prose, but the collector reads `CLICKHOUSE_USER`. This corrects the four prose references to match.

## Why

The page contradicts itself. The prose (4 places) says `CLICKHOUSE_USERNAME`, while every code example on the same page (Helm `extraEnvs`, the `docker run` lines, the compose snippets) uses `CLICKHOUSE_USER`, and the collector's bundled `config.standalone.yaml` interpolates `username: ${env:CLICKHOUSE_USER}`. `CLICKHOUSE_USERNAME` is not read anywhere in the collector.

The failure is quiet: setting `CLICKHOUSE_USERNAME` is ignored, the username resolves to an empty string, and ingestion still works against the default auth-less ClickHouse. It only surfaces once ClickHouse requires a password, where the empty user fails authentication. Anyone following the prose to point the collector at a password-protected ClickHouse hits this.

## Change

Four prose occurrences of `CLICKHOUSE_USERNAME` to `CLICKHOUSE_USER` in `docs/use-cases/observability/clickstack/ingesting-data/collector.md`. The code examples were already correct and are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or config changes.
> 
> **Overview**
> Updates **four prose references** on the ClickStack OpenTelemetry collector ingestion page so the documented ClickHouse username env var is **`CLICKHOUSE_USER`**, matching Helm/Docker examples and what the collector actually reads—not **`CLICKHOUSE_USERNAME`**.
> 
> Covers both **Managed ClickStack** and **Open Source ClickStack** sections (endpoint/password env var lists and “modifying configuration” text). **No code or example blocks** are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e3f90db7dfc8a7d8960de2bd958932fce8bae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->