### PR TITLE
Drop bad anchor on link to 'nested data structures' page

### DIFF
--- a/docs/cloud/onboard/02_migrate/01_migration_guides/02_postgres/appendix.md
+++ b/docs/cloud/onboard/02_migrate/01_migration_guides/02_postgres/appendix.md
@@ -184,5 +184,5 @@ The following table shows the equivalent ClickHouse data types for Postgres.
 | `HSTORE` | [Map(K, V)](/sql-reference/data-types/map), [Map](/sql-reference/data-types/map)(K,[Variant](/sql-reference/data-types/variant)) |
 | `UUID` | [UUID](/sql-reference/data-types/uuid) |
 | `ARRAY<T>` | [ARRAY(T)](/sql-reference/data-types/array) |
-| `JSON` | [String](/sql-reference/data-types/string), [Variant](/sql-reference/data-types/variant), [Nested](/sql-reference/data-types/nested-data-structures/nested#nestedname1-type1-name2-type2-), [Tuple](/sql-reference/data-types/tuple) |
+| `JSON` | [String](/sql-reference/data-types/string), [Variant](/sql-reference/data-types/variant), [Nested](/sql-reference/data-types/nested-data-structures/nested), [Tuple](/sql-reference/data-types/tuple) |
 | `JSONB` | [String](/sql-reference/data-types/string) |


### PR DESCRIPTION
## Summary

On https://clickhouse.com/docs/migrations/postgresql/appendix, the link to the "Nested" data type contains an anchor that's failing the Docusaurus link check: `https://clickhouse.com/docs/sql-reference/data-types/nested-data-structures/nested#nestedname1-type1-name2-type2-`. The anchor doesn't appear to exist, and when testing this link, the user is brought to a location further down the page, which seems unintended.

This PR drops the anchor from the link URL.

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change with no runtime or data-handling impact.
> 
> **Overview**
> Fixes a failing Docusaurus link check on the PostgreSQL migration appendix by updating the `JSON` → **Nested** mapping link.
> 
> The **Nested** target URL no longer includes the invalid `#nestedname1-type1-name2-type2-` fragment; it now points to `/sql-reference/data-types/nested-data-structures/nested` so readers land at the intended page top instead of an incorrect scroll position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7feb5c2918818b45a242810bac244f5bde3c24d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->