### PR TITLE
docs: point AWS BYOC onboarding Terraform at terraform-byoc-onboarding module

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
@@ -53,18 +53,20 @@ The initial BYOC setup can be performed using a [CloudFormation template (AWS)](
 Storage buckets, VPC/VNet, Kubernetes cluster, and compute resources required for running ClickHouse aren't included in this initial setup. They will be provisioned in the next step.
 :::
 
-#### Alternative Terraform Module for AWS {#terraform-module-aws}
+#### Terraform Module for AWS {#terraform-module-aws}
 
-If you prefer to use Terraform instead of CloudFormation for AWS deployments, we also provide a [Terraform module for AWS](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz).
-
-Usage:
+If you prefer to use Terraform instead of CloudFormation for AWS deployments, use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:
 
 ```hcl
 module "clickhouse_onboarding" {
-  source   = "https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz"
-  byoc_env = "production"
+  source      = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  external_id = "<external-id-provided-by-clickhouse>"
 }
 ```
+
+:::note
+The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
+:::
 
 ### Set up BYOC infrastructure {#setup-byoc-infrastructure}
 
@@ -86,7 +88,7 @@ After your BYOC infrastructure has been provisioned, you're ready to launch your
 
 <Image img={byoc_new_service_1} size="md" alt="BYOC create new service"/>
 
-During service creation, you’ll configure the following options:
+During service creation, you'll configure the following options:
 
 - **Service name**: Enter a clear, descriptive name for your ClickHouse service.
 - **BYOC infrastructure**: Select the BYOC environment, including the cloud account and region, where your service will run.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
@@ -59,10 +59,12 @@ If you prefer to use Terraform instead of CloudFormation for AWS deployments, us
 
 ```hcl
 module "clickhouse_onboarding" {
-  source      = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  source      = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=<version>"
   external_id = "<external-id-provided-by-clickhouse>"
 }
 ```
+
+Replace `<version>` with the latest tag from the module's [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases) — always use the latest release.
 
 :::note
 The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -60,11 +60,13 @@ If you prefer to use Terraform instead of CloudFormation, use the [terraform-byo
 
 ```hcl
 module "clickhouse_onboarding" {
-  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=<version>"
   external_id                   = "<external-id-provided-by-clickhouse>"
   include_vpc_write_permissions = false
 }
 ```
+
+Replace `<version>` with the latest tag from the module's [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases) — always use the latest release.
 
 :::note
 The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -46,7 +46,7 @@ Ensure your VPC has working DNS resolution and doesn't block, interfere with, or
 
 ### Configure your AWS account {#configure-aws-account}
 
-The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml) or a [Terraform module](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz).
+The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml) or a Terraform module (see below).
 
 When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` parameter to `false` to ensure ClickHouse Cloud doesn't receive permissions to modify your customer-managed VPC.
 
@@ -54,17 +54,21 @@ When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` param
 Storage buckets, Kubernetes cluster, and compute resources required for running ClickHouse aren't included in this initial setup. They will be provisioned in a later step. While you control your VPC, ClickHouse Cloud still requires IAM permissions to create and manage the Kubernetes cluster, IAM roles for service accounts, S3 buckets, and other essential resources in your AWS account.
 :::
 
-#### Alternative Terraform module {#terraform-module-aws}
+#### Terraform module {#terraform-module-aws}
 
-If you prefer to use Terraform instead of CloudFormation, use the following module:
+If you prefer to use Terraform instead of CloudFormation, use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:
 
 ```hcl
 module "clickhouse_onboarding" {
-  source                     = "https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz"
-  byoc_env                   = "production"
+  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  external_id                   = "<external-id-provided-by-clickhouse>"
   include_vpc_write_permissions = false
 }
 ```
+
+:::note
+The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
+:::
 
 ### Set up BYOC infrastructure {#set-up-byoc-infrastructure}
 


### PR DESCRIPTION
## Summary

- The AWS BYOC onboarding Terraform module is now published at [`ClickHouse/terraform-byoc-onboarding`](https://github.com/ClickHouse/terraform-byoc-onboarding) under `modules/aws`, released as tag `v1.2.0`.
- Updated `01_standard.md` and `02_customization/01_aws.md` to use the GitHub module as the primary instruction for Terraform-based AWS onboarding.
- Added a deprecation note for the old tarball URL (`https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`), which remains available but is no longer the recommended source.
- The per-infra tarball (`iam_per_infra.tar.gz`) is unaffected — only the management-role/onboarding tarball (`byoc.tar.gz`) has moved.
- Translated (i18n) pages are intentionally untouched — they regenerate from the English source.

## Checklist
- [x] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)