### PR TITLE
Docs: correct join_algorithm default (not auto)

### DIFF
--- a/docs/best-practices/minimize_optimize_joins.md
+++ b/docs/best-practices/minimize_optimize_joins.md
@@ -58,7 +58,7 @@ ClickHouse supports several JOIN algorithms that trade off between speed and mem
 Each algorithm has varying support for JOIN types. A full list of supported join types for each algorithm can be found [here](/guides/joining-tables#choosing-a-join-algorithm).
 :::
 
-You can let ClickHouse choose the best algorithm by setting `join_algorithm = 'auto'` (the default), or explicitly control it based on your workload. If you need to select a join algorithm to optimize for performance or memory overhead, we recommend [this guide](/guides/joining-tables#choosing-a-join-algorithm).
+You can let ClickHouse choose the best algorithm by setting `join_algorithm = 'auto'`, or explicitly control it based on your workload. The default value is `direct,parallel_hash,hash`, so ClickHouse uses a direct join when the right-hand side is a dictionary or key-value engine and otherwise falls back to parallel hash, then hash. If you need to select a join algorithm to optimize for performance or memory overhead, we recommend [this guide](/guides/joining-tables#choosing-a-join-algorithm).
 
 For optimal performance:
 


### PR DESCRIPTION
## Summary

The "Minimize and optimize JOINs" best-practices page states that `join_algorithm = 'auto'` is the default. The actual default in source is `direct,parallel_hash,hash` — see [`src/Core/Settings.cpp`](https://github.com/ClickHouse/ClickHouse/blob/master/src/Core/Settings.cpp) (`DECLARE(JoinAlgorithm, join_algorithm, "direct,parallel_hash,hash", ...)`).

This corrects the statement and notes the real default and what it means (direct join when the right-hand side is a dictionary/key-value engine, otherwise parallel hash, then hash). One-sentence prose change; no URL/anchor change.

## Checklist
- [x] Correction verified against `ClickHouse/ClickHouse` source