### PR TITLE
Update 2026.md

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -63,7 +63,9 @@ For more details, see:
 
 ### Horizontal autoscaling (private preview) {#horizontal-autoscaling}
 
-Horizontal autoscaling automatically adjusts the number of replicas in a ClickHouse Cloud cluster, scaling out aggressively when demand spikes and scaling in gradually as load drops — so teams with variable, high-concurrency workloads no longer need to manually right-size clusters. Private preview scales on concurrent query count; CPU and memory signals are planned for public beta. Available to Enterprise and Scale tier customers on ClickHouse 26.2+.
+Horizontal autoscaling automatically adjusts the number of replicas in a ClickHouse Cloud cluster, scaling out aggressively when demand spikes and scaling in gradually as load drops — so teams with variable, high-concurrency workloads no longer need to manually right-size clusters. Private preview scales on concurrent query count; CPU and memory signals are planned for public beta. Available to Enterprise and Scale tier customers on ClickHouse 26.2+. 
+
+Note: For the intial GA launch, horizontal and vertical autoscaling are mutually exclusive. Horizontal autoscaling will only activate when vertical autoscaling is disabled (i.e., the service is set to a fixed size). The same applies to vertical autoscaling being enabled when the number of replicas is fixed. This behavior will become more flexible in future releases.
 
 ### ClickStack MCP Server (open source) {#clickstack-mcp-server}
 


### PR DESCRIPTION
Added details to specify that autoscaling is only supported in one dimension at a time.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog clarification with no product or security behavior changes in code.
> 
> **Overview**
> The **Horizontal autoscaling (private preview)** changelog entry now states that at initial GA, **horizontal and vertical autoscaling cannot run together**: horizontal autoscaling only applies when vertical autoscaling is off (fixed service size), and enabling vertical autoscaling requires a fixed replica count. The note adds that this limitation is expected to ease in later releases.
> 
> A minor trailing whitespace change was made on the paragraph above the new note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c8d6e012f9e3267a0b502741c8e65a2b494b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->