### PR TITLE
Expand replica-aware routing docs

### DIFF
--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -26,6 +26,10 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 - Available on **Enterprise** by default when the feature is GA.
 - Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) is not yet supported.
 
+## Configuring replica-aware routing {#configuring-replica-aware-routing}
+
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, or cache reuse). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.
+
 ## HTTP-based routing (session_id) {#http-based-routing}
 
 To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server until the cluster topology changes.
@@ -84,7 +88,3 @@ Sticky routing is keyed on the `session_id` query parameter, which only exists o
 - Confirm `session_id` is a URL query parameter (`?session_id=...`), not an HTTP header.
 - Wait briefly after enablement. It can take under a minute to take effect.
 - Check whether the service recently scaled or restarted; remapping is expected after topology changes. Use `SELECT hostName()` to discover the new mapping.
-
-## Configuring replica-aware routing {#configuring-replica-aware-routing}
-
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, or cache reuse). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -15,8 +15,8 @@ Replica-aware routing (also known as sticky sessions, sticky routing, or session
 
 It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
 
-:::warning Protocol support — HTTP/HTTPS only
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/language-clients/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions) — the driver sends it as the URL query parameter the proxy hashes on.
+:::warning Protocol support: HTTP/HTTPS only
+Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/language-clients/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
 :::
 
 ## Prerequisites {#prerequisites}
@@ -28,7 +28,7 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 
 ## HTTP-based routing (session_id) {#http-based-routing}
 
-To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server — until the cluster topology changes.
+To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server until the cluster topology changes.
 
 You use your existing service hostname. No special sticky hostnames or DNS changes are required.
 
@@ -39,11 +39,11 @@ curl 'https://<host>:8443/?session_id=my-workload-1' \
   -d 'SELECT hostName()'
 ```
 
-Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica — the mapping is consistent, but you do not choose *which* replica a given value maps to.
+Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you do not choose *which* replica a given value maps to.
 
 `session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
 
-Any HTTP client that can add a query parameter works — `curl`, [clickhouse-connect](/integrations/python), JDBC/ODBC, and others. For `clickhouse-go` (v2), use HTTP mode as noted above.
+Any HTTP client that can add a query parameter works, including `curl`, [clickhouse-connect](/integrations/python), JDBC/ODBC, and others. For `clickhouse-go` (v2), use HTTP mode as noted above.
 
 ### Check which replica you hit {#check-which-replica}
 
@@ -54,12 +54,12 @@ curl 'https://<host>:8443/?session_id=test-123' \
   -d 'SELECT hostName()'
 ```
 
-Run it again with the same `session_id` — you should get the same hostname. A different `session_id` may map to a different replica.
+Run it again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
 :::danger Deprecated
-The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It does not scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing.
+The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It does not scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
 :::
 
 Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
@@ -68,7 +68,7 @@ Previously, enabling replica-aware routing allowed a wildcard subdomain on top o
 
 ### Stickiness can break during service changes {#replica-aware-routing-does-not-guarantee-isolation}
 
-Any disruption to the service: server pod restarts (version upgrade, crash, vertical scaling), or scale out / in — changes the routing hash ring. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
+Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
 
 ### Replica-aware routing is not workload isolation {#not-workload-isolation}
 
@@ -76,7 +76,7 @@ Sticky routing only controls *which* replica handles a request. That replica may
 
 ### Private Link and the deprecated subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
 
-HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname — no extra DNS entries.
+HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
 
 The deprecated subdomain method does not: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
@@ -89,9 +89,9 @@ Sticky routing is keyed on the `session_id` query parameter, which only exists o
 **Queries still land on different replicas with the same `session_id`**
 
 - Confirm `session_id` is a URL query parameter (`?session_id=...`), not an HTTP header.
-- Wait briefly after enablement — it can take under a minute to take effect.
+- Wait briefly after enablement. It can take under a minute to take effect.
 - Check whether the service recently scaled or restarted; remapping is expected after topology changes. Use `SELECT hostName()` to discover the new mapping.
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, or cache reuse). After it's enabled, start sending `?session_id=` on HTTPS requests — no restart is required.
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, or cache reuse). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -1,8 +1,8 @@
 ---
 title: 'Replica-aware routing'
 slug: /manage/replica-aware-routing
-description: 'How to use Replica-aware routing to increase cache re-use'
-keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'session_id']
+description: 'Route related requests to the same ClickHouse Cloud replica for temporary tables, sessions, and cache reuse'
+keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'session_id', 'session affinity', 'temporary tables']
 doc_type: 'guide'
 unlisted: true
 ---
@@ -11,46 +11,87 @@ import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 
 <PrivatePreviewBadge/>
 
-Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) increases the chance of cache reuse by consistently routing related requests to the same ClickHouse replica. It is best-effort and does not guarantee isolation.
+Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, or when you want related queries to reuse the same replica's local caches.
+
+It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
 
 :::warning Protocol support — HTTP/HTTPS only
-Replica-aware routing is applied at the proxy layer over the **HTTP/HTTPS interface**, using the `session_id` query parameter (see below). It is **not available over the native protocol** (native port, e.g. the `clickhouse-go` driver in its default native mode). If you need sticky routing from a native-protocol client, connect that workload over the HTTP interface instead — for `clickhouse-go` (v2), set `Protocol: clickhouse.HTTP` on the connection.
+Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/language-clients/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions) — the driver sends it as the URL query parameter the proxy hashes on.
 :::
+
+## Prerequisites {#prerequisites}
+
+- Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
+- A **running** service. Waking an idle service can change which replica a `session_id` maps to.
+- Available on **Enterprise** by default. **Scale** customers can request access through [support](https://clickhouse.com/support/program).
+- Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) is not yet supported.
 
 ## HTTP-based routing (session_id) {#http-based-routing}
 
-To pin a workload to a replica, set the `session_id` query parameter on the HTTPS interface. The proxy parses the request and uses consistent hashing on the `session_id` to select a replica, so all requests sharing the same `session_id` are routed to the same server — until the cluster topology changes.
+To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server — until the cluster topology changes.
+
+You use your existing service hostname. No special sticky hostnames or DNS changes are required.
 
 ```bash
