### PR TITLE
Note non-deterministic functions in generated function docs

### DIFF
--- a/scripts/settings/generate-functions.sql
+++ b/scripts/settings/generate-functions.sql
@@ -10,7 +10,8 @@ WITH function_docs AS (
         syntax,
         arguments,
         returned_value,
-        examples
+        examples,
+        deterministic
     FROM system.functions
     WHERE categories = {category:String}
     AND alias_to = ''
@@ -27,10 +28,11 @@ function_aliases AS (
 )
 SELECT
     format(
-        '{}{}{}{}{}{}{}{}',
+        '{}{}{}{}{}{}{}{}{}',
         '## ' || fd.name || ' ' || printf('{#%s}', fd.name) || '\n\n',
         'Introduced in: v' || fd.introduced_in || '\n\n',
         fd.description || '\n\n',
+        if(coalesce(fd.deterministic, 1) = 0, ':::note\nThis function is non-deterministic: it can return different results for the same arguments.\n:::\n\n', ''),
         '**Syntax**\n\n' || printf('```sql\n%s\n```', fd.syntax) || '\n\n',
         if(fa.aliases IS NOT NULL AND length(fa.aliases) > 0,
            '**Aliases**: ' || arrayStringConcat(arrayMap(x -> '`' || x || '`', fa.aliases), ', ') || '\n\n',


### PR DESCRIPTION
## What

The function-doc generator (`scripts/settings/generate-functions.sql`) now appends a note to any function that `system.functions` reports as non-deterministic, so its generated page states the fact. Example, on `rand()`:

> :::note
> This function is non-deterministic: it can return different results for the same arguments.
> :::

## Why

[DOC-841](https://github.com/ClickHouse/clickhouse-docs/issues/6429): non-deterministic functions (e.g. `rand`, `now`, `generateUUIDv4`) don't mention this in their docs, even though `system.functions` exposes it. The reporter asked for the generator to add the note automatically.

## How

Two lines: add the `deterministic` column to the generator's `SELECT`, and a conditional slot in the `format()`. The note is emitted only when `coalesce(deterministic, 1) = 0`, so:

- `deterministic = 0` (181 functions) → note added
- `deterministic = 1` (1391) → unchanged
- `deterministic = NULL` (270, "unknown — e.g. aggregate or user-defined functions" per the column's own comment) → unchanged

It keys off a first-class, documented column, so it stays in sync automatically with no per-function maintenance.

## Verification

Ran the generator against a ClickHouse binary:
- `Random Number` category → `rand` (and the other non-deterministic functions) get the note, placed after the description and before **Syntax**.
- `Arithmetic` category (deterministic) → zero notes.

`:::note` renders natively on the current site and converts to `<Note>` under the Mintlify migration, so it's correct on both.
