### PR TITLE
Clarify Cloud UDF dependency handling and version updates

### DIFF
--- a/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
+++ b/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
@@ -86,16 +86,12 @@ for line in sys.stdin:
 EOF
 ```
 
-If your Python script imports third-party packages, you must create a `requirements.txt` file listing those dependencies. For example:
+If your Python script imports third-party packages, list them in a `requirements.txt` file and ClickHouse Cloud installs them for you. You can instead bundle dependencies directly in the ZIP, but then you must include cached packages for both CPU architectures, so `requirements.txt` is simpler. For example:
 
 ```text
 requests>=2.28.0
 numpy>=1.23.0
 ```
-
-:::note[Let Cloud install dependencies]
-The recommended path is to list your packages in `requirements.txt`, which ClickHouse Cloud prepares for you. You can instead bundle dependencies directly in the ZIP, but then you must include cached packages for **both CPU architectures**, so `requirements.txt` is simpler.
-:::
 
 :::note
 ClickHouse Cloud expects to find `main.py` in the zip file you will upload via the UI in the next step.
@@ -171,9 +167,7 @@ true    false
 
 ### Create a new version {#create-new-version}
 
-:::note[Editing vs. creating a new version]
-To change a UDF's code, create a new version — uploading a file in the **Edit** panel won't replace the deployed code. **Edit** only manages which services the UDF is assigned to.
-:::
+To change a UDF's code, create a new version. The **Edit** panel only manages which services a UDF is assigned to; uploading a file there won't replace the deployed code.
 
 1. From the Cloud console homepage, click on the name of your organization in the bottom-left menu.
 2. Select **User-defined functions** from the menu.

--- a/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
+++ b/docs/cloud/features/03_sql_console_features/05_user_defined_functions.md
@@ -93,6 +93,10 @@ requests>=2.28.0
 numpy>=1.23.0
 ```
 
+:::note[Let Cloud install dependencies]
+The recommended path is to list your packages in `requirements.txt`, which ClickHouse Cloud prepares for you. You can instead bundle dependencies directly in the ZIP, but then you must include cached packages for **both CPU architectures**, so `requirements.txt` is simpler.
+:::
+
 :::note
 ClickHouse Cloud expects to find `main.py` in the zip file you will upload via the UI in the next step.
 If you name the file something else you will encounter an error.
@@ -166,6 +170,10 @@ true    false
 ```
 
 ### Create a new version {#create-new-version}
+
+:::note[Editing vs. creating a new version]
+To change a UDF's code, create a new version — uploading a file in the **Edit** panel won't replace the deployed code. **Edit** only manages which services the UDF is assigned to.
+:::
 
 1. From the Cloud console homepage, click on the name of your organization in the bottom-left menu.
 2. Select **User-defined functions** from the menu.


### PR DESCRIPTION
Closes [DOC-833](https://linear.app/clickhouse/issue/DOC-833/udf-docs-cross-link-cloud-guide-sql-reference-fix-stale-preview-badge).

Adds two clarifications to the Cloud UDF guide based on user feedback in Slack (testing in staging):

- **Dependency handling** — `requirements.txt` is the recommended way to install Python dependencies, which ClickHouse Cloud prepares for you. Bundling dependencies directly in the ZIP is possible but requires cached packages for both CPU architectures.
- **Edit vs. new version** — the **Edit** panel only manages which services a UDF is assigned to; changing a UDF's code requires creating a new version. (A user got stuck here because the "Save changes" button stays inactive when re-uploading code in Edit.)

The reference ↔ Cloud cross-link and the stale preview-badge fix are handled separately in [ClickHouse/ClickHouse#107748](https://github.com/ClickHouse/ClickHouse/pull/107748), since the reference page is synced from that repo.

The `deterministic` behavior and network-access flag are intentionally **not** documented yet — both have open questions with eng (tracked in DOC-833).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Cloud UDF guide with no product or runtime behavior changes.
> 
> **Overview**
> Updates the ClickHouse Cloud **user-defined functions** guide with two clarifications from staging feedback.
> 
> The **Python dependencies** section now states that **`requirements.txt`** is the recommended path because Cloud installs packages for you, and that bundling wheels in the ZIP requires cached packages for **both CPU architectures**, making `requirements.txt` simpler.
> 
> The **Create a new version** section adds a note that **Edit** only changes service assignment—re-uploading code there does not update deployed UDF code; code changes require **Create new version**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b899046d9c2b55c27bf8a812a62d1a91463c776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->