### PR TITLE
Fix broken chDB links

### DIFF
--- a/docs/chdb/install/c.md
+++ b/docs/chdb/install/c.md
@@ -327,4 +327,4 @@ cleanup:
 
 - **Main Repository**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
 - **Issues and Support**: Report issues on the [GitHub repository](https://github.com/chdb-io/chdb/issues)
-- **C API Documentation**: [Bindings Documentation](https://github.com/chdb-io/chdb/blob/main/bindings.md)
+- **C API Documentation**: [Bindings Documentation](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)

--- a/docs/chdb/install/python.md
+++ b/docs/chdb/install/python.md
@@ -277,7 +277,7 @@ result = sess.query("""
 """, "JSON")
 ```
 
-See also: [test_stateful.py](https://github.com/chdb-io/chdb/blob/main/tests/test_stateful.py).
+See also: [test_stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py).
 
 ### Python DB-API 2.0 interface {#python-db-api-20}
 

--- a/docs/chdb/reference/data-formats.md
+++ b/docs/chdb/reference/data-formats.md
@@ -14,7 +14,7 @@ Output formats are used to arrange the results of a `SELECT`, and to perform `IN
 As well as the data formats that ClickHouse supports, chDB also supports:
 
 - `ArrowTable` as an output format, the type is Python `pyarrow.Table`
-- `DataFrame` as an input and output format, the type is Python `pandas.DataFrame`. For examples, see [`test_joindf.py`](https://github.com/chdb-io/chdb/blob/main/tests/test_joindf.py)
+- `DataFrame` as an input and output format, the type is Python `pandas.DataFrame`. For examples, see [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py)
 - `Debug` as ab output (as an alias of `CSV`), but with enabled debug verbose output from ClickHouse.
 
 The supported data formats from ClickHouse are:

--- a/i18n/jp/docusaurus-plugin-content-docs/current/chdb/install/c.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/chdb/install/c.md
@@ -334,4 +334,4 @@ cleanup:
 
 - **メインリポジトリ**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
 - **イシューとサポート**: [GitHub リポジトリ](https://github.com/chdb-io/chdb/issues)で問題を報告してください
-- **C API ドキュメント**: [バインディングドキュメント](https://github.com/chdb-io/chdb/blob/main/bindings.md)
+- **C API ドキュメント**: [バインディングドキュメント](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)

--- a/i18n/jp/docusaurus-plugin-content-docs/current/chdb/install/python.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/chdb/install/python.md
@@ -286,7 +286,7 @@ result = sess.query("""
 """, "JSON")
 ```
 
-こちらも参照してください: [test&#95;stateful.py](https://github.com/chdb-io/chdb/blob/main/tests/test_stateful.py).
+こちらも参照してください: [test&#95;stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py).
 
 
 ### Python DB-API 2.0 インターフェース \{#python-db-api-20\}

--- a/i18n/jp/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
@@ -14,7 +14,7 @@ doc_type: 'reference'
 ClickHouse がサポートするフォーマットに加えて、chDB は次の形式もサポートします:
 
 * 出力フォーマットとしての `ArrowTable`。型は Python の `pyarrow.Table`
-* 入力・出力フォーマットとしての `DataFrame`。型は Python の `pandas.DataFrame`。例については [`test_joindf.py`](https://github.com/chdb-io/chdb/blob/main/tests/test_joindf.py) を参照してください
+* 入力・出力フォーマットとしての `DataFrame`。型は Python の `pandas.DataFrame`。例については [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py) を参照してください
 * 出力フォーマットとしての `Debug` (`CSV` のエイリアス) 。ClickHouse からのデバッグ用詳細出力が有効化されます。
 
 ClickHouse でサポートされているフォーマットは次のとおりです:

--- a/i18n/ko/docusaurus-plugin-content-docs/current/chdb/install/c.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/chdb/install/c.md
@@ -334,4 +334,4 @@ cleanup:
 
 - **메인 저장소**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
 - **이슈 및 지원**: [GitHub 저장소](https://github.com/chdb-io/chdb/issues)에서 이슈를 등록하십시오.
-- **C API 문서**: [바인딩 문서](https://github.com/chdb-io/chdb/blob/main/bindings.md)
+- **C API 문서**: [바인딩 문서](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)

--- a/i18n/ko/docusaurus-plugin-content-docs/current/chdb/install/python.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/chdb/install/python.md
@@ -286,7 +286,7 @@ result = sess.query("""
 """, "JSON")
 ```
 
-참고: 자세한 내용은 [test&#95;stateful.py](https://github.com/chdb-io/chdb/blob/main/tests/test_stateful.py)을(를) 참조하십시오.
+참고: 자세한 내용은 [test&#95;stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py)을(를) 참조하십시오.
 
 
 ### Python DB-API 2.0 인터페이스 \{#python-db-api-20\}

--- a/i18n/ko/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
@@ -14,7 +14,7 @@ doc_type: 'reference'
 ClickHouse가 지원하는 데이터 형식 외에도 chDB는 다음을 추가로 지원합니다.
 
 * 출력 형식으로 `ArrowTable`을 지원하며, 타입은 Python `pyarrow.Table`입니다.
-* 입출력 형식으로 `DataFrame`을 지원하며, 타입은 Python `pandas.DataFrame`입니다. 예시는 [`test_joindf.py`](https://github.com/chdb-io/chdb/blob/main/tests/test_joindf.py)를 참조하십시오.
+* 입출력 형식으로 `DataFrame`을 지원하며, 타입은 Python `pandas.DataFrame`입니다. 예시는 [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py)를 참조하십시오.
 * 출력 형식으로 `Debug`를 지원하며(`CSV`의 별칭), ClickHouse에서 디버그 상세 출력이 활성화됩니다.
 
 ClickHouse에서 지원되는 데이터 형식은 다음과 같습니다.

--- a/i18n/ru/docusaurus-plugin-content-docs/current/chdb/install/c.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/chdb/install/c.md
@@ -334,4 +334,4 @@ cleanup:
 
 - **Основной репозиторий**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
 - **Проблемы и поддержка**: Сообщайте о проблемах в [репозитории GitHub](https://github.com/chdb-io/chdb/issues)
-- **Документация C API**: [Документация привязок](https://github.com/chdb-io/chdb/blob/main/bindings.md)
+- **Документация C API**: [Документация привязок](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)

--- a/i18n/ru/docusaurus-plugin-content-docs/current/chdb/install/python.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/chdb/install/python.md
@@ -286,7 +286,7 @@ result = sess.query("""
 """, "JSON")
 ```
 
-См. также: [test&#95;stateful.py](https://github.com/chdb-io/chdb/blob/main/tests/test_stateful.py).
+См. также: [test&#95;stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py).
 
 
 ### Интерфейс Python DB-API 2.0 \{#python-db-api-20\}

--- a/i18n/ru/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
@@ -14,7 +14,7 @@ doc_type: 'reference'
 Помимо форматов данных, которые поддерживает ClickHouse, chDB также поддерживает:
 
 * `ArrowTable` как формат вывода, тип — Python `pyarrow.Table`
-* `DataFrame` как формат ввода и вывода, тип — Python `pandas.DataFrame`. Примеры см. в [`test_joindf.py`](https://github.com/chdb-io/chdb/blob/main/tests/test_joindf.py)
+* `DataFrame` как формат ввода и вывода, тип — Python `pandas.DataFrame`. Примеры см. в [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py)
 * `Debug` как формат вывода (как алиас формата `CSV`), но с включенным подробным отладочным выводом из ClickHouse.
 
 Поддерживаемые ClickHouse форматы данных:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/chdb/install/c.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/chdb/install/c.md
@@ -334,4 +334,4 @@ cleanup:
 
 - **主仓库**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
 - **问题与支持**:在 [GitHub 仓库](https://github.com/chdb-io/chdb/issues) 中提交 Issue
-- **C API 文档**: [绑定文档](https://github.com/chdb-io/chdb/blob/main/bindings.md)
+- **C API 文档**: [绑定文档](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/chdb/install/python.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/chdb/install/python.md
@@ -286,7 +286,7 @@ result = sess.query("""
 """, "JSON")
 ```
 
-另请参阅：[test&#95;stateful.py](https://github.com/chdb-io/chdb/blob/main/tests/test_stateful.py)。
+另请参阅：[test&#95;stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py)。
 
 
 ### Python DB-API 2.0 接口 \{#python-db-api-20\}

--- a/i18n/zh/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/chdb/reference/data-formats.md
@@ -14,7 +14,7 @@ doc_type: 'reference'
 除了 ClickHouse 支持的数据格式之外，chDB 还支持：
 
 * 将 `ArrowTable` 作为输出格式，其类型为 Python `pyarrow.Table`
-* 将 `DataFrame` 作为输入和输出格式，其类型为 Python `pandas.DataFrame`。示例参见 [`test_joindf.py`](https://github.com/chdb-io/chdb/blob/main/tests/test_joindf.py)
+* 将 `DataFrame` 作为输入和输出格式，其类型为 Python `pandas.DataFrame`。示例参见 [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py)
 * 将 `Debug` 作为输出格式 (是 `CSV` 的别名) ，但启用了来自 ClickHouse 的详细调试输出。
 
 ClickHouse 所支持的数据格式包括：


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
