### PR TITLE
Add Cloud changelog entries for week of 2026-06-30

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -35,10 +35,6 @@ TLS activation and verification levels are now consistent across CDC sources. Th
 
 Replicated databases are once again selectable in the ClickPipes destination picker.
 
-### Postgres query insights and metrics {#postgres-query-insights}
-
-New Postgres query insights bring detailed stats, a recent queries table, and a per-query detail flyout, backed by a new time-series metrics endpoint and a capabilities endpoint for discovering available features.
-
 ### ClickHouse Agents updates (public beta) {#clickhouse-agents-updates}
 
 [ClickHouse Agents](/cloud/features/ai-ml/agents) now support Chat Projects for organizing conversations, a context usage gauge showing token and context-window usage, agent-authored Skills, and bundled ClickHouse best-practice Skills. This release also includes improvements to settings, navigation, shortcuts, and pinning.

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,42 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## June 30, 2026 {#2026-06-30}
+
+This week's updates include new observability features for Postgres and ClickHouse internals, expanded ClickPipes controls including Kafka exactly-once delivery, and several platform additions: Azure Marketplace BYOC, the official Airflow provider, and ClickHouse Agents updates.
+
+### Kafka exactly-once delivery in ClickPipes {#clickpipes-kafka-exactly-once}
+
+You can now enable exactly-once delivery for Kafka imports directly in the [ClickPipes](/integrations/clickpipes/kafka) import flow, with the same option exposed through the public API for programmatic setup.
+
+### Unified TLS controls for CDC sources {#clickpipes-cdc-tls-controls}
+
+TLS activation and verification levels are now consistent across CDC sources. The OpenAPI create and update endpoints propagate the `postgres_skip_cert_verification`, `postgres_disable_tls`, and `mongo_skip_cert_verification` fields so you can manage certificate handling via the API.
+
+### Replicated databases return to the ClickPipes picker {#clickpipes-replicated-databases}
+
+Replicated databases are once again selectable in the ClickPipes destination picker.
+
+### Postgres query insights and metrics {#postgres-query-insights}
+
+New Postgres query insights bring detailed stats, a recent queries table, and a per-query detail flyout, backed by a new time-series metrics endpoint and a capabilities endpoint for discovering available features.
+
+### ClickHouse Agents updates (public beta) {#clickhouse-agents-updates}
+
+[ClickHouse Agents](/cloud/features/ai-ml/agents) now support Chat Projects for organizing conversations, a context usage gauge showing token and context-window usage, agent-authored Skills, and bundled ClickHouse best-practice Skills. This release also includes improvements to settings, navigation, shortcuts, and pinning.
+
+### ClickHouse BYOC on the Azure Marketplace {#byoc-azure-marketplace}
+
+ClickHouse [Bring Your Own Cloud](/cloud/reference/byoc/overview) is now listed on the Azure Marketplace, letting customers purchase via private offer and deploy BYOC billed through their Azure account. Billing support for Azure BYOC marketplace listings and product IDs was added on the platform side.
+
+### Official ClickHouse Airflow provider {#airflow-provider}
+
+An official Apache Airflow provider for ClickHouse is now available on PyPI and listed in the Airflow registry, replacing reliance on the legacy community plugin for routing data into and out of ClickHouse.
+
+### Billing visibility and marketplace improvements {#billing-visibility}
+
+Billing now includes a self-service credit history table, a prepaid summary showing used and expired amounts, and GCP MPPO email support.
+
 ## June 3, 2026 {#2026-06-03}
 
 Open House 2026 week brought a wave of launches centered on running ClickHouse where your data lives and bringing agentic, AI-assisted workflows into the platform.

--- a/static/cloud/changelog-rss.xml
+++ b/static/cloud/changelog-rss.xml
@@ -7,6 +7,27 @@
     <language>en-us</language>
     <atom:link href="https://clickhouse.com/docs/cloud/changelog-rss.xml" rel="self" type="application/rss+xml" />
     <item>
+      <title>ClickHouse Cloud - June 30, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-30</link>
+      <description>Kafka exactly-once delivery in ClickPipes:
+
+Unified TLS controls for CDC sources:
+
+Replicated databases return to the ClickPipes picker:
+
+Postgres query insights and metrics:
+
+ClickHouse Agents updates (public beta):
+
+ClickHouse BYOC on the Azure Marketplace:
+
+Official ClickHouse Airflow provider:
+
+Billing visibility and marketplace improvements:</description>
+      <pubDate>Tue, 30 Jun 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-30</guid>
+    </item>
+    <item>
       <title>ClickHouse Cloud - June 3, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-03</link>
       <description>ClickPipes now runs natively on GCP with Private Service Connect:
@@ -27,7 +48,7 @@ Horizontal autoscaling (private preview):
 
 ClickStack MCP Server (open source):
 
-Open House 2026: a roadmap of UX improvements for humans and agents:</description>
+Executable User Defined Functions:</description>
       <pubDate>Wed, 03 Jun 2026 00:00:00 +0200</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-03</guid>
     </item>


### PR DESCRIPTION
Adds the ClickHouse Cloud changelog section for the week of 2026-06-22 – 2026-06-29, sourced from the autogenerated Cloud changelog Notion page.

## Entries

- **Kafka exactly-once delivery in ClickPipes** — enable exactly-once delivery for Kafka imports in the import flow and via the public API
- **Unified TLS controls for CDC sources** — consistent TLS activation/verification and new OpenAPI cert-handling fields
- **Replicated databases return to the ClickPipes picker**
- **Postgres query insights and metrics** — query stats, recent queries table, per-query flyout, new time-series metrics endpoint
- **ClickHouse Agents updates (public beta)** — Chat Projects, context usage gauge, agent-authored and bundled Skills
- **ClickHouse BYOC on the Azure Marketplace**
- **Official ClickHouse Airflow provider**
- **Billing visibility and marketplace improvements**

Also regenerates `static/cloud/changelog-rss.xml` via `scripts/changelog/cloud-changelog-rss.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)