### PR TITLE
docs: add Tigris page under S3-compatible integrations

### DIFF
--- a/docs/integrations/data-ingestion/s3-tigris.md
+++ b/docs/integrations/data-ingestion/s3-tigris.md
@@ -1,0 +1,64 @@
+---
+sidebar_label: 'Tigris'
+sidebar_position: 7
+slug: /integrations/tigris
+description: 'Page describing how to use Tigris with ClickHouse'
+title: 'Using Tigris'
+doc_type: 'guide'
+integration:
+  - support_level: 'community'
+  - category: 'data_ingestion'
+keywords: ['s3', 'tigris', 'object storage', 'data loading', 'compatible storage']
+---
+
+
+import SelfManaged from '@site/docs/_snippets/_self_managed_only_no_roadmap.md';
+
+<SelfManaged />
+
+ClickHouse's `s3` table function and `S3` disk type are compatible with [Tigris](https://www.tigrisdata.com), an S3-compatible object storage service. Tigris exposes a single global endpoint at `https://t3.storage.dev` with reads served from the region nearest the caller, so a multi-region ClickHouse fleet can point at one bucket URL without per-region replicas or cross-region egress.
+
+The backed merge tree configuration is compatible with minor changes:
+
+```xml
+<clickhouse>
+    <storage_configuration>
+        ...
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>https://your-bucket.t3.storage.dev/tables/</endpoint>
+                <access_key_id>your_access_key_id</access_key_id>
+                <secret_access_key>your_secret_access_key</secret_access_key>
+                <region>auto</region>
+                <metadata_path>/var/lib/clickhouse/disks/s3/</metadata_path>
+            </s3>
+            <s3_cache>
+                <type>cache</type>
+                <disk>s3</disk>
+                <path>/var/lib/clickhouse/disks/s3_cache/</path>
+                <max_size>10Gi</max_size>
+            </s3_cache>
+        </disks>
+        ...
+    </storage_configuration>
+</clickhouse>
+```
+
+:::tip
+Set `<region>auto</region>`. Tigris uses a single global endpoint rather than per-region buckets, but the AWS SigV4 signing flow that ClickHouse uses still requires a region value, and `auto` is the convention.
+:::
+
+The `s3` table function works against the same endpoint:
+
+```sql
+SELECT *
+FROM s3(
+    'https://your-bucket.t3.storage.dev/path/to/file.parquet',
+    'your_access_key_id',
+    'your_secret_access_key',
+    'Parquet'
+);
+```
+
+Access keys can be created from the [Tigris Console](https://console.storage.dev/). Access key IDs are prefixed with `tid_` and secrets with `tsec_`.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1024,6 +1024,7 @@ const sidebars = {
         'integrations/data-sources/cassandra',
         'integrations/data-ingestion/gcs/index',
         'integrations/data-ingestion/s3-minio',
+        'integrations/data-ingestion/s3-tigris',
         'integrations/data-ingestion/emqx/index',
         'integrations/data-ingestion/insert-local-files',
         'integrations/data-ingestion/dbms/jdbc-with-clickhouse',


### PR DESCRIPTION
## Summary

Adds a new docs page for using Tigris (an S3-compatible object storage service) as an S3 backend for ClickHouse, mirroring the structure of the existing MinIO page (`docs/integrations/data-ingestion/s3-minio.md`).

## Why

ClickHouse's `s3` table function and `S3` disk type work against any S3-compatible endpoint, and the docs already include a dedicated page for MinIO. Tigris is increasingly used as a multi-region S3-compatible store, but there is no docs entry for it today, so users have to figure out the endpoint and `region` handling from the source.

## What's in the page

- One paragraph framing the integration around the operational trade-off (single global endpoint with reads from the nearest region, vs. per-region S3 buckets).
- The `<storage_configuration>` XML snippet for a backed-MergeTree disk pointed at Tigris.
- One `:::tip` explaining why `<region>auto</region>` is needed (SigV4 still requires a region value, even when the endpoint is global).
- One `s3()` table function example.
- A link to the Tigris Console for creating access keys.

`support_level` is set to `'community'` (Tigris is not a ClickHouse-supported core integration).

## Files

- `docs/integrations/data-ingestion/s3-tigris.md` — new page.
- `sidebars.js` — one-line addition placing the entry next to the MinIO one.

Docs only; no code changes.