### PR TITLE
Fix Databricks workspace URL example on data catalog page

### DIFF
--- a/docs/integrations/data-catalogs/index.md
+++ b/docs/integrations/data-catalogs/index.md
@@ -99,7 +99,7 @@ Before you connect, confirm:
 
 In the flyout:
 
-1. Enter your Databricks **Workspace URL** (e.g. `dbc-1234567a-cbde`).
+1. Enter your Databricks **Workspace URL** (e.g. `dbc-1234567a-cbde.cloud.databricks.com`).
 2. Enter the **Databricks catalog name** to connect (e.g. `icebench`).
 3. Enter the OAuth **Client ID** and **Client secret** for your service principal.
 4. Enter a **Database name** for the ClickHouse database that exposes your Unity Catalog tables.


### PR DESCRIPTION
## Summary
- Update the Unity Catalog (Iceberg) **Workspace URL** example on the data catalog integration page to show the full hostname (`dbc-1234567a-cbde.cloud.databricks.com`) instead of the workspace ID alone.
- Aligns the Cloud UI walkthrough with the format used in the Unity Catalog SQL docs.

## Test plan
- [ ] Preview the data catalog integration page and confirm the Unity Catalog (Iceberg) tab shows the updated example.
- [ ] Verify the page builds without errors.


Made with [Cursor](https://cursor.com)