### PR TITLE
chore: link official specs of Native protocol and format

### DIFF
--- a/docs/integrations/interfaces/tcp.md
+++ b/docs/integrations/interfaces/tcp.md
@@ -8,7 +8,7 @@ doc_type: 'reference'
 ---
 
 
-The native protocol is used in the [command-line client](/interfaces/cli), for inter-server communication during distributed query processing, and also in other C++ programs.
+The native protocol is used in the [command-line client](/interfaces/cli), for inter-server communication during distributed query processing, and also in some language clients (e.g. [clickhouse-go](/integrations/go#connection-details)).
 
 ClickHouse provides official specifications for the native protocol and the columnar format it carries:
 

--- a/docs/integrations/interfaces/tcp.md
+++ b/docs/integrations/interfaces/tcp.md
@@ -8,4 +8,9 @@ doc_type: 'reference'
 ---
 
 
-The native protocol is used in the [command-line client](/interfaces/cli), for inter-server communication during distributed query processing, and also in other C++ programs. Unfortunately, native ClickHouse protocol doesn't have formal specification yet, but it can be reverse-engineered from ClickHouse source code (starting [around here](https://github.com/ClickHouse/ClickHouse/tree/master/src/Client)) and/or by intercepting and analyzing TCP traffic.
+The native protocol is used in the [command-line client](/interfaces/cli), for inter-server communication during distributed query processing, and also in other C++ programs.
+
+ClickHouse provides official specifications for the native protocol and the columnar format it carries:
+
+- [Native Protocol](/interfaces/specs/NativeProtocol) — packet framing, the connection state machine, version negotiation, and the body of every non-`Block` message.
+- [Native Format](/interfaces/specs/NativeFormat) — the `Block` and column structure, the per-type encodings, and the compression frame. This format also appears outside the TCP protocol, for example with `FORMAT Native` over HTTP.

--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -20,8 +20,3 @@ use-cases/observability/clickstack/managed-onboarding/instrument-application.md
 use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
 use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
 
-# NOTE(kavi): To be removed after core PRs are merged
-# https://github.com/ClickHouse/ClickHouse/pull/106723
-
-interfaces/specs/NativeProtocol.md
-interfaces/specs/NativeFormat.md

--- a/sidebars.js
+++ b/sidebars.js
@@ -963,6 +963,16 @@ const sidebars = {
             'integrations/interfaces/arrowflight',
           ],
         },
+        {
+          type: 'category',
+          label: 'Specifications',
+          collapsed: true,
+          collapsible: true,
+          items: [
+            'interfaces/specs/NativeProtocol',
+            'interfaces/specs/NativeFormat',
+          ],
+        },
         'integrations/sql-clients/sql-console',
         'interfaces/third-party/index',
       ],


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Given the original PR on core got merged. Now we can link it in the docs repo
https://github.com/ClickHouse/ClickHouse/pull/106720

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or security behavior changes.
> 
> **Overview**
> Publishes the **Native Protocol** and **Native Format** spec pages in the docs site now that the core specs have landed.
> 
> The native TCP interface page no longer points readers at reverse-engineering the C++ client; it links to the official specs and briefly distinguishes protocol vs. columnar format (including `FORMAT Native` over HTTP). A **Specifications** subsection is added under **Native clients & interfaces** in the sidebar for those two docs.
> 
> The temporary floating-pages exceptions for the spec paths are removed so those pages are included in the normal doc checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647706d2b6e5cb524ed87fa2bb62b466b1631a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->