### PR TITLE
Add query-plan-cache to floating-pages exceptions

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -14,6 +14,7 @@ cloud/features/backups/faq.md
 interfaces/web-terminal
 interfaces/web-sql
 operations/query-rules
+operations/query-plan-cache
 use-cases/observability/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs.md


### PR DESCRIPTION
## Summary

Adds `operations/query-plan-cache` to `plugins/floating-pages-exceptions.txt` to break the chicken/egg between this docs repo and the ClickHouse repo.

The page `docs/operations/query-plan-cache.md` is introduced in ClickHouse/ClickHouse#107125 and syncs into this repo. That creates a deadlock:

- Adding it to `sidebars.js` first (see #6459) fails the build — the sidebar references a doc ID that doesn't exist here yet.
- Letting it sync in without a sidebar entry fails the `Docs check` floating-pages validation.

The floating-pages plugin only globs files that actually exist, then skips anything in the exceptions list, so listing the path now is a safe no-op until the page syncs in.

## Follow-up

Once `query-plan-cache.md` syncs in, it'll be reachable by URL but absent from the sidebar nav. At that point the real sidebar entry (#6459 or equivalent) should land **and this exception line should be removed**. Coordinating with @alexey-milovidov on #6459 so the two don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)