### PR TITLE
Document warehouse replica guardrails and clean up usage limits

### DIFF
--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -89,7 +89,7 @@ To restrict access to specific services by other applications or ad-hoc users, y
 To do so, navigate to **Settings** in the service tab of the particular service you wish to restrict access to in the ClickHouse Cloud console.
 
 IP filtering settings can be applied to each service separately, which means you can control which application can access which service.
-This allows you to restrict users from using specific services.
+This allows you to restrict access to specific services.
 
 In the example below, Alice is restricted from accessing service 2 in the warehouse:
 
@@ -99,19 +99,19 @@ In the example below, Alice is restricted from accessing service 2 in the wareho
 
 _Fig. 5 - Alice is restricted from accessing service 2 because of network access control settings_
 
-ClickHouse roles and grants can also be applied to control access to the data when users are connecting as an individual rather than the _default_ user. 
+ClickHouse roles and grants can also be applied to control access to the data when you connect as an individual rather than the _default_ user. 
 
 ### Read vs read-write services {#read-vs-read-write}
 
 Services can be one of:
 - **read-write**
   - Can both read and write data to ClickHouse
-  - Performs background merge operations (e.g., merging parts after data inserts), which consume CPU and memory
+  - Performs background merge operations (e.g. merging parts after data inserts), which consume CPU and memory
   - Can export data externally
 - **read-only**
   - Can only read data; it cannot write or modify data in ClickHouse
   - Doesn't perform background merge operations outside of system tables, so its resources are fully dedicated to read queries
-  - Can still export data externally (e.g., via table functions), but cannot change data inside ClickHouse
+  - Can still export data externally (e.g. via table functions), but cannot change data inside ClickHouse
   - Idles without delay, unlike read-write services which may be kept awake by background merges.
 
 Sometimes you want to isolate critical read workloads from write/merge overhead by making a service read only.
@@ -131,13 +131,15 @@ _Fig. 6 - Read-write and Read-only services in a warehouse_
 
 ## Scaling {#scaling}
 
-Each service in a warehouse can be adjusted to your workload in terms of:
-- Number of nodes (replicas). The primary service (the service that was created first in the warehouse) should have 2 or more nodes. Each secondary service can have 1 or more nodes.
-- Size of nodes (replicas)
-- If the service should scale automatically (horizontally and vertically)
-- If the service should be idled on inactivity
+Each service in a warehouse scales independently. You can adjust the number and size of replicas, enable horizontal and vertical autoscaling, and configure auto-idling on inactivity.
 
