### PR TITLE
Link ClickHouse Operator GitHub repo from overview references

### DIFF
--- a/docs/kubernetes-operator/01_overview.mdx
+++ b/docs/kubernetes-operator/01_overview.mdx
@@ -38,3 +38,4 @@ Choose your preferred installation method:
 ## Reference {#reference}
 
 - **[API Reference](./04_api_reference.mdx)** - Complete API documentation for custom resources
+- **[GitHub Repository](https://github.com/ClickHouse/clickhouse-operator)** - Source code, issues, and releases for the ClickHouse Operator


### PR DESCRIPTION
## Summary

Adds a link to the official [ClickHouse Operator GitHub repository](https://github.com/ClickHouse/clickhouse-operator) under the **Reference** section of the [ClickHouse Operator overview](https://clickhouse.com/docs/clickhouse-operator/overview) page.

This gives readers a direct path to the source code, issues, and releases from the operator docs.

## Changes

- `docs/kubernetes-operator/01_overview.mdx` — add GitHub repository link to the Reference section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)