### PR TITLE
DOC-892: guide template POC + convert the IdP/SSO family

### DIFF
--- a/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
@@ -5,6 +5,7 @@ title: 'SAML SSO setup'
 description: 'How to set up SAML SSO with ClickHouse Cloud'
 doc_type: 'guide'
 keywords: ['ClickHouse Cloud', 'SAML', 'SSO', 'single sign-on', 'IdP', 'Okta', 'Google']
+toc_max_heading_level: 2
 ---
 
 import Image from '@theme/IdealImage';
@@ -17,6 +18,8 @@ import samlGoogleApp from '@site/static/images/cloud/security/saml-google-app.pn
 import samlAzureApp from '@site/static/images/cloud/security/saml-azure-app.png';
 import samlAzureClaims from '@site/static/images/cloud/security/saml-azure-claims.png';
 import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge'
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 <EnterprisePlanFeatureBadge feature="SAML SSO"/>
 
@@ -28,7 +31,24 @@ Customers enabling SAML integrations can also designate the default role that wi
 
 ## Before you begin {#before-you-begin}
 
-You will need Admin permissions in your IdP, the ability to add a TXT record to the DNS settings for your domain, the **Admin** role in your ClickHouse Cloud organization. We recommend setting up a **direct link to your organization** in addition to your SAML connection to simplify the login process. Each IdP handles this differently. Read on for how to do this for your IdP.
+You will need:
+
+- **Admin** permissions in your IdP.
+- The ability to add a TXT record to the DNS settings for your domain.
+- The **Admin** role in your ClickHouse Cloud organization.
+
+We recommend setting up a **direct link to your organization** in addition to your SAML connection to simplify the login process. Each IdP handles this differently — read on for how to do it for yours.
+
+## How it works {#how-it-works}
+
+Once SAML SSO is configured, users sign in through a service-provider-initiated flow:
+
+1. The user goes to `https://console.clickhouse.cloud` and enters their email address (or uses your organization's direct link).
+2. ClickHouse Cloud redirects them to your identity provider to authenticate.
+3. On success, the identity provider redirects them back to ClickHouse Cloud.
+4. ClickHouse Cloud signs them in, provisioning the account just-in-time on first login and assigning your configured default role.
+
+The rest of this guide covers the one-time configuration.
 
 ## How to configure your IdP {#how-to-configure-your-idp}
 
@@ -36,7 +56,7 @@ You will need Admin permissions in your IdP, the ability to add a TXT record to 
 
 <VerticalStepper headerLevel="h3">
 
-### Access Organization settings {#access-organization-settings}
+### Access organization settings {#access-organization-settings}
 
 Click on your organization name in the lower left corner and select Organization details.
 
@@ -50,10 +70,10 @@ Click the toggle next to `Enable SAML single sign-on`. Leave this screen open as
 
 Create an application within your identity provider and copy the values on the `Enable SAML single sign-on` screen to your identity provider configuration. For more information on this step, refer to your specific identity provider below.
 
-- [Configure Okta SAML](#configure-okta-saml)
-- [Configure Google SAML](#configure-google-saml)
-- [Configure Azure (Microsoft) SAML](#configure-azure-microsoft-saml)
-- [Configure Duo SAML](#configure-duo-saml)
+- [Okta](?idp=okta#configure-idp)
+- [Google](?idp=google#configure-idp)
+- [Azure (Microsoft)](?idp=azure#configure-idp)
+- [Duo](?idp=duo#configure-idp)
 
 :::tip
 ClickHouse doesn't support identity provider initiated sign-in. To make it easy for your users to access ClickHouse Cloud, set up a bookmark for your users using this sign-in URL format: `https://console.clickhouse.cloud/?connection={orgId}` where the `{orgID}` is your organization ID on the Organization details page.
@@ -65,13 +85,13 @@ ClickHouse doesn't support identity provider initiated sign-in. To make it easy 
 
 Obtain the `Metadata URL` from your SAML provider. Return to ClickHouse Cloud, click `Next: Provide metadata URL` and paste the URL in the text box.
 
-   <Image img={samlSelfServe3} size="lg" alt="Add metadata URL" force/> 
+   <Image img={samlSelfServe3} size="lg" alt="Add metadata URL" force/>
 
 ### Get domain verification code {#get-domain-verification-code}
 
-Click `Next: Verify your domains`. Enter your domain in the text box and click `Check domain`. The system will generate a random verification code for you to add to a TXT record with your DNS provider. 
+Click `Next: Verify your domains`. Enter your domain in the text box and click `Check domain`. The system will generate a random verification code for you to add to a TXT record with your DNS provider.
 
-   <Image img={samlSelfServe4} size="lg" alt="Add domain to verify" force/> 
+   <Image img={samlSelfServe4} size="lg" alt="Add domain to verify" force/>
 
 ### Verify your domain {#verify-your-domain}
 
@@ -81,7 +101,7 @@ Create a TXT record with your DNS provider. Copy the `TXT record name` to the TX
 It may take several minutes for the DNS record to update and be verified. You may leave the setup page and return later to complete the process without restarting. The verification value is valid for 48 hours from when it is first generated.
 :::
 
-   <Image img={samlSelfServe5} size="lg" alt="Verify your domain" force/> 
+   <Image img={samlSelfServe5} size="lg" alt="Verify your domain" force/>
 
 ### Update default role and session timeout {#update-defaults}
 
@@ -90,22 +110,22 @@ Once the SAML setup is complete, you can set the default role(s) all users will 
 ### Configure your admin user {#configure-your-admin-user}
 
 :::note
-Users configured with a different authentication method will be retained until an admin in your organization removes them. 
+Users configured with a different authentication method will be retained until an admin in your organization removes them.
 :::
 
 To assign your first admin user via SAML:
+
 1. Log out of [ClickHouse Cloud](https://console.clickhouse.cloud).
 2. In your identity provider, assign the admin user to the ClickHouse applications.
 3. Ask the user to log in via https://console.clickhouse.cloud/?connection={orgId} (shortcut URL). This may be via a bookmark you created in the prior steps. The user won't appear in ClickHouse Cloud until their first login.
-4. If the default SAML role is anything other than Admin, the user may need to log out and log back in with their original authentication method to update the new SAML user's role. 
+4. If the default SAML role is anything other than Admin, the user may need to log out and log back in with their original authentication method to update the new SAML user's role.
    - For email + password accounts, please use `https://console.clickhouse.cloud/?with=email`.
    - For social logins, please click the appropriate button (**Continue with Google** or **Continue with Microsoft**)
+5. Log out one more time and log back in via the shortcut URL to complete the last step below.
 
 :::note
 `email` in `?with=email` above is the literal parameter value, not a placeholder
 :::
-
-5. Log out one more time and log back in via the shortcut URL to complete the last step below.
 
 :::tip
 To reduce steps, you may set your SAML default role to `Admin` initially. When the admin is assigned in your identity provider and logs in for the first time, they can change the default role to a different value.
@@ -117,243 +137,229 @@ Remove any users that are using a non-SAML method to complete the integration an
 
 </VerticalStepper>
 
-### Configure Okta SAML {#configure-okta-saml}
+### Configure your identity provider {#configure-idp}
+
+<Tabs queryString="idp">
+<TabItem value="okta" label="Okta">
 
 You will configure two App Integrations in Okta for each ClickHouse organization: one SAML app and one bookmark to house your direct link.
 
-<details>
-   <summary>  1. Create a group to manage access  </summary>
-   
-   1. Log in to your Okta instance as an **Administrator**.
+#### Create a group to manage access {#okta-create-group}
 
-   2. Select **Groups** on the left.
+1. Log in to your Okta instance as an **Administrator**.
+2. Select **Groups** on the left.
+3. Click **Add group**.
+4. Enter a name and description for the group. This group will be used to keep users consistent between the SAML app and its related bookmark app.
+5. Click **Save**.
+6. Click the name of the group that you created.
+7. Click **Assign people** to assign users you would like to have access to this ClickHouse organization.
 
-   3. Click **Add group**.
+#### Create a bookmark app so users can log in seamlessly {#okta-bookmark-app}
 
-   4. Enter a name and description for the group. This group will be used to keep users consistent between the SAML app and its related bookmark app.
+1. Select **Applications** on the left, then select the **Applications** subheading.
+2. Click **Browse App Catalog**.
+3. Search for and select **Bookmark App**.
+4. Click **Add integration**.
+5. Select a label for the app.
+6. Enter the URL as `https://console.clickhouse.cloud/?connection={organizationid}`.
+7. Go to the **Assignments** tab and add the group you created above.
 
-   5. Click **Save**.
+#### Create a SAML app to enable the connection {#okta-saml-app}
 
-   6. Click the name of the group that you created.
+1. Select **Applications** on the left, then select the **Applications** subheading.
+2. Click **Create App Integration**.
+3. Select SAML 2.0 and click Next.
+4. Enter a name for your application and check the box next to **Don't display application icon to users**, then click **Next**.
+5. Use the following values to populate the SAML settings screen.
 
-   7. Click **Assign people** to assign users you would like to have access to this ClickHouse organization.
+   | Field                          | Value |
+   |--------------------------------|-------|
+   | Single Sign On URL             | Copy the Single Sign-On URL from the console |
+   | Audience URI (SP Entity ID)    | Copy the Service Provider Entity ID from the console |
+   | Default RelayState             | Leave blank       |
+   | Name ID format                 | Unspecified       |
+   | Application username           | Email             |
+   | Update application username on | Create and update |
 
-</details>
+6. Enter the following Attribute Statement.
 
-<details>
-   <summary>  2. Create a bookmark app to enable users to seamlessly log in  </summary>
-   
-   1. Select **Applications** on the left, then select the **Applications** subheading.
-   
-   2. Click **Browse App Catalog**.
-   
-   3. Search for and select **Bookmark App**.
-   
-   4. Click **Add integration**.
-   
-   5. Select a label for the app.
-   
-   6. Enter the URL as `https://console.clickhouse.cloud/?connection={organizationid}`
-   
-   7. Go to the **Assignments** tab and add the group you created above.
-   
-</details>
+   | Name    | Name format   | Value      |
+   |---------|---------------|------------|
+   | email   | Basic         | user.email |
 
-<details>
-   <summary>  3. Create a SAML app to enable the connection  </summary>
-   
-   1. Select **Applications** on the left, then select the **Applications** subheading.
-   
-   2. Click **Create App Integration**.
-   
-   3. Select SAML 2.0 and click Next.
-   
-   4. Enter a name for your application and check the box next to **Don't display application icon to users** then click **Next**. 
-   
-   5. Use the following values to populate the SAML settings screen.
-   
-      | Field                          | Value |
-      |--------------------------------|-------|
-      | Single Sign On URL             | Copy the Single Sign-On URL from the console |
-      | Audience URI (SP Entity ID)    | Copy the Service Provider Entity ID from the console |
-      | Default RelayState             | Leave blank       |
-      | Name ID format                 | Unspecified       |
-      | Application username           | Email             |
-      | Update application username on | Create and update |
-   
-   7. Enter the following Attribute Statement.
+7. Click **Next**.
+8. Enter the requested information on the Feedback screen and click **Finish**.
+9. Go to the **Assignments** tab and add the group you created above.
+10. On the **Sign On** tab for your new app, click the **Copy metadata URL** button.
+11. Return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
 
-      | Name    | Name format   | Value      |
-      |---------|---------------|------------|
-      | email   | Basic         | user.email |
-   
-   9. Click **Next**.
-   
-   10. Enter the requested information on the Feedback screen and click **Finish**.
-   
-   11. Go to the **Assignments** tab and add the group you created above.
-   
-   12. On the **Sign On** tab for your new app, click the **Copy metadata URL** button. 
-   
-   13. Return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
-   
-</details>
-
-### Configure Google SAML {#configure-google-saml}
+</TabItem>
+<TabItem value="google" label="Google">
 
 You will configure one SAML app in Google for each organization and must provide your users the direct link (`https://console.clickhouse.cloud/?connection={organizationId}`) to bookmark if using multi-org SSO.
 
-<details>
-   <summary>  Create a Google Web App  </summary>
-   
-   1. Go to your Google Admin console (admin.google.com).
+1. Go to your Google Admin console (admin.google.com).
 
    <Image img={samlGoogleApp} size="md" alt="Google SAML App" force/>
 
-   2. Click **Apps**, then **Web and mobile apps** on the left.
-   
-   3. Click **Add app** from the top menu, then select **Add custom SAML app**.
-   
-   4. Enter a name for the app and click **Continue**.
-   
-   5. Copy the metadata URL and save it somewhere.
-   
-   7. Enter the ACS URL and Entity ID below.
-   
-      | Field     | Value |
-      |-----------|-------|
-      | ACS URL   | Copy the Single Sign-On URL from the console |
-      | Entity ID | Copy the Service Provider Entity ID from the console |
-   
-   8. Check the box for **Signed response**.
-   
-   9. Select **EMAIL** for the Name ID Format and leave the Name ID as **Basic Information > Primary email.**
-   
-   10. Click **Continue**.
-   
-   11. Enter the following Attribute mapping:
-       
-      | Field             | Value         |
-      |-------------------|---------------|
-      | Basic information | Primary email |
-      | App attributes    | email         |
-       
-   13. Click **Finish**.
-   
-   14. To enable the app click **OFF** for everyone and change the setting to **ON** for everyone. Access can also be limited to groups or organizational units by selecting options on the left side of the screen.
+2. Click **Apps**, then **Web and mobile apps** on the left.
+3. Click **Add app** from the top menu, then select **Add custom SAML app**.
+4. Enter a name for the app and click **Continue**.
+5. Copy the metadata URL and save it somewhere.
+6. Enter the ACS URL and Entity ID below.
 
-   15. Return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
-       
+   | Field     | Value |
+   |-----------|-------|
+   | ACS URL   | Copy the Single Sign-On URL from the console |
+   | Entity ID | Copy the Service Provider Entity ID from the console |
+
+7. Check the box for **Signed response**.
+8. Select **EMAIL** for the Name ID Format and leave the Name ID as **Basic Information > Primary email.**
+9. Click **Continue**.
+10. Enter the following Attribute mapping:
+
+    | Field             | Value         |
+    |-------------------|---------------|
+    | Basic information | Primary email |
+    | App attributes    | email         |
+
+11. Click **Finish**.
+12. To enable the app click **OFF** for everyone and change the setting to **ON** for everyone. Access can also be limited to groups or organizational units by selecting options on the left side of the screen.
+13. Return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
+
+</TabItem>
+<TabItem value="azure" label="Azure (Microsoft)">
+
+Azure (Microsoft) SAML may also be referred to as Azure Active Directory (AD) or Microsoft Entra. You will set up one application integration with a separate sign-on URL for each organization.
+
+1. Log on to the Microsoft Entra admin center.
+2. Navigate to **Applications > Enterprise applications** on the left.
+3. Click **New application** on the top menu.
+4. Click **Create your own application** on the top menu.
+5. Enter a name and select **Integrate any other application you don't find in the gallery (Non-gallery)**, then click **Create**.
+
+   <Image img={samlAzureApp} size="md" alt="Azure Non-Gallery App" force/>
+
+6. Click **Users and groups** on the left and assign users.
+7. Click **Single sign-on** on the left.
+8. Click **SAML**.
+9. Use the following settings to populate the Basic SAML Configuration screen.
+
+   | Field                     | Value |
+   |---------------------------|-------|
+   | Identifier (Entity ID)    | Copy the Service Provider Entity ID from the console |
+   | Reply URL (Assertion Consumer Service URL) | Copy the Single Sign-On URL from the console |
+   | Sign on URL               | `https://console.clickhouse.cloud/?connection={organizationid}` |
+   | Relay State               | Blank |
+   | Logout URL                | Blank |
+
+10. Add (A) or update (U) the following under Attributes & Claims:
+
+    | Claim name                           | Format        | Source attribute |
+    |--------------------------------------|---------------|------------------|
+    | (U) Unique User Identifier (Name ID) | Email address | user.mail        |
+    | (A) email                            | Basic         | user.mail        |
+    | (U) /identity/claims/name            | Omitted       | user.mail        |
+
+    <Image img={samlAzureClaims} size="md" alt="Attributes and Claims" force/>
+
+11. Copy the metadata URL and return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
+
+</TabItem>
+<TabItem value="duo" label="Duo">
+
+1. Follow the instructions for [Duo Single Sign-On for Generic SAML Service Providers](https://duo.com/docs/sso-generic).
+2. Use the following Bridge Attribute mapping:
+
+   |  Bridge Attribute  |  ClickHouse Attribute  |
+   |:-------------------|:-----------------------|
+   | Email Address      | email                  |
+
+3. Use the following values to update your Cloud Application in Duo:
+
+   |  Field    |  Value                                     |
+   |:----------|:-------------------------------------------|
+   | Entity ID | Copy the Service Provider Entity ID from the console |
+   | Assertion Consumer Service (ACS) URL | Copy the Single Sign-On URL from the console |
+   | Service Provider Login URL |  `https://console.clickhouse.cloud/?connection={organizationid}` |
+
+4. Copy the metadata URL and return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
+
+</TabItem>
+</Tabs>
+
+## Troubleshooting {#troubleshooting}
+
+<details id="misconfiguration-or-outage">
+<summary>"There could be a misconfiguration in the system or a service outage"</summary>
+
+**Cause:** identity-provider-initiated login, which isn't supported.
+
+**Fix:** use the direct link `https://console.clickhouse.cloud/?connection={organizationid}`. Follow the instructions for your identity provider above to make this the default login method for your users.
+
 </details>
 
-### Configure Azure (Microsoft) SAML {#configure-azure-microsoft-saml}
+<details id="redirected-back-to-login">
+<summary>You're directed to your identity provider, then back to the login page</summary>
 
-Azure (Microsoft) SAML may also be referred to as Azure Active Directory (AD) or Microsoft Entra.
+**Cause:** the identity provider doesn't have the email attribute mapping.
 
-<details>
-   <summary>  Create an Azure Enterprise Application </summary>
-   
-   You will set up one application integration with a separate sign-on URL for each organization.
-   
-   1. Log on to the Microsoft Entra admin center.
-   
-   2. Navigate to **Applications > Enterprise** applications on the left.
-   
-   3. Click **New application** on the top menu.
-   
-   4. Click **Create your own application** on the top menu.
-   
-   5. Enter a name and select **Integrate any other application you don't find in the gallery (Non-gallery)**, then click **Create**.
-   
-      <Image img={samlAzureApp} size="md" alt="Azure Non-Gallery App" force/>
-   
-   6. Click **Users and groups** on the left and assign users.
-   
-   7. Click **Single sign-on** on the left.
-   
-   8. Click **SAML**.
-   
-   9. Use the following settings to populate the Basic SAML Configuration screen.
-   
-      | Field                     | Value |
-      |---------------------------|-------|
-      | Identifier (Entity ID)    | Copy the Service Provider Entity ID from the console |
-      | Reply URL (Assertion Consumer Service URL) | Copy the Single Sign-On URL from the console |
-      | Sign on URL               | `https://console.clickhouse.cloud/?connection={organizationid}` |
-      | Relay State               | Blank |
-      | Logout URL                | Blank |
-   
-   11. Add (A) or update (U) the following under Attributes & Claims:
-   
-       | Claim name                           | Format        | Source attribute |
-       |--------------------------------------|---------------|------------------|
-       | (U) Unique User Identifier (Name ID) | Email address | user.mail        |
-       | (A) email                            | Basic         | user.mail        |
-       | (U) /identity/claims/name            | Omitted       | user.mail        |
-   
-         <Image img={samlAzureClaims} size="md" alt="Attributes and Claims" force/>
-   
-   12. Copy the metadata URL and return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
+**Fix:** follow the instructions for your identity provider above to configure the user email attribute, then log in again.
 
 </details>
 
-### Configure Duo SAML {#configure-duo-saml}
+<details id="user-not-assigned">
+<summary>"User isn't assigned to this application"</summary>
 
-<details>
-   <summary> Create a Generic SAML Service Provider for Duo </summary>
-   
-   1. Follow the instructions for [Duo Single Sign-On for Generic SAML Service Providers](https://duo.com/docs/sso-generic). 
-   
-   2. Use the following Bridge Attribute mapping:
+**Cause:** the user hasn't been assigned to the ClickHouse application in the identity provider.
 
-      |  Bridge Attribute  |  ClickHouse Attribute  | 
-      |:-------------------|:-----------------------|
-      | Email Address      | email                  |
-   
-   3. Use the following values to update your Cloud Application in Duo:
+**Fix:** assign the user to the application in the identity provider and log in again.
 
-      |  Field    |  Value                                     |
-      |:----------|:-------------------------------------------|
-      | Entity ID | Copy the Service Provider Entity ID from the console |
-      | Assertion Consumer Service (ACS) URL | Copy the Single Sign-On URL from the console |
-      | Service Provider Login URL |  `https://console.clickhouse.cloud/?connection={organizationid}` |
-
-   4. Copy the metadata URL and return to [Add the metadata URL to your SAML configuration](#add-metadata-url) to continue the process.
-   
 </details>
 
-## How it works {#how-it-works}
+<details id="always-same-org">
+<summary>With multiple SAML organizations, you always land in the same one</summary>
 
-### User management with SAML SSO {#user-management-with-saml-sso}
+**Cause:** you're still logged in to the first organization.
 
-For more information on managing user permissions and restricting access to only SAML connections, refer to [Manage cloud users](/cloud/security/manage-cloud-users).
+**Fix:** log out, then log in to the other organization.
 
-### Service provider-initiated SSO {#service-provider-initiated-sso}
+</details>
 
-We only utilize service provider-initiated SSO. This means users go to `https://console.clickhouse.cloud` and enter their email address to be redirected to the IdP for authentication. Users already authenticated via your IdP can use the direct link to automatically log in to your organization without entering their email address at the login page.
+<details id="access-denied-flash">
+<summary>The URL briefly shows `access denied`</summary>
 
-### Multi-org SSO {#multi-org-sso}
+**Cause:** your email domain doesn't match the domain configured.
 
-ClickHouse Cloud supports multi-organization SSO by providing a separate connection for each organization. Use the direct link (`https://console.clickhouse.cloud/?connection={organizationid}`) to log in to each respective organization. Be sure to log out of one organization before logging into another.
+**Fix:** reach out to support for assistance resolving this error.
 
-:::note
-If you do not want users with your company's domain to be directed to an organization when they enter an email address at https://console.clickhouse.cloud, submit a support ticket to manually update your SSO settings to remove this behavior.
-:::
+</details>
 
-## Additional information {#additional-information}
+## Frequently asked questions {#faq}
 
-Security is our top priority when it comes to authentication. For this reason, we made a few decisions when implementing SSO that we need you to know.
+<details id="faq-idp-initiated">
+<summary>Does ClickHouse Cloud support identity-provider-initiated sign-in?</summary>
 
-- **We only process service provider-initiated authentication flows.** Users must navigate to `https://console.clickhouse.cloud` and enter an email address to be redirected to your identity provider. Instructions to add a bookmark application or shortcut are provided for your convenience so your users don't need to remember the URL.
+No — only service-provider-initiated flows. Users navigate to `https://console.clickhouse.cloud` and enter their email to be redirected to your identity provider. Set up a bookmark or direct link (`https://console.clickhouse.cloud/?connection={organizationid}`) so users don't have to remember the URL.
 
-- **We don't automatically link SSO and non-SSO accounts.** You may see multiple accounts for your users in your ClickHouse user list even if they're using the same email address.
+</details>
 
-## Troubleshooting Common Issues {#troubleshooting-common-issues}
+<details id="faq-multi-org">
+<summary>How do I use SAML SSO with multiple organizations?</summary>
 
-| Error | Cause | Solution | 
-|:------|:------|:---------|
-| There could be a misconfiguration in the system or a service outage | Identity provider initiated login | To resolve this error try using the direct link `https://console.clickhouse.cloud/?connection={organizationid}`. Follow the instructions for your identity provider above to make this the default login method for your users | 
-| You're directed to your identity provider, then back to the login page | The identity provider doesn't have the email attribute mapping |  Follow the instructions for your identity provider above to configure the user email attribute and log in again | 
-| User isn't assigned to this application | The user hasn't been assigned to the ClickHouse application in the identity provider | Assign the user to the application in the identity provider and log in again |
-| You have multiple ClickHouse organizations integrated with SAML SSO and you're always logged into the same organization, regardless of which link or tile you use | You're still logged in to the first organization | Log out, then log in to the other organization |
-| The URL briefly shows `access denied` | Your email domain doesn't match the domain we have configured | Reach out to support for assistance resolving this error |
+ClickHouse Cloud supports multi-organization SSO with a separate connection per organization. Use the direct link (`https://console.clickhouse.cloud/?connection={organizationid}`) to log in to each one, and log out of one organization before logging into another. If you don't want users on your domain routed to an organization automatically when they enter their email at `https://console.clickhouse.cloud`, open a support ticket to remove that behavior.
+
+</details>
+
+<details id="faq-duplicate-accounts">
+<summary>Why do I see multiple accounts for the same user?</summary>
+
+ClickHouse Cloud doesn't automatically link SSO and non-SSO accounts, so a user who has signed in both ways may appear more than once in your user list even with the same email address.
+
+</details>
+
+## Next steps {#next-steps}
+
+- [Manage cloud users](/cloud/security/manage-cloud-users) — manage permissions and restrict access to SAML connections only.
+- [SCIM provisioning](/cloud/security/scim-setup) — automate user and group provisioning (private preview).
+- [Console roles and permissions](/cloud/security/console-roles) — the roles you can assign as the default SAML role.

--- a/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
@@ -5,7 +5,6 @@ title: 'SAML SSO setup'
 description: 'How to set up SAML SSO with ClickHouse Cloud'
 doc_type: 'guide'
 keywords: ['ClickHouse Cloud', 'SAML', 'SSO', 'single sign-on', 'IdP', 'Okta', 'Google']
-toc_max_heading_level: 2
 ---
 
 import Image from '@theme/IdealImage';
@@ -198,6 +197,8 @@ You will configure two App Integrations in Okta for each ClickHouse organization
 
 You will configure one SAML app in Google for each organization and must provide your users the direct link (`https://console.clickhouse.cloud/?connection={organizationId}`) to bookmark if using multi-org SSO.
 
+#### Create a Google web app {#google-web-app}
+
 1. Go to your Google Admin console (admin.google.com).
 
    <Image img={samlGoogleApp} size="md" alt="Google SAML App" force/>
@@ -231,6 +232,8 @@ You will configure one SAML app in Google for each organization and must provide
 <TabItem value="azure" label="Azure (Microsoft)">
 
 Azure (Microsoft) SAML may also be referred to as Azure Active Directory (AD) or Microsoft Entra. You will set up one application integration with a separate sign-on URL for each organization.
+
+#### Create an Azure enterprise application {#azure-enterprise-app}
 
 1. Log on to the Microsoft Entra admin center.
 2. Navigate to **Applications > Enterprise applications** on the left.
@@ -267,6 +270,8 @@ Azure (Microsoft) SAML may also be referred to as Azure Active Directory (AD) or
 
 </TabItem>
 <TabItem value="duo" label="Duo">
+
+#### Create a generic SAML service provider for Duo {#duo-saml-provider}
 
 1. Follow the instructions for [Duo Single Sign-On for Generic SAML Service Providers](https://duo.com/docs/sso-generic).
 2. Use the following Bridge Attribute mapping:

--- a/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07_saml-sso-setup.md
@@ -97,14 +97,14 @@ Click `Next: Verify your domains`. Enter your domain in the text box and click `
 Create a TXT record with your DNS provider. Copy the `TXT record name` to the TXT record Name field with your DNS provider. Copy the `Value` to the Content field with your DNS provider. Click `Verify and Finish` to complete the process.
 
 :::note
-It may take several minutes for the DNS record to update and be verified. You may leave the setup page and return later to complete the process without restarting. The verification value is valid for 48 hours from when it is first generated.
+It may take several minutes for the DNS record to update and be verified. You may leave the setup page and return later to complete the process without restarting. The verification value is valid for 48 hours from when it's first generated.
 :::
 
    <Image img={samlSelfServe5} size="lg" alt="Verify your domain" force/>
 
 ### Update default role and session timeout {#update-defaults}
 
-Once the SAML setup is complete, you can set the default role(s) all users will be assigned when they log in and also adjust session timeout settings. For a list of available system roles that may be assigned, please review [Console roles and permissions](/cloud/security/console-roles).
+Once the SAML setup is complete, you can set the default roles all users will be assigned when they log in and also adjust session timeout settings. For a list of available system roles that may be assigned, review [Console roles and permissions](/cloud/security/console-roles).
 
 ### Configure your admin user {#configure-your-admin-user}
 
@@ -118,8 +118,8 @@ To assign your first admin user via SAML:
 2. In your identity provider, assign the admin user to the ClickHouse applications.
 3. Ask the user to log in via https://console.clickhouse.cloud/?connection={orgId} (shortcut URL). This may be via a bookmark you created in the prior steps. The user won't appear in ClickHouse Cloud until their first login.
 4. If the default SAML role is anything other than Admin, the user may need to log out and log back in with their original authentication method to update the new SAML user's role.
-   - For email + password accounts, please use `https://console.clickhouse.cloud/?with=email`.
-   - For social logins, please click the appropriate button (**Continue with Google** or **Continue with Microsoft**)
+   - For email + password accounts, use `https://console.clickhouse.cloud/?with=email`.
+   - For social logins, click the appropriate button (**Continue with Google** or **Continue with Microsoft**)
 5. Log out one more time and log back in via the shortcut URL to complete the last step below.
 
 :::note

--- a/docs/cloud/guides/security/01_cloud_access_management/07b_scim-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07b_scim-setup.md
@@ -14,10 +14,6 @@ import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 
 <PrivatePreviewBadge/>
 
-:::note
-SCIM provisioning is in private preview.
-:::
-
 <EnterprisePlanFeatureBadge feature="SCIM"/>
 
 ClickHouse Cloud supports SCIM 2.0 (System for Cross-domain Identity Management) for automated user and group lifecycle management. Once connected to your identity provider, every user you assign to the ClickHouse Cloud application is automatically created in your organization with the right role, profile updates flow through automatically, and removing a user from your IdP removes their access — no manual invites, no orphaned accounts.
@@ -223,70 +219,123 @@ SCIM errors surface in **Reports → System Log** filtered by your application, 
 
 ## Best practices for production {#best-practices}
 
-**Rotate tokens regularly.** Set a calendar reminder for SCIM token rotation. Recommended cadence: every 12 months, or immediately whenever an admin who knew the token leaves the company. ClickHouse Cloud allows two active tokens per organization specifically so you can rotate without breaking provisioning.
+### Rotate tokens regularly {#rotate-tokens}
 
-**Use groups, not direct assignments.** Direct user assignment to the application works, but quickly becomes hard to audit. Driving assignment through Okta groups means access reviews and role changes happen in one place.
+Set a calendar reminder for SCIM token rotation. Recommended cadence: every 12 months, or immediately whenever an admin who knew the token leaves the company. ClickHouse Cloud allows two active tokens per organization specifically so you can rotate without breaking provisioning.
 
-**Review the audit log.** Every SCIM action — user created, user deactivated, profile updated — is recorded in the ClickHouse Cloud audit log. See [Audit logging](/cloud/security/audit-logging). Check the log periodically, especially after large provisioning bursts.
+### Use groups, not direct assignments {#use-groups}
 
-**Set a sensible default role.** If an Okta user gets assigned to the application but isn't in any pushed group, they're created with the **Default role**. Pick the most restrictive role that still lets the user accomplish *something*, so misconfigurations fail safely.
+Direct user assignment to the application works, but quickly becomes hard to audit. Driving assignment through Okta groups means access reviews and role changes happen in one place.
 
-**Avoid SCIM and manual invites at the same time.** Once SCIM is on, manage membership through Okta — don't also send manual invites for the same users. Mixing the two paths leads to confusion about who is the source of truth and can produce duplicates.
+### Review the audit log {#review-audit-log}
 
-**Monitor for failed provisioning tasks.** Okta retries failed provisioning calls but eventually parks them in the **Tasks** queue. Add this queue to the dashboards your IT team already monitors, or use Okta's webhook or email alerting to flag persistent failures.
+Every SCIM action — user created, user deactivated, profile updated — is recorded in the ClickHouse Cloud audit log. See [Audit logging](/cloud/security/audit-logging). Check the log periodically, especially after large provisioning bursts.
+
+### Set a sensible default role {#default-role}
+
+If an Okta user gets assigned to the application but isn't in any pushed group, they're created with the **Default role**. Pick the most restrictive role that still lets the user accomplish *something*, so misconfigurations fail safely.
+
+### Avoid SCIM and manual invites at the same time {#avoid-manual-invites}
+
+Once SCIM is on, manage membership through Okta — don't also send manual invites for the same users. Mixing the two paths leads to confusion about who is the source of truth and can produce duplicates.
+
+### Monitor for failed provisioning tasks {#monitor-failed-tasks}
+
+Okta retries failed provisioning calls but eventually parks them in the **Tasks** queue. Add this queue to the dashboards your IT team already monitors, or use Okta's webhook or email alerting to flag persistent failures.
 
 ## Troubleshooting {#troubleshooting}
 
-### "Test connector configuration" fails in Okta {#test-credentials-fails}
+<details id="test-credentials-fails">
+<summary>"Test connector configuration" fails in Okta</summary>
 
 - Confirm SCIM is **enabled** in the ClickHouse Cloud Console.
 - Confirm the **base URL** in Okta exactly matches the SCIM endpoint URL shown in the Cloud Console — the organization id must be correct.
 - Confirm the **token key and secret** are pasted without leading or trailing whitespace.
 - If you've rotated tokens, make sure you're using the **new** key and secret, not the previous pair.
 
-### Users get created but have no permissions {#users-no-permissions}
+</details>
+
+<details id="users-no-permissions">
+<summary>Users get created but have no permissions</summary>
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
 - Check that the Okta group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
 - If your design intentionally provisions some users without a group, confirm the **Default role** is set.
 
-### Duplicate user in the member list {#duplicate-user}
+</details>
+
+<details id="duplicate-user">
+<summary>Duplicate user in the member list</summary>
 
 Usually caused by inconsistent email casing between Okta and an earlier manual invite. Remove the duplicate from the Members list, then unassign and reassign the user in Okta to provision fresh.
 
-### Group push fails with "displayName not recognised" {#group-display-name}
+</details>
+
+<details id="group-display-name">
+<summary>Group push fails with "displayName not recognised"</summary>
 
 The group name in Okta doesn't match a configured mapping in ClickHouse Cloud. Either rename the Okta group or add a mapping under **Map roles in "Users and roles"** from the SCIM Configuration panel (or via **Users and roles → Roles**).
 
-### Deactivated users still show as members {#deactivated-users-remaining}
+</details>
+
+<details id="deactivated-users-remaining">
+<summary>Deactivated users still show as members</summary>
 
 It can take up to a minute for Okta to propagate a deactivation. If the user is still a member after several minutes, check Okta's **Provisioning → View Logs** for an error on the deactivate task.
 
-### I rotated the SCIM token and now Okta is failing {#token-rotation-issue}
+</details>
+
+<details id="token-rotation-issue">
+<summary>I rotated the SCIM token and now Okta is failing</summary>
 
 Check that you updated the credentials on **the same SCIM application** in Okta. After updating, click `Test Connector Configuration` to confirm. Once provisioning is back to green, revoke the old token in ClickHouse Cloud Console.
 
-### I lost the SCIM token {#lost-token}
+</details>
+
+<details id="lost-token">
+<summary>I lost the SCIM token</summary>
 
 Tokens can't be recovered. In **Organization settings → SAML and SCIM settings → SCIM Configuration** in the ClickHouse Cloud Console, revoke the lost token and generate a new one, then update the credentials in Okta.
 
+</details>
+
 ## Frequently asked questions {#faq}
 
-**Do I need SAML SSO before I can use SCIM?**
+<details id="faq-need-saml-sso">
+<summary>Do I need SAML SSO before I can use SCIM?</summary>
+
 Yes. SCIM creates the user accounts, but ClickHouse Cloud authenticates them through SAML. Set up [SAML SSO](/cloud/security/saml-setup) first.
 
-**Does SCIM work with Microsoft Entra ID, OneLogin, or other SCIM 2.0 IdPs?**
+</details>
+
+<details id="faq-other-idps">
+<summary>Does SCIM work with Microsoft Entra ID, OneLogin, or other SCIM 2.0 IdPs?</summary>
+
 Microsoft Entra ID is also supported — see [SCIM provisioning with Entra ID](/cloud/security/scim-setup-entra). The endpoint follows SCIM 2.0 (RFC 7644) and accepts either Basic Auth (used by Okta) or a bearer token (used by Entra ID). Other SCIM 2.0 IdPs may work in practice if they can authenticate one of these ways, but Okta and Entra ID are the IdPs we've tested and support today.
 
-**How quickly do changes in Okta show up in ClickHouse Cloud?**
+</details>
+
+<details id="faq-change-timing">
+<summary>How quickly do changes in Okta show up in ClickHouse Cloud?</summary>
+
 Most operations propagate within a few seconds. Bulk changes (large group push) can take longer depending on size, but Okta retries automatically on transient errors.
 
-**Can I provision multiple ClickHouse Cloud organizations from a single Okta tenant?**
+</details>
+
+<details id="faq-multi-org">
+<summary>Can I provision multiple ClickHouse Cloud organizations from a single Okta tenant?</summary>
+
 Yes — install the application once per organization, with its own SCIM endpoint URL and token. Push the same Okta groups to each application as needed.
 
-**Where do I get help if I'm stuck?**
+</details>
+
+<details id="faq-get-help">
+<summary>Where do I get help if I'm stuck?</summary>
+
 Open a support ticket from the ClickHouse Cloud Console (**Help → Contact support**) and include:
 
 - your organization id,
 - your Okta application id, and
 - a screenshot of the failing task or test from the Okta logs.
+
+</details>

--- a/docs/cloud/guides/security/01_cloud_access_management/07b_scim-setup.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07b_scim-setup.md
@@ -161,7 +161,7 @@ Okta and ClickHouse Cloud need to agree on how user fields line up. On the **Pro
 You can add optional attributes such as department, manager, and location — ClickHouse Cloud stores them on the user profile but doesn't use them for permissions today. Anything outside the SCIM standard set is ignored on the ClickHouse Cloud side.
 
 :::warning Email casing matters
-Make sure your Okta `userName` and `email` use the same casing. ClickHouse Cloud normalises emails to lowercase; mismatches between the two fields can cause test failures.
+Make sure your Okta `userName` and `email` use the same casing. ClickHouse Cloud normalizes emails to lowercase; mismatches between the two fields can cause test failures.
 :::
 
 ### Push groups and assign users {#push-groups-and-assign-users}
@@ -197,7 +197,7 @@ Group-based assignment is cleaner for ongoing management — when someone change
 
 ## Test the integration {#test-the-integration}
 
-Once provisioning is configured, return to **Settings → Users and roles** in the ClickHouse Cloud Console to confirm that synchronised users have appeared with the expected roles.
+Once provisioning is configured, return to **Settings → Users and roles** in the ClickHouse Cloud Console to confirm that synchronized users have appeared with the expected roles.
 
 ![Verify user synchronization in Users and roles](/images/cloud/security/scim-okta/scim-okta-18.png)
 
@@ -259,7 +259,7 @@ Okta retries failed provisioning calls but eventually parks them in the **Tasks*
 <summary>Users get created but have no permissions</summary>
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
-- Check that the Okta group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
+- Check that the Okta group name **exactly** matches the SCIM group name in the mapping, including capitalization and hyphens.
 - If your design intentionally provisions some users without a group, confirm the **Default role** is set.
 
 </details>

--- a/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
@@ -5,6 +5,7 @@ title: 'SCIM provisioning with Microsoft Entra ID'
 description: 'How to set up SCIM provisioning between Microsoft Entra ID and ClickHouse Cloud'
 doc_type: 'guide'
 keywords: ['ClickHouse Cloud', 'SCIM', 'provisioning', 'Entra ID', 'Azure AD', 'Microsoft', 'SSO', 'SAML', 'identity provider', 'IdP', 'user management']
+toc_max_heading_level: 2
 ---
 
 import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge'
@@ -204,92 +205,128 @@ SCIM errors surface in the application's **Provisioning → View provisioning lo
 
 ## Best practices for production {#best-practices}
 
-**Rotate tokens regularly.** Set a calendar reminder for SCIM token rotation. Recommended cadence: every 12 months, or immediately whenever an admin who knew the token leaves the company. ClickHouse Cloud allows two active tokens per organization specifically so you can rotate without breaking provisioning — generate the new token, update the **Secret Token** in Entra ID, confirm with **Test Connection**, then revoke the old token.
+### Rotate tokens regularly {#rotate-tokens}
 
-**Use groups, not direct assignments.** Direct user assignment to the application works, but quickly becomes hard to audit. Driving assignment through Entra ID groups means access reviews and role changes happen in one place.
+Rotate every 12 months, or immediately when an admin who knew the token leaves. ClickHouse Cloud allows two active tokens per organization so you can rotate without downtime: generate the new token, update the **Secret Token** in Entra ID, confirm with **Test Connection**, then revoke the old one.
 
-**Review the audit log.** Every SCIM action — user created, user deactivated, profile updated — is recorded in the ClickHouse Cloud audit log. See [Audit logging](/cloud/security/audit-logging). Check the log periodically, especially after large provisioning bursts.
+### Use groups, not direct assignments {#use-groups}
 
-**Set a sensible default role.** If an Entra ID user gets assigned to the application but isn't in any assigned group, they're created with the **Default role**. Pick the most restrictive role that still lets the user accomplish *something*, so misconfigurations fail safely.
+Direct user assignment works but quickly becomes hard to audit. Driving assignment through Entra ID groups keeps access reviews and role changes in one place.
 
-**Avoid SCIM and manual invites at the same time.** Once SCIM is on, manage membership through Entra ID — don't also send manual invites for the same users. Mixing the two paths leads to confusion about who is the source of truth and can produce duplicates.
+### Review the audit log {#review-audit-log}
 
-**Account for the provisioning cycle.** Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine changes aren't instant. Use **Provision on demand** when you need a change to land immediately, and monitor **Provisioning logs** for persistent failures.
+Every SCIM action — user created, deactivated, profile updated — is recorded in the [audit log](/cloud/security/audit-logging). Check it periodically, especially after large provisioning bursts.
+
+### Set a sensible default role {#default-role}
+
+If a user is assigned outside any group, they're created with the **Default role**. Pick the most restrictive role that still lets them accomplish *something*, so misconfigurations fail safely.
+
+### Avoid SCIM and manual invites at the same time {#avoid-manual-invites}
+
+Once SCIM is on, manage membership through Entra ID — don't also send manual invites for the same users. Mixing the two paths causes source-of-truth confusion and duplicate accounts.
+
+### Account for the provisioning cycle {#provisioning-cycle}
+
+Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine changes aren't instant. Use **Provision on demand** when you need a change to land immediately, and monitor **Provisioning logs** for persistent failures.
 
 ## Troubleshooting {#troubleshooting}
 
-### "Test connection" fails in Entra ID {#test-credentials-fails}
+<details id="test-credentials-fails">
+<summary>"Test connection" fails in Entra ID</summary>
 
 - Confirm SCIM is **enabled** in the ClickHouse Cloud Console.
 - Confirm the **Tenant URL** in Entra ID exactly matches the SCIM endpoint URL shown in the Cloud Console — the organization id must be correct.
 - Confirm the **Secret Token** is in the form `<scim-key>:<scim-secret>` — the key (starting with `scim_`), a colon, and then the secret. Include no leading or trailing whitespace, and no `Bearer` prefix (Entra ID adds that automatically).
 - If you've rotated tokens, make sure you're using the **new** key and secret, not the previous pair.
 
-### Users get created but have no permissions {#users-no-permissions}
+</details>
+
+<details id="users-no-permissions">
+<summary>Users get created but have no permissions</summary>
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
 - Check that the Entra ID group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
 - If your design intentionally provisions some users without a group, confirm the **Default role** is set.
 
-### Users or groups aren't provisioning at all {#nothing-provisioning}
+</details>
+
+<details id="nothing-provisioning">
+<summary>Users or groups aren't provisioning at all</summary>
 
 - Confirm **Provisioning Status** is `On`.
 - Confirm **Scope** is set to `Sync only assigned users and groups` and that the users/groups are actually assigned to the application under **Users and groups**.
 - Remember the cycle runs roughly every 40 minutes — use **Provision on demand** to test a single user immediately.
 - Provisioning groups (rather than just their members) requires Microsoft Entra ID P1 or higher.
 
-### Duplicate user in the member list {#duplicate-user}
+</details>
+
+<details id="duplicate-user">
+<summary>Duplicate user in the member list</summary>
 
 Usually caused by inconsistent email casing between Entra ID and an earlier manual invite. Remove the duplicate from the Members list, then unassign and reassign the user in Entra ID (or re-run **Provision on demand**) to provision fresh.
 
-### Group provisioning fails with a name mismatch {#group-display-name}
+</details>
+
+<details id="group-display-name">
+<summary>Group provisioning fails with a name mismatch</summary>
 
 The group display name in Entra ID doesn't match a configured mapping in ClickHouse Cloud. Either rename the Entra ID group or add a mapping under **Map roles in "Users and roles"** from the SCIM Configuration panel (or via **Users and roles → Roles**).
 
-### Deactivated users still show as members {#deactivated-users-remaining}
+</details>
+
+<details id="deactivated-users-remaining">
+<summary>Deactivated users still show as members</summary>
 
 Deactivation propagates on the next provisioning cycle. To force it immediately, use **Provision on demand** for that user. If the user is still a member afterwards, check **Provisioning → View provisioning logs** for an error on the disable operation.
 
-### I rotated the SCIM token and now Entra ID is failing {#token-rotation-issue}
+</details>
+
+<details id="token-rotation-issue">
+<summary>I rotated the SCIM token and now Entra ID is failing</summary>
 
 Check that you updated the **Secret Token** on the correct enterprise application in Entra ID, in the form `<scim-key>:<scim-secret>`. After updating, click `Test Connection` to confirm. Once provisioning is back to healthy, revoke the old token in the ClickHouse Cloud Console.
 
-### I lost the SCIM token {#lost-token}
+</details>
+
+<details id="lost-token">
+<summary>I lost the SCIM token</summary>
 
 Tokens can't be recovered. In **Organization settings → SAML and SCIM settings → SCIM Configuration** in the ClickHouse Cloud Console, revoke the lost token and generate a new one, then update the **Secret Token** in Entra ID.
 
+</details>
+
 ## Frequently asked questions {#faq}
 
-<details>
-<summary><strong>Do I need SAML SSO before I can use SCIM?</strong></summary>
+<details id="faq-need-saml-sso">
+<summary>Do I need SAML SSO before I can use SCIM?</summary>
 
 Yes. SCIM creates the user accounts, but ClickHouse Cloud authenticates them through SAML. Set up [SAML SSO](/cloud/security/saml-setup) first.
 
 </details>
 
-<details>
-<summary><strong>Can I use the same enterprise application for SAML and SCIM?</strong></summary>
+<details id="faq-same-enterprise-app">
+<summary>Can I use the same enterprise application for SAML and SCIM?</summary>
 
 Yes. With SAML-based SSO, a single Entra ID enterprise application handles both single sign-on and SCIM provisioning.
 
 </details>
 
-<details>
-<summary><strong>Why is the Secret Token formatted as <code>key:secret</code>?</strong></summary>
+<details id="faq-secret-token-format">
+<summary>Why is the Secret Token formatted as <code>key:secret</code>?</summary>
 
 Entra ID authenticates by sending the Secret Token as an `Authorization: Bearer` header. The ClickHouse Cloud SCIM endpoint expects the bearer value to be your token key and secret joined by a colon.
 
 </details>
 
-<details>
-<summary><strong>How quickly do changes in Entra ID show up in ClickHouse Cloud?</strong></summary>
+<details id="faq-change-timing">
+<summary>How quickly do changes in Entra ID show up in ClickHouse Cloud?</summary>
 
 Entra ID provisions on a recurring cycle of roughly 40 minutes. For an immediate update, use **Provision on demand** for the specific user.
 
 </details>
 
-<details>
-<summary><strong>Where do I get help if I'm stuck?</strong></summary>
+<details id="faq-get-help">
+<summary>Where do I get help if I'm stuck?</summary>
 
 Open a support ticket from the ClickHouse Cloud Console (**Help → Contact support**) and include:
 

--- a/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
@@ -143,7 +143,7 @@ The remaining rows below come mapped by default — double-check that each is in
 Open **Provision Microsoft Entra ID Groups** and confirm `displayName` maps to `displayName` and `members` maps to `members` — group display name is what binds to your ClickHouse Cloud role.
 
 :::warning Email casing matters
-Make sure the value that flows into `userName` and the value that flows into the primary email use the same casing. ClickHouse Cloud normalises emails to lowercase; mismatches between the two fields can cause provisioning failures.
+Make sure the value that flows into `userName` and the value that flows into the primary email use the same casing. ClickHouse Cloud normalizes emails to lowercase; mismatches between the two fields can cause provisioning failures.
 :::
 
 ### Set the provisioning scope {#configure-provisioning-behavior}
@@ -184,7 +184,7 @@ Entra ID runs provisioning on a recurring cycle (approximately every 40 minutes)
 
 ## Test the integration {#test-the-integration}
 
-Once provisioning is on, use **Provision on demand** to push one or two test users right away rather than waiting for the next cycle. Then return to **Settings → Users and roles** in the ClickHouse Cloud Console to confirm that synchronised users have appeared with the expected roles.
+Once provisioning is on, use **Provision on demand** to push one or two test users right away rather than waiting for the next cycle. Then return to **Settings → Users and roles** in the ClickHouse Cloud Console to confirm that synchronized users have appeared with the expected roles.
 
 Run through this short test plan with one or two test users **before** you assign your whole team. If a step doesn't take effect, use **Provision on demand** to force a sync, then check the [Troubleshooting](#troubleshooting) section.
 
@@ -244,7 +244,7 @@ Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine chang
 <summary>Users get created but have no permissions</summary>
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
-- Check that the Entra ID group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
+- Check that the Entra ID group name **exactly** matches the SCIM group name in the mapping, including capitalization and hyphens.
 - If your design intentionally provisions some users without a group, confirm the **Default role** is set.
 
 </details>

--- a/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
@@ -99,7 +99,7 @@ SCIM groups bind to ClickHouse Cloud roles by name, with a few rules to keep in 
 
 Open the **Microsoft Entra ID** overview and, under **Manage** in the left-hand menu, select **Enterprise applications**. Open the application you created when you set up SAML SSO for ClickHouse Cloud.
 
-If you haven't created the enterprise application yet, follow the [SAML SSO setup guide](/cloud/security/saml-setup#configure-azure-microsoft-saml) first — with SAML-based SSO, the same enterprise application is used for both single sign-on and SCIM provisioning.
+If you haven't created the enterprise application yet, follow the [SAML SSO setup guide](/cloud/security/saml-setup?idp=azure#configure-idp) first — with SAML-based SSO, the same enterprise application is used for both single sign-on and SCIM provisioning.
 
 ### Set the provisioning mode and credentials {#connect-entra-scim}
 

--- a/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
+++ b/docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md
@@ -5,7 +5,6 @@ title: 'SCIM provisioning with Microsoft Entra ID'
 description: 'How to set up SCIM provisioning between Microsoft Entra ID and ClickHouse Cloud'
 doc_type: 'guide'
 keywords: ['ClickHouse Cloud', 'SCIM', 'provisioning', 'Entra ID', 'Azure AD', 'Microsoft', 'SSO', 'SAML', 'identity provider', 'IdP', 'user management']
-toc_max_heading_level: 2
 ---
 
 import EnterprisePlanFeatureBadge from '@theme/badges/EnterprisePlanFeatureBadge'

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,0 +1,65 @@
+# Writing a ClickHouse guide
+
+Guidance for authoring or restructuring a how-to / setup guide — for humans, and for
+agents (e.g. Claude Code) pointed here to "build a guide with this template."
+
+## Start from the template
+
+Copy `templates/guide-template.md` and fill in the `{placeholders}`. It carries the
+canonical section order and a working example of every component pattern (stepper, tabs,
+table, collapsibles). Keep the section order; drop a section only if it genuinely doesn't
+apply. The main procedure may be **one or several `## {Task}` sections**.
+
+For a filled-in reference, see
+`docs/cloud/guides/security/01_cloud_access_management/07c_scim-setup-entra.md`.
+
+## Frontmatter
+
+Required: `title`, `sidebar_label`, `slug`, `description`, `keywords`, `doc_type: 'guide'`.
+
+## What each section is for
+
+- **Intro** — one or two sentences: what the guide does and the outcome. Lead with the outcome, not the tooling.
+- **Before you begin** — prerequisites, as a bullet list.
+- **How it works** — a concise mental model of the end-to-end *flow*, placed **before** the steps. This is *what happens, in order* — not behavioral or reference detail. Reference detail belongs in FAQ, or the section becomes a catch-all.
+- **{Task}** — the core procedure(s). Use a descriptive action header ("Configure X", "Install X"), not the bare word "Steps". Split into multiple `## {Task}` sections for multi-part setups.
+- **Verify** — how the reader confirms it worked.
+- **Best practices** — advisory recommendations, read in full.
+- **Troubleshooting** — the issues a reader hits, each independently findable.
+- **FAQ** — standalone questions.
+- **Next steps** — where to go next.
+
+Verify, Best practices, and FAQ are **prompts** as much as sections: even when a guide omits them, the scaffold makes you ask "how does the reader confirm success? what breaks in production? what will they ask?" **Don't fabricate content to fill them** — leave a section out if there's nothing real to say. For guide families that centralize (e.g. a shared FAQ page), Troubleshooting/FAQ may **link to the shared page** instead of being inline.
+
+## Format rules — match the mechanic to the content shape
+
+Classify the content's *shape*; the shape dictates the form. This is what keeps guides consistent instead of drifting as each is cloned from the last.
+
+- **Procedure with depth** (screenshots, code, sub-steps) → `<VerticalStepper headerLevel="h3">` with `### {#anchor}` steps. A trivial one-line list can stay a plain numbered list.
+- **A step or section that differs by variant** (provider, OS, deployment) → `<Tabs>` / `<TabItem>`. Not repeated prose, and not `<details>` accordions. **When the variants are deep-link targets** (linked from elsewhere on the page or from another page), use `<Tabs queryString="x">` under a single section anchor and link with `?x=value#anchor` — plain tabs destroy per-variant anchors.
+- **Selective-consult content** the reader dips into for one item (Troubleshooting, FAQ) → collapsible `<details id="stable-id">`. Keep the ids stable — they're deep-link and support-link targets.
+- **Advisory list read in full** (Best practices) → `### {#anchor}` subheadings, one per item. Not a table, not collapsed.
+- **Table** → only when the reader scans a column *down* to compare values across rows (verification action→result, required-flags, source→target mappings). If each row is just "label + freeform description," it's a list, not a matrix — use subheadings or collapsibles.
+- **Don't over-collapse.** Reserve `<details>` for selective-consult content. Never collapse the primary procedure or anything you want read in full.
+
+## Components
+
+- **Global — no import:** `VerticalStepper`, `Details` / `details`, admonitions (`:::note`, `:::tip`, `:::warning`).
+- **Need imports:** `Tabs` / `TabItem` (from `@theme/Tabs`, `@theme/TabItem`), `Image` (from `@theme/IdealImage`).
+- Every `##` / `###` needs a unique `{#anchor}` (enforced by markdownlint).
+
+## When restructuring an existing guide
+
+- **Grep for inbound links to any anchor you remove or rename** — in-page *and* cross-page — before changing it. Broken anchors are the most common conversion regression.
+- **Preserve substantive content; relocate rather than drop** (behavioral detail → FAQ; a catch-all "Additional information" section → distributed into the sections it belongs to).
+- After converting, diff against the original to confirm nothing substantive was lost.
+
+## Platform
+
+Syntax here is Docusaurus (current docs). Mintlify equivalents for the migration: `<details>` → `<Accordion>`, `<VerticalStepper>` → `<Steps>`, `<Tabs>` maps directly; the TOC is managed automatically. Don't optimize structure for Algolia heading granularity — search is moving to Inkeep (semantic retrieval that ingests full page content, collapsed sections included).
+
+## Before shipping
+
+- `vale <file>`
+- `npx markdownlint-cli2 --config scripts/.markdownlint-cli2.yaml <file>` → 0 errors
+- Run the `docs-pre-ship-review` skill for voice and prose.

--- a/templates/guide-template.md
+++ b/templates/guide-template.md
@@ -1,0 +1,122 @@
+---
+title: '{Page title}'
+sidebar_label: '{Nav label}'
+slug: /{path/to/page}
+description: '{One-sentence summary for search and link previews}'
+keywords: ['{keyword}', '{keyword}']
+doc_type: 'guide'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# {Page title}
+
+{One or two sentences: what this guide does and the outcome the reader will have by the end.}
+
+## Before you begin {#before-you-begin}
+
+{What the reader needs in place first.}
+
+- {Prerequisite}
+- {Prerequisite}
+
+## How it works {#how-it-works}
+
+{Build the reader's mental model of the end-to-end flow — as a numbered sequence (example below) or a short paragraph, whichever fits best.}
+
+1. {What happens first}
+2. {What happens next}
+3. {And so on}
+
+## {First task — e.g. "Configure X"} {#task-1}
+
+{/* One "## {Task}" section per major part of the setup. Deep tasks use a stepper; simple ones a plain numbered list. */}
+
+<VerticalStepper headerLevel="h3">
+
+### {First step, phrased as an action} {#step-1}
+
+{Step detail.}
+
+### {Second step, phrased as an action} {#step-2}
+
+{/* When a step differs by variant (provider, OS, deployment), branch with Tabs instead of repeating the step. */}
+
+<Tabs groupId="{variant}">
+<TabItem value="{option-a}" label="{Option A}">
+
+{Step detail for Option A.}
+
+</TabItem>
+<TabItem value="{option-b}" label="{Option B}">
+
+{Step detail for Option B.}
+
+</TabItem>
+</Tabs>
+
+</VerticalStepper>
+
+## {Second task — e.g. "Configure network access"} {#task-2}
+
+1. {Step}
+2. {Step}
+
+## Verify {#verify}
+
+{How to confirm it worked.}
+
+| Action | Expected result |
+|---|---|
+| {What the reader does} | {What they should see} |
+| {What the reader does} | {What they should see} |
+
+## Best practices {#best-practices}
+
+### {Practice, phrased as an imperative} {#practice-1}
+
+{Why it matters and what to do.}
+
+### {Practice, phrased as an imperative} {#practice-2}
+
+{Why it matters and what to do.}
+
+## Troubleshooting {#troubleshooting}
+
+<details id="{symptom-1}">
+<summary>{Symptom, phrased as the reader would describe it}</summary>
+
+{Cause and fix.}
+
+</details>
+
+<details id="{symptom-2}">
+<summary>{Symptom}</summary>
+
+{Cause and fix.}
+
+</details>
+
+## Frequently asked questions {#faq}
+
+<details id="{faq-1}">
+<summary>{Question}</summary>
+
+{Answer.}
+
+</details>
+
+<details id="{faq-2}">
+<summary>{Question}</summary>
+
+{Answer.}
+
+</details>
+
+## Next steps {#next-steps}
+
+{Where to go from here — related guides or the next thing to do.}
+
+- {Link}
+- {Link}


### PR DESCRIPTION
Establishes a doc-type guide template and applies it to the cloud access-management IdP/SSO family as a proof of concept.

## Template artifacts
- `templates/guide-template.md` — structural scaffold (frontmatter + section spine + component examples)
- `templates/AGENTS.md` — guidance layer: content-shape → form decision rules

## Guides converted to the template
- `07_saml-sso-setup.md` — per-IdP accordions → `queryString` Tabs; "How it works" distilled to a flow and moved before steps; troubleshooting table → collapsibles; FAQ + Next steps
- `07b_scim-setup.md` / `07c_scim-setup-entra.md` — SCIM pair, now mutually consistent (collapsible FAQ/troubleshooting, `###` best-practices)
- `08_saml-sso-removal.md` — reviewed; unchanged (template correctly doesn't force sections on a short runbook)

Validated across a two-sided setup guide, two provisioning guides, and a short runbook. All changed guides pass Vale + markdownlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)