### PR TITLE
Add interfaces/documentation-search to floating-pages exceptions

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -19,4 +19,4 @@ use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-
 use-cases/observability/clickstack/managed-onboarding/instrument-application.md
 use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
 use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
-
+interfaces/documentation-search


### PR DESCRIPTION
**Step 1 of 2** for adding the `/docs` documentation-search Web UI page from ClickHouse/ClickHouse#108345.

The new page `interfaces/documentation-search` lives in the ClickHouse repo and isn't in an `autogenerated` sidebar folder, so the floating-pages check fails on #108345's docs CI. Per the [style guide floating-pages process](https://github.com/ClickHouse/clickhouse-docs/blob/main/contribute/style-guide.md#floating-pages), this PR adds it to the exceptions list first to break the chicken-and-egg.

**Safe to merge now** — it only adds a path string; it does not reference a page that must already exist.

Sequence:
1. ⬅️ **This PR** — add to `floating-pages-exceptions.txt` (merge first).
2. #108345 docs check passes → #108345 merges.
3. Follow-up (#6453) — remove this entry and add the page to `sidebars.js`.