### PR TITLE
Escape version-history labels in generated settings docs

### DIFF
--- a/scripts/settings/format-settings.sql
+++ b/scripts/settings/format-settings.sql
@@ -10,9 +10,9 @@ WITH
                     (i, x) -> '{' ||
                         '"id": "row-' || toString(i) || '",' ||
                         '"items": [' ||
-                            '{"label": "' || toString(x.1) || '"},' ||
-                            '{"label": "' || toString(x.2) || '"},' ||
-                            '{"label": "' || replaceRegexpAll(x.3, '([\\"])', '\\\\$1') || '"}' ||
+                            '{"label": ' || toJSONString(toString(x.1)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.2)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.3)) || '}' ||
                         ']' ||
                     '}',
                     arrayEnumerate(groupArray((version, default_value, comment))),

--- a/scripts/settings/mergetree-settings.sql
+++ b/scripts/settings/mergetree-settings.sql
@@ -9,9 +9,9 @@ WITH
                     (i, x) -> '{' ||
                         '"id": "row-' || toString(i) || '",' ||
                         '"items": [' ||
-                            '{"label": "' || toString(x.1) || '"},' ||
-                            '{"label": "' || toString(x.2) || '"},' ||
-                            '{"label": "' || replaceRegexpAll(x.3, '([\\"])', '\\\\$1') || '"}' ||
+                            '{"label": ' || toJSONString(toString(x.1)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.2)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.3)) || '}' ||
                         ']' ||
                     '}',
                     arrayEnumerate(groupArray((version, default_value, comment))),

--- a/scripts/settings/session-settings.sql
+++ b/scripts/settings/session-settings.sql
@@ -10,9 +10,9 @@ WITH
                     (i, x) -> '{' ||
                         '"id": "row-' || toString(i) || '",' ||
                         '"items": [' ||
-                            '{"label": "' || toString(x.1) || '"},' ||
-                            '{"label": "' || toString(x.2) || '"},' ||
-                            '{"label": "' || replaceRegexpAll(x.3, '([\\"])', '\\\\$1') || '"}' ||
+                            '{"label": ' || toJSONString(toString(x.1)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.2)) || '},' ||
+                            '{"label": ' || toJSONString(toString(x.3)) || '}' ||
                         ']' ||
                     '}',
                     arrayEnumerate(groupArray((version, default_value, comment))),


### PR DESCRIPTION
The settings markdown generators (`format-settings.sql`, `session-settings.sql` and `mergetree-settings.sql`) build the `<VersionHistory rows={...}/>` JSX expression by concatenating the version, default value and comment of each settings-history entry into a JSON array. Only the comment was escaped (and only for `"` and `\`), while the version and default value were inserted verbatim.

A default value that contains a control character — for example a newline — produced a raw newline inside the JS string literal, which MDX/`acorn` rejects with `Could not parse expression with acorn`, breaking `yarn build-docs` (the `Build docusaurus` step of the `Docs check`).

This fix uses `toJSONString` to encode all three labels: it adds the surrounding quotes and escapes `"`, `\` and control characters (including newlines), producing valid JSON/JS for every possible value.

### Motivation

This is exercised by ClickHouse PR https://github.com/ClickHouse/ClickHouse/pull/107582, which adds the `format_hive_text_rows_delimiter` setting whose default is `\n` (the first setting with a control-character default that also has a `SettingsChangesHistory` entry). Without this fix, that setting breaks the live docs build once merged to `master`.

Verified by running the modified `format-settings.sql` against `clickhouse local`: the generated `<VersionHistory>` rows now parse as valid JSON/JS, with a newline default rendered as the escaped `"\n"` rather than a raw newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)