### PR TITLE
Docs: note the 48-hour validity window for SAML domain verification

### DIFF
--- a/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
@@ -78,7 +78,7 @@ Click `Next: Verify your domains`. Enter your domain in the text box and click `
 Create a TXT record with your DNS provider. Copy the `TXT record name` to the TXT record Name field with your DNS provider. Copy the `Value` to the Content field with your DNS provider. Click `Verify and Finish` to complete the process.
 
 :::note
-It may take several minutes for the DNS record to update and be verified. You may leave the setup page and return later to complete the process without restarting.
+It may take several minutes for the DNS record to update and be verified. You may leave the setup page and return later to complete the process without restarting. The verification value is valid for 48 hours from when it is first generated.
 :::
 
    <Image img={samlSelfServe5} size="lg" alt="Verify your domain" force/> 


### PR DESCRIPTION
## Summary
The SAML domain-verification step generates a TXT-record value that is valid for 48 hours from first generation, but this window isn't documented. The existing note says users can "leave the setup page and return later... without restarting," which reads as open-ended; in practice the value expires after 48 hours and a new one is minted on the next visit, so a TXT record created against the old value silently fails verification. This adds a sentence stating the 48-hour window. Reported by a customer who hit exactly this.

## Checklist
- [x] No URL changes (heading text and `{#verify-your-domain}` anchor unchanged)
