### PR TITLE
fix(clickpipes): document that SQS queues / Pub/Sub subscriptions must not be shared across pipes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/object-storage/amazon-s3/03_unordered-mode.md
+++ b/docs/integrations/data-ingestion/clickpipes/object-storage/amazon-s3/03_unordered-mode.md
@@ -35,6 +35,10 @@ Various types of failures can occur when ingesting data, which can result in par
 
 **1.** In the AWS Console, navigate to **Simple Queue Service > Create queue**. Use the defaults to create a new standard queue.
 
+:::warning One queue per ClickPipe
+Each ClickPipe needs its own dedicated SQS queue. SQS delivers each message to only one consumer: if two or more ClickPipes (or any other application) consume the same queue, each event is received by only one of them, and files are silently skipped by the pipes that never receive the event. This applies even if the ClickPipes use different path patterns — a pipe that receives an event for a non-matching file discards it, and no other pipe will ever see it. To ingest from the same bucket with multiple ClickPipes, create one queue per ClickPipe and use EventBridge rules to route events to each queue.
+:::
+
 :::tip
 We strongly recommend configuring a **Dead-Letter-Queue (DLQ)** for the SQS queue, so it's easier to debug and retry failed messages. If a DLQ is configured, failed messages will be reenqueued and reprocessed up to the number of times configured in the DLQ `maxReceiveCount` parameter.
 :::
@@ -128,7 +132,7 @@ Optionally, add an `object.key` condition to the pattern to filter by prefix or 
 }
 ```
 
-**b.** In the S3 bucket properties, enable **Event notifications** for `ObjectCreated` events and set the destination to the SQS queue. Optionally, specify a prefix or suffix to filter which objects trigger notifications — if you do, make sure it matches the path set for the ClickPipe.
+**b.** In the S3 bucket properties, enable **Event notifications**, select **All object create events** (`s3:ObjectCreated:*`) as the event type, and set the destination to the SQS queue. Do not select individual event types instead: uploads can emit different `ObjectCreated` events depending on how they are performed (for example, multipart uploads emit `CompleteMultipartUpload` rather than `Put`), and files whose event type is not selected will never be delivered to the queue. Optionally, specify a prefix or suffix to filter which objects trigger notifications — if you do, make sure it matches the path set for the ClickPipe.
 
 :::note
 S3 doesn't allow multiple overlapping notification rules for the same event types on the same bucket. If you already have a notification rule for `ObjectCreated` events on this bucket, use the EventBridge approach instead.
@@ -202,7 +206,7 @@ S3 doesn't allow multiple overlapping notification rules for the same event type
 
 **1.** In the ClickHouse Cloud console, navigate to **Data Sources > Create ClickPipe** and select **Amazon S3**. Enter the details to connect to your S3 bucket. Under **Authentication method**, choose **IAM role** and provide the ARN of the role you created in the previous step.
 
-**2.** Under **Incoming data**, toggle on **Continuous ingestion**. Select **Any order** as the ingestion mode and provide the **SQS queue URL** for the queue connected to your bucket. To process only files from the queue and skip the initial scan of existing files in the selected path, enable **Skip initial load**.
+**2.** Under **Incoming data**, toggle on **Continuous ingestion**. Select **Any order** as the ingestion mode and provide the **SQS queue URL** for the queue connected to your bucket. The queue must be used exclusively by this ClickPipe — see [Create an Amazon SQS queue](#create-sqs-queue). To process only files from the queue and skip the initial scan of existing files in the selected path, enable **Skip initial load**.
 
 **3.** Under **Parse information**, define a **Sorting key** for the target table. Make any necessary adjustments to the mapped schema, then configure a role for the ClickPipes database user.
 

--- a/docs/integrations/data-ingestion/clickpipes/object-storage/google-cloud-storage/03_unordered-mode.md
+++ b/docs/integrations/data-ingestion/clickpipes/object-storage/google-cloud-storage/03_unordered-mode.md
@@ -30,6 +30,10 @@ Various types of failures can occur when ingesting data, which can result in par
 
 **1.** In the Google Cloud Console, navigate to **Pub/Sub > Topics > Create topic**. Create a new topic with a default subscription and note the **Topic Name**.
 
+:::warning One subscription per ClickPipe
+Each ClickPipe needs its own dedicated Pub/Sub subscription. Within a single subscription, Pub/Sub delivers each message to only one subscriber: if two or more ClickPipes (or any other application) consume the same subscription, each notification is received by only one of them, and files are silently skipped by the pipes that never receive it. This applies even if the ClickPipes use different path patterns — a pipe that receives a notification for a non-matching file discards it, and no other pipe will ever see it. To ingest from the same bucket with multiple ClickPipes, create a separate subscription on the topic for each ClickPipe.
+:::
+
 **2.** Configure a GCS bucket notification that publishes [`OBJECT_FINALIZE` events](https://docs.cloud.google.com/storage/docs/pubsub-notifications) to the Pub/Sub topic created above.
 
 **2.1.** This step cannot be performed in the Google Cloud Console, so you must use the `gcloud` client or your preferred programmatic interface for Google Cloud. For example, using `gcloud`:
@@ -72,7 +76,7 @@ Various types of failures can occur when ingesting data, which can result in par
 
 **1.** In the ClickHouse Cloud console, navigate to **Data Sources > Create ClickPipe** and select **Google Cloud Storage**. Enter the details to connect to your GCS bucket. Under **Authentication method**, choose **Service Account** and provide the `.json` service account key.
 
-**2.** Toggle on **Continuous ingestion**, then select **Any order** as the ingestion mode and provide the **Pub/Sub subscription** name for the subscription connected to your bucket. To process only files from the subscription and skip the initial scan of existing files in the selected path, enable **Skip initial load**. The subscription name must use the following format:
+**2.** Toggle on **Continuous ingestion**, then select **Any order** as the ingestion mode and provide the **Pub/Sub subscription** name for the subscription connected to your bucket. The subscription must be used exclusively by this ClickPipe — see [Create a Google Cloud Pub/Sub topic](#create-pubsub-topic). To process only files from the subscription and skip the initial scan of existing files in the selected path, enable **Skip initial load**. The subscription name must use the following format:
 
 ```text
 projects/${YOUR_PROJECT_ID}/subscriptions/${YOUR_SUBSCRIPTION_NAME}

