### PR TITLE
[JAVA] JDBC note update. 

### DIFF
--- a/docs/integrations/language-clients/java/jdbc/jdbc.mdx
+++ b/docs/integrations/language-clients/java/jdbc/jdbc.mdx
@@ -933,7 +933,8 @@ try (Connection conn = DriverManager.getConnection(url, properties)) {
 
 - V2 uses only `Schema` term to name databases. `Catalog` term is reserved for future use.
 - V2 returns `false` for `DatabaseMetaData.supportsTransactions()` and `DatabaseMetaData.supportsSavepoints()`. This will be changed in the future development.
-
+- In `DatabaseMetaData.getTypeInfo()`, the `LITERAL_PREFIX` and `LITERAL_SUFFIX` columns now return `null` for data types where prefixes and suffixes are not expected (e.g., numeric types). 
+In V1, these columns returned non-null values for such types. These columns should be used when generating SQL queries to properly quote literal values according to their data type.
 
 </Version>
 


### PR DESCRIPTION
## Summary
Adds note to JDBC doc about differences in type info between v1 and v2

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the JDBC integration guide; no runtime or API code is modified.
> 
> **Overview**
> The JDBC migration guide’s **Database Metadata Changes** section now documents a V1 vs V2 difference for `DatabaseMetaData.getTypeInfo()`: in V2, **`LITERAL_PREFIX` and `LITERAL_SUFFIX` are `null`** for types that should not use literal quoting (e.g. numeric types), whereas V1 returned non-null values. The note clarifies that tools generating SQL should rely on these columns when quoting literals by type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4546494d7346768ff25acf0d4a4f62a73c9f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->