### PR TITLE
Unlist replica-aware routing docs page from nav and search (DOC-849)

### DIFF
--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -4,6 +4,7 @@ slug: /manage/replica-aware-routing
 description: 'How to use Replica-aware routing to increase cache re-use'
 keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing']
 doc_type: 'guide'
+unlisted: true
 ---
 
 import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';

--- a/scripts/search/index_pages.py
+++ b/scripts/search/index_pages.py
@@ -81,12 +81,17 @@ def read_metadata(text):
     for part in parts:
         parts = part.split(":")
         if len(parts) == 2:
-            if parts[0] in ['title', 'description', 'slug', 'keywords', 'score', 'doc_type']:
+            if parts[0] in ['title', 'description', 'slug', 'keywords', 'score', 'doc_type', 'unlisted', 'draft']:
                 value = parts[1].strip()
                 # Strip quotes only from doc_type
                 if parts[0] == 'doc_type':
                     value = value.strip("'\"")
-                metadata[parts[0]] = int(value) if parts[0] == 'score' else value
+                if parts[0] == 'score':
+                    metadata[parts[0]] = int(value)
+                elif parts[0] in ['unlisted', 'draft']:
+                    metadata[parts[0]] = value.strip("'\"").lower() == 'true'
+                else:
+                    metadata[parts[0]] = value
     return metadata
 
 
@@ -423,6 +428,12 @@ def process_markdown_directory(directory, base_directory, base_url):
                 if md_file_path not in files_processed:
                     files_processed.add(md_file_path)
                     metadata, content = parse_metadata_and_content(directory, base_directory, md_file_path)
+                    # Skip pages hidden from search via frontmatter. `unlisted` pages are
+                    # excluded from the sidebar and tagged `noindex` by Docusaurus; `draft`
+                    # pages are dropped from production builds entirely. Neither should be
+                    # indexed, but they remain reachable by direct URL.
+                    if metadata.get('unlisted') or metadata.get('draft'):
+                        continue
                     for sub_doc in parse_markdown_content(metadata, content, base_url):
                         url_without_anchor, anchor = split_url_and_anchor(sub_doc['url'])
                         sub_doc['url_without_anchor'] = url_without_anchor


### PR DESCRIPTION
Retires the replica-aware routing page without deleting it — some users are still on the feature, so it stays reachable by direct URL while being removed from navigation and search.

DOC-849

## Changes

- **`docs/cloud/features/05_infrastructure/replica-aware-routing.md`** — add `unlisted: true`. Docusaurus drops it from the autogenerated sidebar, excludes it from the sitemap, and tags it `noindex`. The page is still served at `/manage/replica-aware-routing`.
- **`scripts/search/index_pages.py`** — teach the Algolia indexer to read and skip `unlisted`/`draft` pages. It previously ignored these flags, so unlisted pages were still indexed and surfaced in site search.

## Note for reviewers

The indexer change is **repo-wide by design**: it now correctly excludes all 8 currently-unlisted pages (this one, the AI `model-parameters` page, and 6 managed-onboarding pages) — 65 search records that were being indexed despite `unlisted: true`. Verified locally with `index_pages.py --dry_run`: the replica-aware routing page went from 5 records to 0, total index 22,426 → 22,361.

The `update search` label is applied so the index is refreshed on merge.

## Not covered here

kapa.ai ("Ask AI") is a separate ingestion pipeline managed outside this repo and is unaffected by these changes. If the page should also be excluded from AI answers, that needs a URL exclusion in the kapa dashboard — tracked as a follow-up on DOC-849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)