### PR TITLE
docs(clickpipes): add us-west1 GCP static NAT IPs

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/index.md
@@ -122,6 +122,7 @@ For other services, ClickPipes traffic will originate from a default region base
 | **europe-west4** - Netherlands (from 27 May 2026) | `34.34.86.3`, `34.6.175.56`, `34.178.6.187`, `34.91.204.220`, `34.12.85.206`                            |
 | **us-central1** - Iowa (from 27 May 2026)        | `34.28.24.54`, `34.42.56.195`, `34.63.141.9`, `35.238.146.37`, `34.10.251.49`                            |
 | **us-east1** - South Carolina (from 27 May 2026) | `34.24.134.232`, `34.24.214.165`, `34.24.20.1`, `35.243.193.248`, `34.23.98.76`                          |
+| **us-west1** - Oregon (from 1 Jul 2026)          | `136.118.254.175`, `8.229.115.2`, `34.83.0.219`, `35.247.34.28`, `35.199.165.121`                       |
 
 ## Adjusting ClickHouse settings {#adjusting-clickhouse-settings}
 ClickHouse Cloud provides sensible defaults for most of the use cases. However, if you need to adjust some ClickHouse settings for the ClickPipes destination tables, a dedicated role for ClickPipes is the most flexible solution.


### PR DESCRIPTION
## Summary
Adds the **us-west1** (Oregon) GCP-native ClickPipes static NAT egress IPs to the "Google Cloud static NAT IPs" table in the ClickPipes docs, so customers can allowlist them on their source services. us-west1 is a newly-bootstrapped GCP prod region; its peers (us-east1, us-central1, europe-west2/4, asia-northeast1/southeast1) are already listed.

IPs (Cloud NAT external addresses `clickpipes-production-us-west1-0..4`, verified via `gcloud compute addresses list --project clickpipes-production`):
`136.118.254.175`, `8.229.115.2`, `34.83.0.219`, `35.247.34.28`, `35.199.165.121`

🤖 Generated with [Claude Code](https://claude.com/claude-code)