### PR TITLE
Remove oom-canary from floating-pages exceptions

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -22,4 +22,3 @@ use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-
 use-cases/observability/clickstack/managed-onboarding/instrument-application.md
 use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
 use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
-operations/settings/oom-canary


### PR DESCRIPTION
Follow-up cleanup. Now that `operations/settings/oom-canary` is listed in the Settings sidebar (added in #6390), the floating-pages exception added in #6506 is redundant. The page is still covered by the floating-pages check via its sidebar entry, so removing the exception is safe.

Sequenced intentionally after #6390 merged — removing the exception before the sidebar entry landed would have flagged the page as floating and broken the docs build.

Related: #6390, #6506
