### PR TITLE
docs: BYOB restore — document restore_access_entities_with_current_grants (26.4+)

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -198,8 +198,6 @@ SELECT version()
 When enabled, restored users and roles have their grants limited to what the restoring user is allowed to grant
 (the same semantics as [`GRANT CURRENT GRANTS`](/sql-reference/statements/grant)), instead of the `RESTORE`
 failing with `ACCESS_DENIED` when the backup contains more permissions than the restoring user can grant.
-
-On versions earlier than 26.4, omit the setting and exclude the access entities from the restore instead by using `RESTORE ALL EXCEPT TABLES system.users, system.roles` (note that your users and roles will not be restored in this case).
 :::
 </TabItem>
 </Tabs>

--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -178,6 +178,31 @@ where `uuid` is a unique identifier, used to identify the backup.
 <TabItem value="Restore" label="RESTORE" default>
 
 ```sql
+RESTORE ALL
+FROM S3(
+    'https://testchbackups.s3.amazonaws.com/<uuid>',
+    '<key id>',
+    '<key secret>'
+)
+SETTINGS restore_access_entities_with_current_grants = 1
+```
+
+:::note Restoring users and roles requires ClickHouse 26.4 or later
+The `restore_access_entities_with_current_grants` setting is available from ClickHouse Cloud version **26.4** (build **26.4.1.1942** or later).
+You can check the version your service is running with:
+
+```sql
+SELECT version()
+```
+
+When enabled, restored users and roles have their grants limited to what the restoring user is allowed to grant
+(the same semantics as [`GRANT CURRENT GRANTS`](/sql-reference/statements/grant)), instead of the `RESTORE`
+failing with `ACCESS_DENIED` when the backup contains more permissions than the restoring user can grant.
+
+On versions earlier than 26.4, omit the setting and exclude the access entities from the restore instead, so that
+the `RESTORE` does not fail (note that your users and roles will not be restored in this case):
+
+```sql
 RESTORE ALL EXCEPT TABLES system.users, system.roles
 FROM S3(
     'https://testchbackups.s3.amazonaws.com/<uuid>',
@@ -185,6 +210,7 @@ FROM S3(
     '<key secret>'
 )
 ```
+:::
 </TabItem>
 </Tabs>
 

--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -194,7 +194,7 @@ You can check the version your service is running with:
 SELECT version()
 ```
 
-When enabled, restored users and roles have their grants limited to what the restoring user is allowed to grant
+When `restore_access_entities_with_current_grants` is enabled, restored users and roles have their grants limited to what the restoring user is allowed to grant
 (the same semantics as [`GRANT CURRENT GRANTS`](/sql-reference/statements/grant)), instead of the `RESTORE`
 failing with `ACCESS_DENIED` when the backup contains more permissions than the restoring user can grant.
 

--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -199,17 +199,7 @@ When enabled, restored users and roles have their grants limited to what the res
 (the same semantics as [`GRANT CURRENT GRANTS`](/sql-reference/statements/grant)), instead of the `RESTORE`
 failing with `ACCESS_DENIED` when the backup contains more permissions than the restoring user can grant.
 
-On versions earlier than 26.4, omit the setting and exclude the access entities from the restore instead, so that
-the `RESTORE` does not fail (note that your users and roles will not be restored in this case):
-
-```sql
-RESTORE ALL EXCEPT TABLES system.users, system.roles
-FROM S3(
-    'https://testchbackups.s3.amazonaws.com/<uuid>',
-    '<key id>',
-    '<key secret>'
-)
-```
+On versions earlier than 26.4, omit the setting and exclude the access entities from the restore instead by using `RESTORE ALL EXCEPT TABLES system.users, system.roles` (note that your users and roles will not be restored in this case).
 :::
 </TabItem>
 </Tabs>

--- a/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/03_backup_restore_using_commands.md
@@ -187,7 +187,6 @@ FROM S3(
 SETTINGS restore_access_entities_with_current_grants = 1
 ```
 
-:::note Restoring users and roles requires ClickHouse 26.4 or later
 The `restore_access_entities_with_current_grants` setting is available from ClickHouse Cloud version **26.4** (build **26.4.1.1942** or later).
 You can check the version your service is running with:
 
@@ -198,7 +197,8 @@ SELECT version()
 When enabled, restored users and roles have their grants limited to what the restoring user is allowed to grant
 (the same semantics as [`GRANT CURRENT GRANTS`](/sql-reference/statements/grant)), instead of the `RESTORE`
 failing with `ACCESS_DENIED` when the backup contains more permissions than the restoring user can grant.
-:::
+
+On versions earlier than 26.4, omit the setting.
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## What
Documents the new `restore_access_entities_with_current_grants` RESTORE setting in the BYOB "restore using commands" guide.

The previous example used `RESTORE ALL EXCEPT TABLES system.users, system.roles` to work around the `ACCESS_DENIED` failure that occurs when a backup's access entities (e.g. `default_role`) carry more grants than the restoring user can grant. On **ClickHouse Cloud 26.4** (build `26.4.1.1942`+) you can instead `RESTORE ALL` with `SETTINGS restore_access_entities_with_current_grants = 1`, which clamps restored grants to what the restoring user may grant (same semantics as `GRANT CURRENT GRANTS`) instead of failing.

## Details
- Primary example switched to `RESTORE ALL ... SETTINGS restore_access_entities_with_current_grants = 1`.
- Added a version note (Cloud 26.4 / build `26.4.1.1942`+) with `SELECT version()` to check the running version.
- Kept the `EXCEPT TABLES system.users, system.roles` form documented as the pre-26.4 fallback.

Upstream feature PR: ClickHouse/ClickHouse#98795
Rollout: ClickHouse/data-plane-base-configurations#2084

English source only; translations handled by the docs i18n flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)