### PR TITLE
fix(clickpipes): Remove the limitation on null snapshotting values

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/parallel_initial_load.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/parallel_initial_load.md
@@ -53,4 +53,3 @@ You can run **SHOW processlist** in MySQL to see the parallel snapshot in action
 ### Limitations {#limitations-parallel-mysql-snapshot}
 - The snapshot parameters can't be edited after pipe creation. If you want to change them, you will have to create a new ClickPipe.
 - When adding tables to an existing ClickPipe, you can't change the snapshot parameters. The ClickPipe will use the existing parameters for the new tables.
-- The partition key column shouldn't contain `NULL`s, as they're skipped by the partitioning logic.

--- a/docs/integrations/data-ingestion/clickpipes/postgres/parallel_initial_load.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/parallel_initial_load.md
@@ -50,4 +50,3 @@ You can analyze **pg_stat_activity** to see the parallel snapshot in action. The
 
 - The snapshot parameters can't be edited after pipe creation. If you want to change them, you will have to create a new ClickPipe.
 - When adding tables to an existing ClickPipe, you can't change the snapshot parameters. The ClickPipe will use the existing parameters for the new tables.
-- The partition key column shouldn't contain `NULL`s, as they're skipped by the partitioning logic.


### PR DESCRIPTION
## Summary
Support was added some months ago.

## Checklist
- [x] Delete items not relevant to your PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or security impact.
> 
> **Overview**
> Updates the **MySQL** and **Postgres** parallel snapshot / initial load guides by removing the limitation that the partition key column must not contain `NULL` values (because nulls were skipped by partitioning).
> 
> The **Limitations** sections now only list snapshot-parameter immutability after pipe creation and when adding tables. This aligns the docs with product behavior that already supports null partition-key values during parallel snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b3ae4d19fe4293bce4e8ea3ce8f93c664a2d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->