--- a/scripts/aspell-ignore/en/aspell-dict.txt
+++ b/scripts/aspell-ignore/en/aspell-dict.txt
@@ -2939,6 +2939,7 @@ multidirectory
 multiif
 multiline
 multilinestring
+multipart
 multiplyDecimal
 multipolygon
 multiprocess


### PR DESCRIPTION
## Summary

Prompted by [support-escalation #8195](https://github.com/ClickHouse/support-escalation/issues/8195): a customer pointed two S3 ClickPipes (different path patterns) at the **same SQS queue**. SQS delivers each message to exactly one consumer, so each `ObjectCreated` event was received by only one of the two pipes — and a pipe receiving an event for a file outside its path pattern silently discards (and deletes) the message. Result: random, silent file loss on both pipes, with no error signal anywhere. The same failure mode exists for GCS pipes sharing a single Pub/Sub subscription.

## Changes

**S3 unordered-mode guide:**
- Add a `:::warning` in the *Create an Amazon SQS queue* step: one dedicated queue per ClickPipe; sharing a queue across pipes (or any other consumer) loses files, even with different path patterns; use EventBridge fan-out (one rule per queue) to feed multiple pipes from the same bucket.
- Reinforce at the *Create a ClickPipe* step where the queue URL is entered.
- Make the direct S3 → SQS instructions explicit about selecting **All object create events** (`s3:ObjectCreated:*`): selecting individual event types (e.g. only `Put`) silently misses files uploaded via other methods such as multipart uploads (`CompleteMultipartUpload`).

**GCS unordered-mode guide:**
- Equivalent `:::warning` for Pub/Sub: one dedicated subscription per ClickPipe; fan out with one subscription per pipe on the same topic.
- Reinforce at the *Create a ClickPipe* step.

**Spell dictionary:** add `multipart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)