### PR TITLE
[Java] update JDBC docs. 

### DIFF
--- a/docs/integrations/language-clients/java/jdbc/jdbc.mdx
+++ b/docs/integrations/language-clients/java/jdbc/jdbc.mdx
@@ -164,7 +164,7 @@ Note: no need to url encode JDBC URL or properties, they will be automatically e
 
 We deliberately avoid adding default settings to connection properties to avoid problems with read-only profiles.
 However some users need to pass format settings (for example to read JSON as String) and we recommend using `readonly=2` profile.
-Read more about read-only profiles [here](/operations/settings/settings-profiles#read-only).
+Read more about read-only profiles [here](/operations/settings/constraints-on-settings#read-only).
 
 ### Client Identification {#client-identification}
 
@@ -581,7 +581,7 @@ try (Connection conn = ...) {
 
 **JSON Type**
 
-JSON type is mapped to Map<String, Object> by default where keys are JSON object keys and values are JSON object values.
+JSON type is mapped to `Map<String, Object>` by default where keys are JSON object keys and values are JSON object values.
 For example:
 ```json
 {

--- a/docs/integrations/language-clients/java/jdbc/jdbc.mdx
+++ b/docs/integrations/language-clients/java/jdbc/jdbc.mdx
@@ -160,6 +160,12 @@ jdbc:ch:http://localhost:8123/?user=default&password=password&client_name=my-app
 ```
 Note: no need to url encode JDBC URL or properties, they will be automatically encoded.
 
+**Readonly Profiles**
+
+We deliberately avoid adding default settings to connection properties to avoid problems with read-only profiles.
+However some users need to pass format settings (for example to read JSON as String) and we recommend using `readonly=2` profile.
+Read more about read-only profiles [here](/operations/settings/settings-profiles#read-only).
+
 ### Client Identification {#client-identification}
 
 There are two ways to identify application originated a request: set `com.clickhouse.client.api.ClientConfigProperties#CLIENT_NAME` via 
@@ -572,6 +578,58 @@ try (Connection conn = ...) {
 - `UUID` can be read/written as `String` by using `getObject(columnIndex, String.class)` method.
 - `IPv4` and `IPv6` aren't JDBC standard types. However they're part of JDK. By default `java.net.Inet4Address` and `java.net.Inet6Address` are returned on `getObject()` method.
 - `IPv4` and `IPv6` can be read/written as `String` by using `getObject(columnIndex, String.class)` method.
+
+**JSON Type**
+
+JSON type is mapped to Map<String, Object> by default where keys are JSON object keys and values are JSON object values.
+For example:
+```json
+{
+    "key1": "value1",
+    "key2": ["value2", "value3"]
+    "key3": {
+        "key4": "value4",
+        "key5": "value5"
+    }
+}
+```
+will be mapped to:
+
+```java
+Map<String, Object> map = new HashMap<>();
+map.put("key1", "value1");
+map.put("key2", Arrays.asList("value2", "value3"));
+map.put("key3", new HashMap<String, Object>() {{
+    put("key4", "value4");
+    put("key5", "value5");
+}});
+```
+There is more convinient option to read JSON as String by passing server setting `jdbc_read_json_as_string=true` to connection properties.
+This makes driver return JSON values as String and can be used to parse using any JSON library.
+
+```java
+Properties properties = new Properties();
+properties.setProperty(
+                ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING),
+                "1");
+try (Connection conn = DriverManager.getConnection(url, properties)) {
+     try (ResultSet rs = stmt.executeQuery("SELECT * FROM test_json ORDER BY order")) {
+        while (rs.next()) {
+            String json = rs.getString("json");
+            // ...
+        }
+    }
+}
+```
+
+Starting ClickHouse version 25.8 numbers are no longer quoted by default. For older versions you can disable quoting by passing server settings to connection properties:
+```java
+Properties properties = new Properties();
+properties.put(ClientConfigProperties.serverSetting("output_format_json_quote_64bit_integers"), "0");
+properties.put(ClientConfigProperties.serverSetting("output_format_json_quote_64bit_floats"), "0");
+properties.put(ClientConfigProperties.serverSetting("output_format_json_quote_decimals"), "0");
+```
+
 
 ### Handling Dates, Times, and Timezones {#handling-dates-times-and-timezones}
 


### PR DESCRIPTION
## Summary
- Adds note about usage of readonly profiles 
- Adds description how to read JSON values in JDBC 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/2760

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> **Documentation-only** updates to the Java JDBC integration guide (`jdbc.mdx`).
> 
> Adds a **Readonly Profiles** note under connection configuration: the driver intentionally omits default connection settings to stay compatible with read-only profiles, and recommends **`readonly=2`** when users need format-related server settings (e.g. reading JSON as a string), with a link to the constraints-on-settings docs.
> 
> Adds a **JSON Type** section under special types: default **`Map<String, Object>`** mapping with a nested example, optional **string** reads via connection/server settings (`jdbc_read_json_as_string` / `OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING`), and guidance on **JSON number quoting** for ClickHouse **25.8+** vs older servers via `output_format_json_quote_*` server settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f629dd2299001e297687f1b93ce92711a9d04cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->