### PR TITLE
Add Python clickhouse-migrations to schema migration tools (and disambiguate the Node.js entry)

### DIFF
--- a/knowledgebase/schema_migration_tools.md
+++ b/knowledgebase/schema_migration_tools.md
@@ -123,7 +123,8 @@ The following tools also work with ClickHouse. They may be a better fit dependin
 | [Bytebase](https://www.bytebase.com/) | Open Core | For large organizations that need governance, approval workflows, and audit trails for multiple environments | 
 | [Flyway](https://flywaydb.org/) | Open Source | Teams already standardized on Flyway or JVM-based infrastructure |
 | [Liquibase](https://www.liquibase.org/) | Open Core | Teams that use Liquibase across multiple databases and want consistency| 
-| [clickhouse-migrations](https://www.npmjs.com/package/clickhouse-migrations) | Open Source | Node/TypeScript teams wanting a simple, ClickHouse-focused runner | 
+| [clickhouse-migrations (Node.js)](https://www.npmjs.com/package/clickhouse-migrations) | Open Source | Node/TypeScript teams wanting a simple, ClickHouse-focused runner | 
 | [Houseplant](https://github.com/junehq/houseplant) | Open Source | Python teams wanting environment-aware, ClickHouse-specific tooling | 
 | [Sqitch](https://sqitch.org/) | Open Source | Teams preferring native ClickHouse Client deployment scripting or needing explicit dependency management across complex deployments. | 
 | [Alembic](https://alembic.sqlalchemy.org/) (SQLAlchemy) | Open Source | Python shops already using SQLAlchemy for database access |
+| [clickhouse-migrations (Python)](https://github.com/zifter/clickhouse-migrations) | Open Source | Python teams wanting a simple, file-based migration runner (CLI and library) with ClickHouse cluster support |


### PR DESCRIPTION
## Summary

The **Schema migration tools for ClickHouse** knowledge-base page lists `clickhouse-migrations` in the "Other Tools in the Ecosystem" table, but the link points to the **npm / Node.js** package. There is a separate, actively maintained **Python** project of the same name that isn't represented:

- PyPI: https://pypi.org/project/clickhouse-migrations/
- Source: https://github.com/zifter/clickhouse-migrations

This PR:

- Renames the existing row to **clickhouse-migrations (Node.js)** so the name collision between the two projects is explicit.
- Adds **clickhouse-migrations (Python)** — a file-based schema migration runner available both as a CLI and as a Python library, with single-node and cluster (`ON CLUSTER` / replicated) support, `--dry-run` and `--fake` modes, and multi-statement migration files. Supports Python 3.9–3.14, MIT licensed.

Only the one table in `knowledgebase/schema_migration_tools.md` is changed; no other content is touched.

## Why

Readers searching for a Python-native ClickHouse migration tool currently see only Houseplant and Alembic, and the same-named Node.js entry is easy to mistake for the Python package. Disambiguating the name and listing the Python project makes the ecosystem table accurate and more useful.