### PR TITLE
chore(docs): Update release status page

### DIFF
--- a/docs/cloud/reference/01_changelog/02_release_status.md
+++ b/docs/cloud/reference/01_changelog/02_release_status.md
@@ -47,6 +47,19 @@ For advance testing before production upgrades, use the Fast or Regular channel 
 
 <ReleaseSchedule releases={[
     {
+     changelog_link: 'https://clickhouse.com/docs/changelogs/26.4',
+     version: '26.4',
+     fast_start_date: '2026-06-22',
+     fast_end_date: 'TBD',
+     regular_start_date: 'TBD',
+     regular_end_date: 'TBD',
+     slow_start_date: 'TBD',
+     slow_end_date: 'TBD',
+     fast_progress: 'green',
+     regular_progress: 'green',
+     slow_progress: 'green',
+    },
+    {
      changelog_link: 'https://clickhouse.com/docs/changelogs/26.2',
      version: '26.2',
      fast_start_date: '2026-04-03',


### PR DESCRIPTION
## Summary
Update 26.4 fast release channel start date.
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to published rollout dates; no product or runtime behavior.
> 
> **Overview**
> Updates the Cloud **release status** page by adding **26.4** to the `ReleaseSchedule` list at the top of the rollout table.
> 
> The new row links to the 26.4 changelog and sets the **Fast** channel rollout start to **2026-06-22**, with Regular/Slow channel dates and end dates still marked **TBD**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383f64523b8c614aa81088cac5490f6b1ba25b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->