-For more information, see the ["Autoscaling"](/manage/scaling) page.
+Services, including the primary service, can run with a single replica, but that isn't recommended for production — use at least 2 replicas for high availability.
+
+The combined replica count across all services in a warehouse is capped at 50 by default. See [usage limits](/cloud/bestpractices/usage-limits) for details. Contact [support](https://clickhouse.com/support/program) to raise the limit.
+
+[Scheduled scaling](/cloud/features/autoscaling/scheduled-scaling) works for individual services in a warehouse. Warehouse limits still apply — plan schedules so the combined replica count across all services at peak times stays within the warehouse cap. For more information, see [Automatic scaling](/manage/scaling).
+ 
+
 
 ## Changes in `clusterAllReplicas` behavior {#changes-in-behavior}
 
@@ -151,10 +153,6 @@ To query across all services in the warehouse, use the `all_groups.default` clus
 SELECT * FROM clusterAllReplicas('all_groups.default', system, processes)
 ```
 
-:::note
-Secondary single-node services can scale vertically, while primary single-node services cannot.
-:::
-
 ## Limitations {#limitations}
 
 ### Workload isolation limitations {#workload-isolation-limitations}
@@ -162,7 +160,7 @@ Secondary single-node services can scale vertically, while primary single-node s
 Some workloads can't be isolated to specific services; there are edge cases where one workload in one service will affect another service in the warehouse. These include:
 
 -  **All read-write services handle background merge operations by default.** When inserting data to ClickHouse, the database at first inserts the data to some staging partitions, and then performs merges in the background. These merges can consume memory and CPU resources. When two read-write services share the same storage, they both are performing background operations. That means that there can be a situation where there is an `INSERT` query in Service 1, but the merge operation is completed by Service 2. 
-Note that read-only services don't execute background merges, thus they don't spend their resources on this operation. Our support has the ability to turn off merges on a service.
+Note that read-only services don't execute background merges, thus they don't spend their resources on this operation. Contact [support](https://clickhouse.com/support/program) to turn off merges on a service.
 
 - **All read-write services are performing S3Queue table engine insert operations.** When creating a S3Queue table on a read/write service, all other read/write services on the warehouse may perform reading data from S3 and writing data to the database.
 
@@ -184,8 +182,6 @@ SETTINGS distributed_ddl_task_timeout=0
 
 If you manually stop a service, you will need to start it up again in order for queries to be executed. 
 
-- **One replica Primary Service** Today, the default behavior is the secondary services can have one replica, the primary service must have at least 2.
-  To enable single replica primary services, please contact support. This behavior will be enabled by default in Q2 2026.
 - **Primary service idling**: primary service auto-idling is enabled by default.
 
 ## Pricing {#pricing}

--- a/docs/cloud/features/05_infrastructure/warehouses.md
+++ b/docs/cloud/features/05_infrastructure/warehouses.md
@@ -133,13 +133,11 @@ _Fig. 6 - Read-write and Read-only services in a warehouse_
 
 Each service in a warehouse scales independently. You can adjust the number and size of replicas, enable horizontal and vertical autoscaling, and configure auto-idling on inactivity.
 
-Services, including the primary service, can run with a single replica, but that isn't recommended for production — use at least 2 replicas for high availability.
+Services, including the primary service, can run with a single replica, but that isn't recommended for production — use at least 2 replicas for high availability. Secondary single-node services can scale vertically, while primary single-node services cannot.
 
 The combined replica count across all services in a warehouse is capped at 50 by default. See [usage limits](/cloud/bestpractices/usage-limits) for details. Contact [support](https://clickhouse.com/support/program) to raise the limit.
 
 [Scheduled scaling](/cloud/features/autoscaling/scheduled-scaling) works for individual services in a warehouse. Warehouse limits still apply — plan schedules so the combined replica count across all services at peak times stays within the warehouse cap. For more information, see [Automatic scaling](/manage/scaling).
- 
-
 
 ## Changes in `clusterAllReplicas` behavior {#changes-in-behavior}
 
@@ -160,7 +158,7 @@ SELECT * FROM clusterAllReplicas('all_groups.default', system, processes)
 Some workloads can't be isolated to specific services; there are edge cases where one workload in one service will affect another service in the warehouse. These include:
 
 -  **All read-write services handle background merge operations by default.** When inserting data to ClickHouse, the database at first inserts the data to some staging partitions, and then performs merges in the background. These merges can consume memory and CPU resources. When two read-write services share the same storage, they both are performing background operations. That means that there can be a situation where there is an `INSERT` query in Service 1, but the merge operation is completed by Service 2. 
-Note that read-only services don't execute background merges, thus they don't spend their resources on this operation. Contact [support](https://clickhouse.com/support/program) to turn off merges on a service.
+Note that read-only services don't execute background merges. Contact [support](https://clickhouse.com/support/program) to turn off merges on a read/write service.
 
 - **All read-write services are performing S3Queue table engine insert operations.** When creating a S3Queue table on a read/write service, all other read/write services on the warehouse may perform reading data from S3 and writing data to the database.
 

--- a/docs/cloud/guides/best_practices/usagelimits.md
+++ b/docs/cloud/guides/best_practices/usagelimits.md
@@ -15,26 +15,29 @@ The details of these guardrails are listed below.
 
 :::tip
 If you've run up against one of these guardrails, it's possible that you're 
-implementing your use case in an unoptimized way. Contact our support team and 
+implementing your use case in an unoptimized way. Contact [support](https://clickhouse.com/support/program) and 
 we will gladly help you refine your use case to avoid exceeding the guardrails 
 or look together at how we can increase them in a controlled manner. 
 :::
 
-| Dimension                     | Limit                                                                                             |
-|-------------------------------|---------------------------------------------------------------------------------------------------|
-| **Databases**                 | 1000                                                                                              |
-| **Tables**                    | 5000                                                                                              |
-| **Columns**                   | ∼1000 (wide format is preferred to compact)                                                       |
-| **Partitions**                | 50k                                                                                               |
-| **Parts**                     | 10k (see [`max_parts_in_total`](/whats-new/cloud-compatibility#max_parts_in_total-10000) setting) |
-| **Part size**                 | 150gb                                                                                             |
-| **Services per organization** | 20 (soft)                                                                                         |
-| **Services per warehouse**    | 5 (soft)                                                                                          |
-| **Replicas per service**      | 20 (soft)                                                                                         |  
-| **Low cardinality**           | 10k or less                                                                                       |
-| **Primary keys in a table**   | 4-5 that sufficiently filter down the data                                                        |
-| **Query concurrency**         | 1000 (per replica)                                                                                |
-| **Batch ingest**              | anything > 1M will be split by the system in 1M row blocks                                        |
+| Dimension | Limit |
+| --- | --- |
+| **Databases** | 1000 |
+| **Tables** | 5000 |
+| **Columns** | ~1000 (wide format is preferred to compact) |
+| **Partitions** | 50k |
+| **Parts** | 10k (see [`max_parts_in_total`](/whats-new/cloud-compatibility#max_parts_in_total-10000)) |
+| **Part size** | 150 GB |
+| **Services per organization** | 20 (soft) |
+| **Services per warehouse** | 5 (soft) |
+| **Replicas per service** | 20 (soft) |
+| **Replicas per warehouse** | 50 (soft) |
+| **Low cardinality** | 10k or less |
+| **Primary keys in a table** | 4–5 that sufficiently filter down the data |
+| **Query concurrency** | 1000 (per replica) |
+| **Batch ingest** | Anything > 1M rows is split into 1M-row blocks |
+
+For warehouse replica and scaling limits, see [warehouses](/cloud/reference/warehouses#scaling).
 
 :::note
 For Single Replica Services, the maximum number of databases is restricted to 

--- a/docs/cloud/guides/best_practices/usagelimits.md
+++ b/docs/cloud/guides/best_practices/usagelimits.md
@@ -29,7 +29,6 @@ or look together at how we can increase them in a controlled manner.
 | **Parts** | 10k (see [`max_parts_in_total`](/whats-new/cloud-compatibility#max_parts_in_total-10000)) |
 | **Part size** | 150 GB |
 | **Services per organization** | 20 (soft) |
-| **Services per warehouse** | 5 (soft) |
 | **Replicas per service** | 20 (soft) |
 | **Replicas per warehouse** | 50 (soft) |
 | **Low cardinality** | 10k or less |


### PR DESCRIPTION
## Summary
- Consolidate warehouse replica and scaling rules into the Scaling section on the warehouses page, including single-replica guidance, the 50-replica warehouse cap, and scheduled scaling limits
- Add a Replicas per warehouse row to usage limits and clean up the limits table formatting
- Remove duplicated replica callouts, fix support links, and apply minor voice/style fixes

## Test plan
- [ ] Preview warehouses page and verify Scaling section reads clearly
- [ ] Preview usage limits page and confirm table renders correctly
- [ ] Verify cross-links between warehouses and usage limits work


Made with [Cursor](https://cursor.com)