### PR TITLE
small fixes on the Managed ClickStack guide

### DIFF
--- a/docs/use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
+++ b/docs/use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
@@ -230,18 +230,18 @@ At this point the application is running but uninstrumented. ClickStack shows no
 
 The application needs two values to reach the collector you deployed above:
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT`: the OTLP endpoint your collector exposes (commonly port `4318` for OTLP over HTTP).
-- `OTEL_EXPORTER_OTLP_HEADERS`: the authorization header carrying your ingestion token, in the form `authorization=<token>`. Use the `OTLP_AUTH_TOKEN` you set on the collector above, or whatever auth header your existing collector expects.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: the OTLP endpoint your collector exposes (commonly port `4318` for OTLP over HTTPS).
+- `OTEL_EXPORTER_OTLP_HEADERS`: the authorization header carrying your ingestion token, in the form `authorization=<ingestion_token>`. Use the `OTLP_AUTH_TOKEN` you set on the collector above, or whatever auth header your existing collector expects.
 
-Open `.env` and set them:
+Copy `.env.example` to `.env`, then open the file and set the following variables:
 
 ```bash
 OTEL_SERVICE_NAME=hn-analyzer-api
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-collector-endpoint>:4318
-OTEL_EXPORTER_OTLP_HEADERS=authorization=<your-ingestion-token>
+OTEL_EXPORTER_OTLP_HEADERS=authorization=<ingestion_token>
 ```
 
-The SDK uses `OTEL_EXPORTER_OTLP_HEADERS` to set the authorization header for all three signals: traces, metrics, and logs. If your collector runs locally and doesn't enforce auth, you can leave the value empty (`OTEL_EXPORTER_OTLP_HEADERS=authorization=`), but the variable must be present; the SDK skips initialization entirely if it's unset or fully empty.
+The SDK uses `OTEL_EXPORTER_OTLP_HEADERS` to set the authorization header for all three signals: traces, metrics, and logs. If your collector runs locally and doesn't enforce auth, you can leave the value empty (`OTEL_EXPORTER_OTLP_HEADERS=authorization=`), but the variable must be present; the SDK skips initialization entirely if it's unset or fully empty. Finally, when running the collector without TLS, ensure you use the correct HTTP protocol (ex: `http://localhost:4318`).
 
 ## Instrument the application {#instrument-the-application}
 


### PR DESCRIPTION
## Summary
Small fixes on the Managed ClickStack guide

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact on production systems.
> 
> **Overview**
> Updates the **Managed ClickStack getting started** guide’s “Connect the application to your collector” section so OTLP setup matches HTTPS and local dev expectations.
> 
> **OTEL env docs:** Describes port `4318` as OTLP over **HTTPS** (not HTTP), standardizes placeholders to `<ingestion_token>`, and tells readers to **copy `.env.example` to `.env`** before setting `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_HEADERS`.
> 
> **Non-TLS collectors:** Adds a note to use plain **HTTP** (e.g. `http://localhost:4318`) when the collector does not use TLS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ad78492b0ee22b140a9e54dd2dfc29007f89f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->