### PR TITLE
docs: add Tigris page under S3-compatible integrations

### DIFF
--- a/docs/integrations/data-ingestion/s3-tigris.md
+++ b/docs/integrations/data-ingestion/s3-tigris.md
@@ -1,0 +1,64 @@
+---
+sidebar_label: 'Tigris'
+sidebar_position: 7
+slug: /integrations/tigris
+description: 'Page describing how to use Tigris with ClickHouse'
+title: 'Using Tigris'
+doc_type: 'guide'
+integration:
+  - support_level: 'community'
+  - category: 'data_ingestion'
+keywords: ['s3', 'tigris', 'object storage', 'data loading', 'compatible storage']
+---
+
+
+import SelfManaged from '@site/docs/_snippets/_self_managed_only_no_roadmap.md';
+
+<SelfManaged />
+
+ClickHouse's `s3` table function and `S3` disk type are compatible with [Tigris](https://www.tigrisdata.com), an S3-compatible object storage service. Tigris exposes a single global endpoint at `https://t3.storage.dev` with reads served from the region nearest the caller, so a multi-region ClickHouse fleet can point at one bucket URL without per-region replicas or cross-region egress.
+
+The backed merge tree configuration is compatible with minor changes:
+
+```xml
+<clickhouse>
+    <storage_configuration>
+        ...
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>https://your-bucket.t3.storage.dev/tables/</endpoint>
+                <access_key_id>your_access_key_id</access_key_id>
+                <secret_access_key>your_secret_access_key</secret_access_key>
+                <region>auto</region>
+                <metadata_path>/var/lib/clickhouse/disks/s3/</metadata_path>
+            </s3>
+            <s3_cache>
+                <type>cache</type>
+                <disk>s3</disk>
+                <path>/var/lib/clickhouse/disks/s3_cache/</path>
+                <max_size>10Gi</max_size>
+            </s3_cache>
+        </disks>
+        ...
+    </storage_configuration>
+</clickhouse>
+```
+
+:::tip
+Set `<region>auto</region>`. Tigris uses a single global endpoint rather than per-region buckets, but the AWS SigV4 signing flow that ClickHouse uses still requires a region value, and `auto` is the convention.
+:::
+
+The `s3` table function works against the same endpoint:
+
+```sql
+SELECT *
+FROM s3(
+    'https://your-bucket.t3.storage.dev/path/to/file.parquet',
+    'your_access_key_id',
+    'your_secret_access_key',
+    'Parquet'
+);
+```
+
+Access keys can be created from the [Tigris Console](https://console.storage.dev/). Access key IDs are prefixed with `tid_` and secrets with `tsec_`.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1024,6 +1024,7 @@ const sidebars = {
         'integrations/data-sources/cassandra',
         'integrations/data-ingestion/gcs/index',
         'integrations/data-ingestion/s3-minio',
+        'integrations/data-ingestion/s3-tigris',
         'integrations/data-ingestion/emqx/index',
         'integrations/data-ingestion/insert-local-files',
         'integrations/data-ingestion/dbms/jdbc-with-clickhouse',

--- a/styles/ClickHouse/Headings.yml
+++ b/styles/ClickHouse/Headings.yml
@@ -593,6 +593,7 @@ exceptions:
   - Synapse
   - Systemd
   - "TABLUM.IO"
+  - Tigris
   - TimescaleDB
   - Upsonic
   - WebUI


### PR DESCRIPTION
Adds a docs page for [Tigris](https://www.tigrisdata.com) under S3-compatible integrations, plus the sidebar entry.

### Credit

Takes over #6445 by @davidmyriel, whose original commit is preserved here (he's the author of "add tigris data"). Opened from an internal branch because fork PRs can't get Vercel preview deployments or full CI (secrets aren't exposed to forks), and the original had been idle ~11 days.

### What's added on top

- `Tigris` added to the proper-noun exceptions in `styles/ClickHouse/Headings.yml`, clearing the frontmatter sentence-casing check that blocked #6445 (per the guidance left on that PR).

Rebased onto current `main`.

Closes #6445 once this merges (leaving it open until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)