### PR TITLE
Fix duplicate allocation profiling entry in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1600,7 +1600,6 @@ const sidebars = {
         'operations/ssl-zookeeper',
         'operations/startup-scripts',
         'operations/storing-data',
-        'operations/allocation-profiling',
         {
           type: 'category',
           label: 'Backup/Restore',
@@ -1620,7 +1619,6 @@ const sidebars = {
           collapsible: true,
           link: { type: 'doc', id: 'operations/allocation-profiling' },
           items: [
-            'operations/allocation-profiling',
             'operations/allocation-profiling-old',
           ],
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -1617,8 +1617,8 @@ const sidebars = {
           label: 'Allocation profiling',
           collapsed: true,
           collapsible: true,
-          link: { type: 'doc', id: 'operations/allocation-profiling' },
           items: [
+            'operations/allocation-profiling',
             'operations/allocation-profiling-old',
           ],
         },


### PR DESCRIPTION
## Summary

Closes ClickHouse/clickhouse-docs#6444

The "Allocation profiling" page appeared twice in the Server Admin sidebar: once as a standalone item and once as the link/first item of the "Allocation profiling" category.

This removes the standalone `operations/allocation-profiling` item and the redundant copy inside the category. The category header now links to the current page, with the pre-25.9 version as its only child.

## Checklist

- [X] Delete items not relevant to your PR