### PR TITLE
Add query plan cache page to the Operations sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1479,6 +1479,7 @@ const sidebars = {
         'operations/optimizing-performance/sampling-query-profiler',
         'operations/query-cache',
         'operations/query-condition-cache',
+        'operations/query-plan-cache',
         'operations/userspace-page-cache',
         'operations/performance-test',
       ],


### PR DESCRIPTION
Adds `operations/query-plan-cache` to the Operations sidebar.

The new page `docs/en/operations/query-plan-cache.md` introduced in ClickHouse/ClickHouse#107125 is otherwise a floating page (no sidebar entry), which makes the `Docs check` (Build docusaurus) fail with:

```
1 floating pages found:
  - /opt/clickhouse-docs/docs/operations/query-plan-cache.md
Error: Found "floating" pages without sidebars.
```

Related: https://github.com/ClickHouse/ClickHouse/pull/107125