### PR TITLE
Docs: clarify that usage limits are default guardrails and enforced per service

### DIFF
--- a/docs/cloud/guides/best_practices/usagelimits.md
+++ b/docs/cloud/guides/best_practices/usagelimits.md
@@ -37,6 +37,10 @@ or look together at how we can increase them in a controlled manner.
 | **Batch ingest**              | anything > 1M will be split by the system in 1M row blocks                                        |
 
 :::note
+The values above are default guardrails. The limit enforced for a specific service may be higher than the value shown here, as larger services are configured with more headroom. The actual limit that applies to your service is included in the warning you receive as you approach it.
+:::
+
+:::note
 For Single Replica Services, the maximum number of databases is restricted to 
 100, and the maximum number of tables is restricted to 500. In addition, storage
 for Basic Tier Services is limited to 1 TB.


### PR DESCRIPTION
## Summary

The usage-limits table presents values like "Tables: 5000" as flat enforced ceilings, but ClickHouse Cloud configures these guardrails per service, scaled to size — so larger services carry higher limits than the documented baseline, and the number in a customer's warning won't match the table. This adds a short note clarifying that the values are defaults and that the actual enforced limit for a service is the one surfaced in its warning. Prompted by customer confusion where a service's warning cited a much higher table limit than the docs.

## Checklist
- [x] No URL changes
