### PR TITLE
Add MySQL FAQ entry for unsupported MariaDB partial row events

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -16,9 +16,9 @@ integration:
 Yes, the MySQL ClickPipe supports MariaDB 10.0 and above. The configuration for it is very similar to MySQL, using GTID replication by default.
 
 ### Why did my pipe fail with an unsupported MariaDB partial row event? {#mariadb-partial-row-event-unsupported}
-MariaDB 12.3 and above can emit a [partial rows event](https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/row-binlog-events#partial_rows_log_event) in the binlog. When a row change exceeds the fragment threshold, MariaDB splits it across several binlog events that a consumer must buffer and reassemble before decoding. ClickPipes does not yet support reassembling these fragments, so rather than silently dropping the row change the pipe fails loudly and requires a resync.
+MariaDB 12.3 and above can emit a [partial rows event](https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/row-binlog-events#partial_rows_log_event) in the binlog, which we don't support yet.
 
-To recover, [resync the pipe](./table_resync.md). To reduce the chance of hitting this again, you can also raise `binlog_row_event_fragment_threshold` on the source so fewer row changes get fragmented — keep it below your `max_allowed_packet`, since a single unfragmented binlog event larger than `max_allowed_packet` will fail the replication stream instead.
+To recover, resync the pipe. To reduce the chance of hitting this again, you can also raise `binlog_row_event_fragment_threshold` setting on the source so fewer row changes get fragmented — keep it below your `max_allowed_packet`, since a single unfragmented binlog event larger than `max_allowed_packet` will fail the replication stream instead (see [Why is my pipe failing with a max_allowed_packet binlog error?](#binlog-event-exceeded-max-allowed-packet)).
 
 ### Does the MySQL ClickPipe support PlanetScale, Vitess, or TiDB? {#does-the-clickpipe-support-planetscale-vitess}
 No, these don't support MySQL's binlog API.

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -16,7 +16,7 @@ integration:
 Yes, the MySQL ClickPipe supports MariaDB 10.0 and above. The configuration for it is very similar to MySQL, using GTID replication by default.
 
 ### Why did my pipe fail with an unsupported MariaDB partial row event? {#mariadb-partial-row-event-unsupported}
-MariaDB 12.3 and above can emit a `PARTIAL_ROW_DATA_EVENT` in the binlog. When a row change exceeds the fragment threshold, MariaDB splits it across several binlog events that a consumer must buffer and reassemble before decoding. ClickPipes does not yet support reassembling these fragments, so rather than silently dropping the row change the pipe fails loudly and requires a resync.
+MariaDB 12.3 and above can emit a [partial rows event](https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/row-binlog-events#partial_rows_log_event) in the binlog. When a row change exceeds the fragment threshold, MariaDB splits it across several binlog events that a consumer must buffer and reassemble before decoding. ClickPipes does not yet support reassembling these fragments, so rather than silently dropping the row change the pipe fails loudly and requires a resync.
 
 To recover, [resync the pipe](./table_resync.md). To reduce the chance of hitting this again, you can also raise `binlog_row_event_fragment_threshold` on the source so fewer row changes get fragmented — keep it below your `max_allowed_packet`, since a single unfragmented binlog event larger than `max_allowed_packet` will fail the replication stream instead.
 

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -15,6 +15,11 @@ integration:
 ### Does the MySQL ClickPipe support MariaDB? {#does-the-clickpipe-support-mariadb}
 Yes, the MySQL ClickPipe supports MariaDB 10.0 and above. The configuration for it is very similar to MySQL, using GTID replication by default.
 
+### Why did my pipe fail with an unsupported MariaDB partial row event? {#mariadb-partial-row-event-unsupported}
+MariaDB 12.3 and above can emit a `PARTIAL_ROW_DATA_EVENT` in the binlog. When a row change exceeds the fragment threshold, MariaDB splits it across several binlog events that a consumer must buffer and reassemble before decoding. ClickPipes does not yet support reassembling these fragments, so rather than silently dropping the row change the pipe fails loudly and requires a resync.
+
+To recover, [resync the pipe](./table_resync.md). To reduce the chance of hitting this again, you can also raise `binlog_row_event_fragment_threshold` on the source so fewer row changes get fragmented — keep it below your `max_allowed_packet`, since a single unfragmented binlog event larger than `max_allowed_packet` will fail the replication stream instead.
+
 ### Does the MySQL ClickPipe support PlanetScale, Vitess, or TiDB? {#does-the-clickpipe-support-planetscale-vitess}
 No, these don't support MySQL's binlog API.
 


### PR DESCRIPTION
## What

Adds a MySQL ClickPipes FAQ entry (anchor `#mariadb-partial-row-event-unsupported`) explaining why a pipe fails when it encounters a MariaDB 12.3+ `PARTIAL_ROW_DATA_EVENT`, and how to recover.

## Why

MariaDB 12.3+ fragments oversized row changes into `PARTIAL_ROW_DATA_EVENT`s that a consumer must buffer and reassemble. ClickPipes doesn't support reassembly yet, so it now fails loudly (rather than silently dropping the row change) and requires a resync. The new `NOTIFY_BINLOG_PARTIAL_ROW_EVENT_UNSUPPORTED` alert links users here.

## Mitigation documented

- Resync the pipe to recover.
- Optionally raise `binlog_row_event_fragment_threshold` on the source to reduce fragmentation, keeping it below `max_allowed_packet`.

Paired with clickpipes-platform PR (branch `fix/dbi-815/mysql-fail-on-maria-partial-row-data-event`) which references this anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)