### PR TITLE
Exclude interfaces/web-sql from the floating-pages check

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -12,6 +12,7 @@ integrations/language-clients/java/jdbc-v1
 operations/utilities/clickhouse-keeper-http-api.md
 cloud/features/backups/faq.md
 interfaces/web-terminal
+interfaces/web-sql
 operations/query-rules
 use-cases/observability/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md


### PR DESCRIPTION
## Summary

The ClickHouse main repository adds a new `docs/en/interfaces/web-sql.md` page (documenting the `/play` Web SQL UI and its new query tabs) in ClickHouse/ClickHouse#107826. Like `interfaces/web-terminal`, the page is reachable from the interfaces index but is not part of an autogenerated sidebar, so the floating-pages check fails the `Docs check` job on that PR with:

```
1 floating pages found:
  - /opt/clickhouse-docs/docs/interfaces/web-sql.md
Error: Found "floating" pages without sidebars.
```

This adds `interfaces/web-sql` to `plugins/floating-pages-exceptions.txt`, matching exactly how `interfaces/web-terminal` is handled.

Related: https://github.com/ClickHouse/ClickHouse/pull/107826

## Checklist
- [x] Delete items not relevant to your PR