-echo 'SELECT hostName()' | curl \
-  -H 'X-ClickHouse-User: default' -H 'X-ClickHouse-Key: <password>' \
-  'https://<host>:8443/?session_id=my-workload-1' -d @-
+curl 'https://<host>:8443/?session_id=my-workload-1' \
+  -H 'X-ClickHouse-User: default' \
+  -H 'X-ClickHouse-Key: <password>' \
+  -d 'SELECT hostName()'
 ```
 
 Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica — the mapping is consistent, but you do not choose *which* replica a given value maps to.
 
+`session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
+
+Any HTTP client that can add a query parameter works — `curl`, [clickhouse-connect](/integrations/python), JDBC/ODBC, and others. For `clickhouse-go` (v2), use HTTP mode as noted above.
+
+### Check which replica you hit {#check-which-replica}
+
+```bash
+curl 'https://<host>:8443/?session_id=test-123' \
+  -H 'X-ClickHouse-User: default' \
+  -H 'X-ClickHouse-Key: <password>' \
+  -d 'SELECT hostName()'
+```
+
+Run it again with the same `session_id` — you should get the same hostname. A different `session_id` may map to a different replica.
+
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
 :::danger Deprecated
-The subdomain-based mechanism below is **deprecated** and is no longer enabled on new services. It does not scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead.
+The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It does not scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing.
 :::
 
 Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
 
 ## Limitations of replica-aware routing {#limitations-of-replica-aware-routing}
 
-### Replica-aware routing doesn't guarantee isolation {#replica-aware-routing-does-not-guarantee-isolation}
+### Stickiness can break during service changes {#replica-aware-routing-does-not-guarantee-isolation}
 
-Any disruption to the service — server pod restarts (version upgrade, crash, vertical scaling), or scale out / in — changes the routing hash ring. This causes requests sharing the same `session_id` to land on a different server pod.
+Any disruption to the service: server pod restarts (version upgrade, crash, vertical scaling), or scale out / in — changes the routing hash ring. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
 
-### Replica-aware routing doesn't work out of the box with private link {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
+### Replica-aware routing is not workload isolation {#not-workload-isolation}
 
-When using the deprecated subdomain method, customers need to manually add a DNS entry to make name resolution work for the new hostname pattern. It is possible that this can cause imbalance in the server load if customers use it incorrectly.
+Sticky routing only controls *which* replica handles a request. That replica may still serve other traffic. For dedicated compute, use [compute-compute separation](/cloud/reference/warehouses).
+
+### Private Link and the deprecated subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
+
+HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname — no extra DNS entries.
+
+The deprecated subdomain method does not: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
 ### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
 
-Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing is not available over the native protocol. Native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing is not available over the native protocol. Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+
+## Troubleshooting {#troubleshooting}
+
+**Queries still land on different replicas with the same `session_id`**
+
+- Confirm `session_id` is a URL query parameter (`?session_id=...`), not an HTTP header.
+- Wait briefly after enablement — it can take under a minute to take effect.
+- Check whether the service recently scaled or restarted; remapping is expected after topology changes. Use `SELECT hostName()` to discover the new mapping.
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-To enable replica-aware routing, please contact [our support team](https://clickhouse.com/support/program).
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, or cache reuse). After it's enabled, start sending `?session_id=` on HTTPS requests — no restart is required.

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -33,10 +33,10 @@ To pin a workload to a replica, set the `session_id` query parameter on the [HTT
 You use your existing service hostname. No special sticky hostnames or DNS changes are required.
 
 ```bash
-curl 'https://<host>:8443/?session_id=my-workload-1' \
+echo 'SELECT hostName()' | curl \
   -H 'X-ClickHouse-User: default' \
   -H 'X-ClickHouse-Key: <password>' \
-  -d 'SELECT hostName()'
+  'https://<host>:8443/?session_id=my-workload-1' -d @-
 ```
 
 Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you do not choose *which* replica a given value maps to.

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -15,7 +15,7 @@ Replica-aware routing (also known as sticky sessions, sticky routing, or session
 
 It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
 
-:::warning Protocol support: HTTP/HTTPS only
+:::warning Requires the HTTP interface
 Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
 :::
 
@@ -24,7 +24,7 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 - Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
 - A **running** service. Waking an idle service can change which replica a `session_id` maps to.
 - Available on **Enterprise** by default when the feature is GA.
-- Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) is not yet supported.
+- Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) isn't supported yet.
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
@@ -43,7 +43,7 @@ echo 'SELECT hostName()' | curl \
   'https://<host>:8443/?session_id=my-workload-1' -d @-
 ```
 
-Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you do not choose *which* replica a given value maps to.
+Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you don't choose *which* replica a given value maps to.
 
 `session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
 
@@ -56,7 +56,7 @@ Run the `SELECT hostName()` example above again with the same `session_id`. You 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
 :::danger Deprecated
-The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It does not scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
+The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
 :::
 
 Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
@@ -67,7 +67,7 @@ Previously, enabling replica-aware routing allowed a wildcard subdomain on top o
 
 Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
 
-### Replica-aware routing is not workload isolation {#not-workload-isolation}
+### Replica-aware routing isn't workload isolation {#not-workload-isolation}
 
 Sticky routing only controls *which* replica handles a request. That replica may still serve other traffic. For dedicated compute, use [compute-compute separation](/cloud/reference/warehouses).
 
@@ -75,11 +75,11 @@ Sticky routing only controls *which* replica handles a request. That replica may
 
 HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
 
-The deprecated subdomain method does not: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
+The deprecated subdomain method doesn't: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
 ### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
 
-Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing is not available over the native protocol. Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing isn't available over the native protocol. Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
 
 ## Troubleshooting {#troubleshooting}
 

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -47,14 +47,7 @@ Any HTTP client that can add a query parameter works, including `curl`, [clickho
 
 ### Check which replica you hit {#check-which-replica}
 
-```bash
-curl 'https://<host>:8443/?session_id=test-123' \
-  -H 'X-ClickHouse-User: default' \
-  -H 'X-ClickHouse-Key: <password>' \
-  -d 'SELECT hostName()'
-```
-
-Run it again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
+Run the `SELECT hostName()` example above again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -23,7 +23,7 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 
 - Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
 - A **running** service. Waking an idle service can change which replica a `session_id` maps to.
-- Available on **Enterprise** by default. **Scale** customers can request access through [support](https://clickhouse.com/support/program).
+- Available on **Enterprise** by default when feature is GA.
 - Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) is not yet supported.
 
 ## HTTP-based routing (session_id) {#http-based-routing}

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -23,7 +23,7 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 
 - Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
 - A **running** service. Waking an idle service can change which replica a `session_id` maps to.
-- Available on **Enterprise** by default when feature is GA.
+- Available on **Enterprise** by default when the feature is GA.
 - Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) is not yet supported.
 
 ## HTTP-based routing (session_id) {#http-based-routing}

--- a/docs/cloud/features/05_infrastructure/replica-aware-routing.md
+++ b/docs/cloud/features/05_infrastructure/replica-aware-routing.md
@@ -16,7 +16,7 @@ Replica-aware routing (also known as sticky sessions, sticky routing, or session
 It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
 
 :::warning Protocol support: HTTP/HTTPS only
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/language-clients/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
+Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
 :::
 
 ## Prerequisites {#prerequisites}


### PR DESCRIPTION
## Summary
- Add prerequisites (2+ replicas, running service, Enterprise/Scale availability, BYOC limitation) and clarify primary use cases: temporary tables, session state, and cache reuse
- Improve `session_id` usage with simpler curl examples, verification steps, and corrected clickhouse-go HTTP guidance
- Reframe Private Link (works with `session_id` on the normal hostname; DNS only needed for deprecated subdomains), add troubleshooting, and expand enablement instructions

## Test plan
- [ ] Preview the page locally and confirm links resolve
- [ ] Review against the internal runbook for accuracy
- [ ] Vale lint `docs/cloud/features/05_infrastructure/replica-aware-routing.md`


Made with [Cursor](https://cursor.com)