### PR TITLE
docs(cloud-changelog): add July 13, 2026 Cloud changelog entry

### DIFF
--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -21,7 +21,7 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
 
 ## July 13, 2026 {#2026-07-13}
 
-This week's updates include sticky replica routing over plain HTTPS, custom billing period start dates, new initial-load controls for object storage ClickPipes, and the first GA release of the ClickHouse ADBC driver.
+This week's updates include sticky replica routing over plain HTTPS, custom billing period start dates, and new initial-load controls for object storage ClickPipes.
 
 ### Sticky replica routing over HTTPS (private preview) {#sticky-replica-routing-https}
 
@@ -34,10 +34,6 @@ You can now request a change to your organization's billing date, the day of the
 ### Skip initial load for object storage ClickPipes {#object-storage-skip-initial-load}
 
 Object storage [ClickPipes](/integrations/clickpipes) (S3, GCS, and Azure Blob Storage) now offer two ways to control the initial load when you create a pipe: **Start after**, which skips files up to and including a given object key, and **Skip initial load**, which skips pre-existing files entirely and processes only new object notifications. Previously a new pipe always backfilled every file in the path. The two options are mutually exclusive and permanent for a given pipe: a skipped backfill can't be triggered later. Available in the UI, the Cloud API, and Terraform v3.18.0 and later.
