### PR TITLE
docs: document BYO-IAM workflow with the per-infra IAM Terraform module

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -90,19 +90,58 @@ New region setup can take up to 40 minutes.
 
 </VerticalStepper>
 
-## Customer-managed IAM roles {#customer-managed-iam-roles}
+## Customer-managed IAM roles (BYO-IAM) {#customer-managed-iam-roles}
 
 For organizations with advanced security requirements or strict compliance policies, you can provide your own IAM roles instead of having ClickHouse Cloud create them. This approach gives you complete control over IAM permissions and allows you to enforce your organization's security policies.
 
 :::info
-Customer-managed IAM roles are in private preview. If you require this capability, contact ClickHouse Support to discuss your specific requirements and timeline.
+Customer-managed IAM roles are in private preview. Contact ClickHouse Support to enable this capability for your organization before following the steps below.
+:::
 
-When available, this feature will allow you to:
+With customer-managed IAM roles, you:
 
-- Provide pre-configured IAM roles for ClickHouse Cloud to use
-- Remove write permissions to IAM related permissions for `ClickHouseManagementRole` used for cross-account access
+- Pre-create the per-infrastructure IAM roles that ClickHouse Cloud would otherwise create
+- Remove IAM write permissions from the `ClickHouseManagementRole` used for cross-account access
 - Maintain full control over role permissions and trust relationships
 
+<VerticalStepper headerLevel="h3">
+
+### Configure the management role without IAM write permissions {#byo-iam-management-role}
+
+When performing the [initial BYOC setup](/cloud/reference/byoc/onboarding/standard), disable IAM write permissions on the management role. With the CloudFormation template, set the `IncludeIAMWritePermissions` parameter to `false`. With the Terraform module:
+
+```hcl
+module "clickhouse_onboarding" {
+  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=<version>"
+  external_id                   = "<external-id-provided-by-clickhouse>"
+  include_iam_write_permissions = false
+}
+```
+
+Replace `<version>` with the latest tag from the module's [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases) — always use the latest release.
+
+### Create the per-infrastructure IAM roles {#byo-iam-per-infra-roles}
+
+Before each BYOC infrastructure is provisioned, create its required IAM roles (EKS pod identity roles, the ClickHouse S3 access role, and the data-plane management role) with the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) per-infra module:
+
+```hcl
+module "clickhouse_per_infra_iam" {
+  source = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws-per-infra-iam?ref=<version>"
+
+  spoken_name = "<spoken-name-provided-by-clickhouse>"
+  region      = "<aws-region-of-the-infrastructure>"
+  external_id = "<external-id-provided-by-clickhouse>"
+}
+```
+
+Replace `<version>` with the latest tag from the module's [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases) — always use the latest release.
+
+### Keep the per-infrastructure roles up to date {#byo-iam-keep-up-to-date}
+
+:::important
+ClickHouse periodically adds roles and permissions required by new platform capabilities. When ClickHouse notifies you of an update, re-apply the per-infra module at the latest release — running an outdated version can cause provisioning and upgrades of your BYOC infrastructure to fail.
 :::
+
+</VerticalStepper>
 
 For information about the IAM roles that ClickHouse Cloud creates by default, see the [BYOC Privilege Reference](/cloud/reference/byoc/reference/privilege).

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -90,7 +90,7 @@ New region setup can take up to 40 minutes.
 
 </VerticalStepper>
 
-## Customer-managed IAM roles (BYO-IAM) {#customer-managed-iam-roles}
+## Customer-managed IAM roles {#customer-managed-iam-roles}
 
 For organizations with advanced security requirements or strict compliance policies, you can provide your own IAM roles instead of having ClickHouse Cloud create them. This approach gives you complete control over IAM permissions and allows you to enforce your organization's security policies.
 


### PR DESCRIPTION
### What
- Expands the "Customer-managed IAM roles" section on the AWS customization page from a contact-support stub into the concrete workflow, now that the per-infra IAM module is published:
  - management role with `include_iam_write_permissions = false` (Terraform) / `IncludeIAMWritePermissions=false` (CloudFormation)
  - per-infrastructure roles via `terraform-byoc-onboarding//modules/aws-per-infra-iam` (version placeholder, always-latest instruction)
  - an important-callout on re-applying the module when ClickHouse updates role definitions (outdated roles cause provisioning/upgrade failures)
- Keeps the private-preview admonition and the existing `{#customer-managed-iam-roles}` anchor.
- Translated pages intentionally untouched (regenerate from English).

### Why
- BYO-IAM customers previously had no public documentation for this flow; the per-infra module is now published with auto-releases, so the docs can be self-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)