### PR TITLE
Document Unity Catalog managed storage limitation

### DIFF
--- a/docs/integrations/data-catalogs/index.md
+++ b/docs/integrations/data-catalogs/index.md
@@ -89,7 +89,7 @@ Glue supports multiple table formats, but ClickHouse only reads **Iceberg** tabl
 </TabItem>
 <TabItem value="unity-iceberg" label="Unity Catalog (Iceberg)">
 
-Query Unity Catalog managed [Iceberg](/engines/table-engines/integrations/iceberg) tables using OAuth client credentials from a Databricks service principal. See the [Unity Catalog guide](/use-cases/data-lake/unity-catalog#read-iceberg) for full setup.
+Query Unity Catalog [Iceberg](/engines/table-engines/integrations/iceberg) tables that use external storage locations, using OAuth client credentials from a Databricks service principal. See the [Unity Catalog guide](/use-cases/data-lake/unity-catalog#read-iceberg) for full setup.
 
 Before you connect, confirm:
 
@@ -107,7 +107,7 @@ In the flyout:
 </TabItem>
 <TabItem value="unity-delta" label="Unity Catalog (Delta)">
 
-Query Unity Catalog [Delta Lake](/engines/table-engines/integrations/deltalake) tables using a Databricks Personal Access Token (PAT). See the [Unity Catalog guide](/use-cases/data-lake/unity-catalog#read-delta) for full setup.
+Query Unity Catalog [Delta Lake](/engines/table-engines/integrations/deltalake) tables that use external storage locations, using a Databricks Personal Access Token (PAT). See the [Unity Catalog guide](/use-cases/data-lake/unity-catalog#read-delta) for full setup.
 
 Before you connect, confirm:
 

--- a/docs/use-cases/data_lake/guides/connecting-catalogs.md
+++ b/docs/use-cases/data_lake/guides/connecting-catalogs.md
@@ -35,11 +35,10 @@ For example purposes, we'll use the Unity catalog.
 
 [Databricks Unity Catalog](https://www.databricks.com/product/unity-catalog) provides centralized governance for Databricks lakehouse data.
 
-Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog tables as both Delta and Iceberg.
+Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog Delta and Iceberg tables that use external storage locations.
 
 :::note
-Integration with the Unity Catalog works for managed and external tables.
-This integration is currently only supported on AWS.
+This integration is currently only supported on AWS. Tables on Databricks managed storage are not supported because Unity Catalog does not provide credential vending for those locations. See the [Unity Catalog reference](/use-cases/data-lake/unity-catalog) for details.
 :::
 
 ### Configuring Unity in Databricks {#configuring-unity-in-databricks}

--- a/docs/use-cases/data_lake/reference/unity_catalog.md
+++ b/docs/use-cases/data_lake/reference/unity_catalog.md
@@ -20,7 +20,7 @@ ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, et
 Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog Delta and Iceberg tables that use external storage locations.
 
 :::note
-ClickHouse does not support Delta Lake or Iceberg tables stored on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external). These tables require [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending), which Unity Catalog does not support for managed storage locations.
+Unity Catalog does not provide [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending) for Delta Lake or Iceberg tables stored on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external). ClickHouse relies on credential vending to read table data from Unity Catalog.
 :::
 
 :::note

--- a/docs/use-cases/data_lake/reference/unity_catalog.md
+++ b/docs/use-cases/data_lake/reference/unity_catalog.md
@@ -20,7 +20,7 @@ ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, et
 Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog Delta and Iceberg tables that use external storage locations.
 
 :::note
-ClickHouse does not support Delta Lake or Iceberg tables stored on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external). These tables require [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending), which ClickHouse does not support.
+ClickHouse does not support Delta Lake or Iceberg tables stored on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external). These tables require [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending), which Unity Catalog does not support for managed storage locations.
 :::
 
 :::note

--- a/docs/use-cases/data_lake/reference/unity_catalog.md
+++ b/docs/use-cases/data_lake/reference/unity_catalog.md
@@ -17,7 +17,11 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, etc.). This guide will walk you through the steps to query your data managed by Databricks using ClickHouse and the [Unity Catalog](https://www.databricks.com/product/unity-catalog). 
 
-Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog tables as both Delta and Iceberg.
+Databricks supports multiple data formats for their lakehouse. With ClickHouse, you can query Unity Catalog Delta and Iceberg tables that use external storage locations.
+
+:::note
+ClickHouse does not support Delta Lake or Iceberg tables stored on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external). These tables require [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending), which ClickHouse does not support.
+:::
 
 :::note
 As this feature is experimental, you will need to enable it using:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the [Unity Catalog reference page](/use-cases/data-lake/unity-catalog) to document that ClickHouse does not support Delta Lake or Iceberg tables stored on Databricks managed storage.

## Changes

- Clarifies that ClickHouse supports Unity Catalog Delta and Iceberg tables that use **external storage locations**.
- Adds a note explaining that tables on [Databricks managed storage](https://docs.databricks.com/aws/en/data-governance/unity-catalog/managed-versus-external) are not supported because they require [credential vending](https://docs.databricks.com/aws/en/external-access/credential-vending), which ClickHouse does not support.

## Related context

The [connecting catalogs guide](/use-cases/data-lake/getting-started/connecting-catalogs) still states that the Unity Catalog integration "works for managed and external tables." That may need a follow-up update for consistency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-549d3d38-489e-43a6-889c-f06b16877701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-549d3d38-489e-43a6-889c-f06b16877701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