-
-### ClickHouse ADBC driver 0.1.0 (GA) {#adbc-driver-ga}
-
-The first GA release of [`adbc_clickhouse`](https://github.com/ClickHouse/adbc_clickhouse) moves the Arrow Database Connectivity driver out of alpha. It brings access from languages without a dedicated ClickHouse driver (C, R, Ruby, and more), bulk ingestion of Arrow record batches with no SQL required, driver auto-detection from `clickhouse://` connection strings, and support for binary strings and `arrow.uuid` as query parameters. One breaking change applies, limited to the Rust API (`adbc_core` 0.23.0, `arrow-*` 58.3.0). See the [release notes](https://github.com/ClickHouse/adbc_clickhouse/releases) for full details.
 
 ## June 30, 2026 {#2026-06-30}
 

--- a/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
+++ b/docs/cloud/reference/01_changelog/01_cloud_changelog/2026.md
@@ -19,6 +19,26 @@ In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibil
   </a>
 :::
 
+## July 13, 2026 {#2026-07-13}
+
+This week's updates include sticky replica routing over plain HTTPS, custom billing period start dates, new initial-load controls for object storage ClickPipes, and the first GA release of the ClickHouse ADBC driver.
+
+### Sticky replica routing over HTTPS (private preview) {#sticky-replica-routing-https}
+
+You can now pin queries to a specific replica over standard HTTPS by adding a `?session_id=` parameter to your normal service URL, with no special hostnames or DNS changes required. This keeps session-scoped objects such as temporary tables available across queries, and helps repeated queries hit warm replica-local caches. It's rolling out in private preview to all Enterprise customers, and to Scale customers on request. The existing subdomain-based routing keeps working but will eventually migrate to this approach. See the [replica-aware routing](/manage/replica-aware-routing) docs.
+
+### Custom billing period start dates {#custom-billing-period-start-dates}
+
+You can now request a change to your organization's billing date, the day of the month each billing period starts, for example to align invoices with the calendar month. Open a support ticket with your requested date. Billing dates apply in UTC, and each invoice covers usage from the billing date up to (but not including) the same date the following month.
+
+### Skip initial load for object storage ClickPipes {#object-storage-skip-initial-load}
+
+Object storage [ClickPipes](/integrations/clickpipes) (S3, GCS, and Azure Blob Storage) now offer two ways to control the initial load when you create a pipe: **Start after**, which skips files up to and including a given object key, and **Skip initial load**, which skips pre-existing files entirely and processes only new object notifications. Previously a new pipe always backfilled every file in the path. The two options are mutually exclusive and permanent for a given pipe: a skipped backfill can't be triggered later. Available in the UI, the Cloud API, and Terraform v3.18.0 and later.
+
+### ClickHouse ADBC driver 0.1.0 (GA) {#adbc-driver-ga}
+
+The first GA release of [`adbc_clickhouse`](https://github.com/ClickHouse/adbc_clickhouse) moves the Arrow Database Connectivity driver out of alpha. It brings access from languages without a dedicated ClickHouse driver (C, R, Ruby, and more), bulk ingestion of Arrow record batches with no SQL required, driver auto-detection from `clickhouse://` connection strings, and support for binary strings and `arrow.uuid` as query parameters. One breaking change applies, limited to the Rust API (`adbc_core` 0.23.0, `arrow-*` 58.3.0). See the [release notes](https://github.com/ClickHouse/adbc_clickhouse/releases) for full details.
+
 ## June 30, 2026 {#2026-06-30}
 
 This week's updates include new observability features for Postgres and ClickHouse internals, expanded ClickPipes controls including Kafka exactly-once delivery, and several platform additions: Azure Marketplace BYOC, the official Airflow provider, and ClickHouse Agents updates.

--- a/static/cloud/changelog-rss.xml
+++ b/static/cloud/changelog-rss.xml
@@ -13,9 +13,7 @@
 
 Custom billing period start dates:
 
-Skip initial load for object storage ClickPipes:
-
-ClickHouse ADBC driver 0.1.0 (GA):</description>
+Skip initial load for object storage ClickPipes:</description>
       <pubDate>Mon, 13 Jul 2026 00:00:00 +0200</pubDate>
       <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-07-13</guid>
     </item>

--- a/static/cloud/changelog-rss.xml
+++ b/static/cloud/changelog-rss.xml
@@ -7,6 +7,19 @@
     <language>en-us</language>
     <atom:link href="https://clickhouse.com/docs/cloud/changelog-rss.xml" rel="self" type="application/rss+xml" />
     <item>
+      <title>ClickHouse Cloud - July 13, 2026</title>
+      <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-07-13</link>
+      <description>Sticky replica routing over HTTPS (private preview):
+
+Custom billing period start dates:
+
+Skip initial load for object storage ClickPipes:
+
+ClickHouse ADBC driver 0.1.0 (GA):</description>
+      <pubDate>Mon, 13 Jul 2026 00:00:00 +0200</pubDate>
+      <guid isPermaLink="true">https://clickhouse.com/docs/cloud/whats-new/cloud#2026-07-13</guid>
+    </item>
+    <item>
       <title>ClickHouse Cloud - June 30, 2026</title>
       <link>https://clickhouse.com/docs/cloud/whats-new/cloud#2026-06-30</link>
       <description>Kafka exactly-once delivery in ClickPipes:
@@ -14,8 +27,6 @@
 Unified TLS controls for CDC sources:
 
 Replicated databases return to the ClickPipes picker:
-
-Postgres query insights and metrics:
 
 ClickHouse Agents updates (public beta):
 


### PR DESCRIPTION
Adds the **July 13, 2026** entry to the 2026 ClickHouse Cloud changelog, drawn from the week of Jul 7–13 in `#shipped`.

### Entries
- **Sticky replica routing over HTTPS (private preview)** — pin queries to a replica via `?session_id=` on the standard HTTPS URL, no special hostnames/DNS.
- **Custom billing period start dates** — request a change to the org billing date (day of month a period starts) via support.
- **Skip initial load for object storage ClickPipes** — new `Start after` and `Skip initial load` options for S3/GCS/Azure Blob pipes.

### Files
- `docs/.../01_cloud_changelog/2026.md` — the new entry, in the existing Cloud changelog format (`##` date + `###` per item), not an `<Update>` block.
- `static/cloud/changelog-rss.xml` — regenerated via `scripts/changelog/cloud-changelog-rss.sh` (TZ pinned to `Europe/Berlin` to avoid `pubDate` churn on existing entries).

### Notes / exclusions
- Internal-only details (sysadmin tooling, runbook links) stripped.
- **Langfuse excluded** — distinct product with its own changelog, no precedent in this feed.
- **ADBC driver 0.1.0 GA excluded** — general client-library release, not a Cloud feature.
- The RSS regen also drops a stale `Postgres query insights and metrics` line from the June 30 item — it was in the feed but has no matching heading on the changelog page, so the script (page = source of truth) removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)