### PR TITLE
Update 05_automatic_idling.md

### DIFF
--- a/docs/cloud/features/04_automatic_scaling/05_automatic_idling.md
+++ b/docs/cloud/features/04_automatic_scaling/05_automatic_idling.md
@@ -17,7 +17,7 @@ When you create a ClickHouse Cloud service, the default setting for the IP allow
 
 ### Adaptive Idling {#adaptive-idling}
  ClickHouse Cloud implements adaptive idling to prevent disruptions while optimizing cost savings. The system evaluates several conditions before transitioning a service to idle. Adaptive idling overrides the idling duration setting when any of the below listed conditions are met:
-- When the number of parts exceeds the maximum idle parts threshold (default: 10,000), the service isn't idled so that background maintenance can continue
+- When the number of parts exceeds the maximum active parts threshold (default: 10,000), the service isn't idled so that background maintenance can continue
 - When there are ongoing merge operations, the service isn't idled until those merges complete to avoid interrupting critical data consolidation
 - Additionally, the service also adapts idle timeouts based on server initialization time:
   - If server initialization time is less than 15 minutes, no adaptive timeout is applied and the customer-configured default idle timeout is used


### PR DESCRIPTION
idle parts doesn't make sense, it should be active parts

## Summary
I saw a response to a customer including this text and that caught my attention as I never heard of "idle parts"... as far as I know a part can be active or inactive and, within this context, it's clear that it's referring to an active part

## Checklist
- [X] Delete items not relevant to your PR
- [NA] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ NA] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
