### PR TITLE
Add operations/restore-settings to floating-pages exceptions

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -15,6 +15,7 @@ interfaces/web-terminal
 interfaces/web-sql
 operations/query-rules
 operations/query-plan-cache
+operations/restore-settings
 use-cases/observability/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-kubernetes.md
 use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs.md


### PR DESCRIPTION
Adds `operations/restore-settings` to `plugins/floating-pages-exceptions.txt`.

### Why

The docs check on [ClickHouse/ClickHouse#102402](https://github.com/ClickHouse/ClickHouse/pull/102402) fails because it adds a new `docs/en/operations/restore-settings.md` page that isn't yet wired into `sidebars.js`, so the floating-pages check flags it repo-wide.

Per [`contribute/style-guide.md` → Floating pages](https://github.com/ClickHouse/clickhouse-docs/blob/main/contribute/style-guide.md#floating-pages), this is **step 1** of the documented two-step flow:

1. **This PR** — add the exception so the upstream docs check passes.
2. **Follow-up** — once #102402 is merged into ClickHouse `master` (so the page syncs into this repo), remove this line and register the page in `sidebars.js`. That step is already staged in #6493, which is blocked on #102402 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)