### PR TITLE
chore(aws-x-region-pl): add mx-central-1 to supported cross-region PrivateLink locations

### DIFF
--- a/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
+++ b/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
@@ -29,6 +29,7 @@ ClickHouse Cloud supports [cross-region PrivateLink](https://aws.amazon.com/abou
 - sa-east-1
 - il-central-1
 - me-south-1
+- mx-central-1
 - eu-central-2
 - eu-north-1
 - eu-south-2


### PR DESCRIPTION
## Summary

`mx-central-1` was enabled for cross-regional connectivity

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/docusaurus.config.js
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update with no product, API, or security logic changes.
> 
> **Overview**
> Documents **Mexico (`mx-central-1`)** as a supported **consumer region** for AWS **cross-region PrivateLink** to ClickHouse Cloud.
> 
> The only change is one new bullet in the note on `02_aws-privatelink.md`, alongside the existing regional list; setup steps and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1d3a16e3149c7a3c19abd75d3a63ad2f608b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->