### PR TITLE
Add MySQL ClickPipes FAQ for unsupported MariaDB COMPRESSED columns

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -37,7 +37,7 @@ To resolve it:
   ```sql
   ALTER TABLE <table> MODIFY <column> <type>; -- without COLUMN_FORMAT COMPRESSED
   ```
-- resync the pipe
+- resync the table or the pipe
 
 ### Does the MySQL ClickPipe support PlanetScale, Vitess, or TiDB? {#does-the-clickpipe-support-planetscale-vitess}
 No, these don't support MySQL's binlog API.

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -31,13 +31,13 @@ convert them to a non-compressed type or remove the table from the mirror
 
 it means the table has one or more columns using MariaDB's [column compression](https://mariadb.com/kb/en/storage-engine-independent-column-compression/) (`COLUMN_FORMAT COMPRESSED`). We can't decompress these values from the binlog, so the affected table can't be replicated via CDC.
 
-To resolve it, either:
+To resolve it:
 
-- **Convert the compressed columns to a non-compressed type** on the source, then resync the pipe:
+- **Convert the compressed columns to a non-compressed type** on the source:
   ```sql
   ALTER TABLE <table> MODIFY <column> <type>; -- without COLUMN_FORMAT COMPRESSED
   ```
-- **Remove the table from the mirror** if you don't need to replicate it.
+- resync the pipe
 
 ### Does the MySQL ClickPipe support PlanetScale, Vitess, or TiDB? {#does-the-clickpipe-support-planetscale-vitess}
 No, these don't support MySQL's binlog API.

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -33,7 +33,7 @@ it means the table has one or more columns using MariaDB's [column compression](
 
 To resolve it:
 
-- **Convert the compressed columns to a non-compressed type** on the source:
+- **Convert the compressed columns to a non-compressed type** on the source (or remove a table from the pipe):
   ```sql
   ALTER TABLE <table> MODIFY <column> <type>; -- without COLUMN_FORMAT COMPRESSED
   ```

--- a/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/faq.md
@@ -20,6 +20,25 @@ MariaDB 12.3 and above can emit a [partial rows event](https://mariadb.com/docs/
 
 To recover, resync the pipe. To reduce the chance of hitting this again, you can also raise `binlog_row_event_fragment_threshold` setting on the source so fewer row changes get fragmented — keep it below your `max_allowed_packet`, since a single unfragmented binlog event larger than `max_allowed_packet` will fail the replication stream instead (see [Why is my pipe failing with a max_allowed_packet binlog error?](#binlog-event-exceeded-max-allowed-packet)).
 
+### Why did my pipe fail with an unsupported MariaDB COMPRESSED column? {#mariadb-compressed-column-unsupported}
+
+If your pipe fails with an error similar to:
+
+```text
+table <database>.<table> has MariaDB COMPRESSED column(s) [<columns>], which cannot be replicated via CDC;
+convert them to a non-compressed type or remove the table from the mirror
+```
+
+it means the table has one or more columns using MariaDB's [column compression](https://mariadb.com/kb/en/storage-engine-independent-column-compression/) (`COLUMN_FORMAT COMPRESSED`). We can't decompress these values from the binlog, so the affected table can't be replicated via CDC.
+
+To resolve it, either:
+
+- **Convert the compressed columns to a non-compressed type** on the source, then resync the pipe:
+  ```sql
+  ALTER TABLE <table> MODIFY <column> <type>; -- without COLUMN_FORMAT COMPRESSED
+  ```
+- **Remove the table from the mirror** if you don't need to replicate it.
+
 ### Does the MySQL ClickPipe support PlanetScale, Vitess, or TiDB? {#does-the-clickpipe-support-planetscale-vitess}
 No, these don't support MySQL's binlog API.
 


### PR DESCRIPTION
## Summary

Adds a MySQL ClickPipes FAQ entry documenting the `NOTIFY_MYSQL_COMPRESSED_COLUMN_UNSUPPORTED` failure: tables with MariaDB `COLUMN_FORMAT COMPRESSED` columns can't be replicated via CDC. The entry explains the error and how to recover (convert the columns to a non-compressed type, or remove the table from the mirror).

It mirrors the existing MariaDB partial row event FAQ entry and is anchored at `#mariadb-compressed-column-unsupported`, matching the mitigation link emitted by the ingestion metrics reporter.

## Related

Pairs with the `NOTIFY_MYSQL_COMPRESSED_COLUMN_UNSUPPORTED` notification handling added in clickpipes-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)