### PR TITLE
docs: fix parallel_view_processing example to use INSERT SELECT

### DIFF
--- a/docs/materialized-view/incremental-materialized-view.md
+++ b/docs/materialized-view/incremental-materialized-view.md
@@ -1115,13 +1115,17 @@ ORDER BY uuid ASC
 3 rows in set. Elapsed: 0.004 sec.
 ```
 
+:::note
+As of ClickHouse v25.5, `parallel_view_processing` only applies to `INSERT ... SELECT` queries. Use `INSERT ... SELECT` to demonstrate parallel view processing as shown below.
+:::
+
 Conversely, consider what happens if we insert a row with `parallel_view_processing=1` enabled. With this enabled, the views are executed in parallel, giving no guarantees to the order at which rows arrive to the target table:
 
 ```sql
 TRUNCATE target;
 SET parallel_view_processing = 1;
 
-INSERT INTO source VALUES ('test');
+INSERT INTO source SELECT 'test';
 ```
 
 ```response


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106845

### What changed
The example demonstrating `parallel_view_processing=1` was using 
`INSERT INTO source VALUES ('test')`, which no longer honors this 
setting since v25.5 (after PR #77309).

Updated the example to use `INSERT INTO source SELECT 'test'` which 
correctly demonstrates parallel view processing.

Also added a note clarifying that `parallel_view_processing` only 
applies to `INSERT ... SELECT` queries since v25.5.

### Changelog category
- Documentation (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the **Parallel vs sequential processing** section so the `parallel_view_processing=1` demo matches ClickHouse **v25.5+** behavior.
> 
> Adds a note that **`parallel_view_processing` applies only to `INSERT ... SELECT`**, not `INSERT ... VALUES`. The parallel example is changed from `INSERT INTO source VALUES ('test')` to **`INSERT INTO source SELECT 'test'`**, so readers can still see parallel MV execution and faster insert timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 706f6cef0cb76b20492e13d6555f812572658fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->