### PR TITLE
docs: default clickhousectl examples to the latest ClickHouse release

### DIFF
--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -67,8 +67,8 @@ For local development, `clickhousectl` helps to install ClickHouse versions and 
 # Install the CLI
 curl https://clickhouse.com/cli | sh
 
-# Install the latest stable ClickHouse, set it as your default, and symlink the clickhouse binary onto your PATH
-clickhousectl local use stable
+# Install the latest ClickHouse, set it as your default, and symlink the clickhouse binary onto your PATH
+clickhousectl local use latest
 clickhousectl local server start
 clickhousectl local client
 ```

--- a/docs/getting-started/install/_snippets/_cli_install.md
+++ b/docs/getting-started/install/_snippets/_cli_install.md
@@ -15,10 +15,10 @@ A `chctl` alias is also created automatically for convenience.
 
 ## Install ClickHouse {#cli-install-clickhouse}
 
-Install the latest stable version of ClickHouse and make it your default:
+Install the latest version of ClickHouse and make it your default:
 
 ```bash
-clickhousectl local use stable
+clickhousectl local use latest
 ```
 
 `local use` installs the version if it isn't already present, sets it as your
@@ -29,9 +29,8 @@ that runs a `clickhouse` command then works as-is.
 You can also select a specific version:
 
 ```bash
-clickhousectl local use lts             # Latest LTS release
-clickhousectl local use 25.6            # Latest 25.6.x.x
-clickhousectl local use 25.6.1.1        # Exact version
+clickhousectl local use 26.5            # Latest 26.5.x.x
+clickhousectl local use 26.5.2.39       # Exact version
 ```
 
 :::note[Use vs install]

--- a/docs/getting-started/quick-start/oss.mdx
+++ b/docs/getting-started/quick-start/oss.mdx
@@ -56,10 +56,10 @@ plain-binary workflow.
 ClickHouse runs natively on Linux and macOS, and runs on Windows via
 the [WSL](https://learn.microsoft.com/en-us/windows/wsl/about).
 
-Use the CLI to install the latest stable version of ClickHouse and make it your default:
+Use the CLI to install the latest version of ClickHouse and make it your default:
 
 ```bash
-clickhousectl local use stable
+clickhousectl local use latest
 ```
 
 `local use` installs the version if it isn't already present, sets it as your


### PR DESCRIPTION
## Summary

Update the `clickhousectl` examples in the install and quick-start docs to recommend the latest ClickHouse release:

- Use `clickhousectl local use latest` instead of `stable`.
- Bump the pinned version examples from `25.6` / `lts` to `26.5` / `26.5.2.39`.

Affects `deployment-modes.md`, `_cli_install.md`, and `quick-start/oss.mdx`.

## Checklist
- [x] No URL changes
- [x] No new integration page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and example command changes with no runtime or URL changes.
> 
> **Overview**
> **`clickhousectl` install and quick-start docs** now steer readers toward the **latest** ClickHouse build instead of **stable**: default commands use `clickhousectl local use latest`, and copy is updated from “latest stable version” to “latest version.”
> 
> In **`_cli_install.md`**, pinned version examples drop **`lts`** and **`25.6`** in favor of **`26.5`** and **`26.5.2.39`**. The same default command change appears in **`deployment-modes.md`** and **`oss.mdx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4667b0f98157c475dd526d4a819aad13e40898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->