### PR TITLE
Add clickhouse-proxy to the utilities sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1764,6 +1764,7 @@ const sidebars = {
         'operations/utilities/clickhouse-keeper-client',
         'operations/utilities/clickhouse-local',
         'operations/utilities/clickhouse-obfuscator',
+        'operations/utilities/clickhouse-proxy',
         'operations/utilities/odbc-bridge',
         'tools-and-utilities/static-files-disk-uploader',
         'getting-started/playground',


### PR DESCRIPTION
[ClickHouse/ClickHouse#79699](https://github.com/ClickHouse/ClickHouse/pull/79699) adds a new documentation page `docs/en/operations/utilities/clickhouse-proxy.md` for the native `clickhouse-proxy` load-balancing / routing proxy.

That page is currently a "floating page" — it is not referenced from any sidebar — which makes the `Build docusaurus` docs check fail on the ClickHouse PR:

```
1 floating pages found:
  - /opt/clickhouse-docs/docs/operations/utilities/clickhouse-proxy.md
Error: Found "floating" pages without sidebars.
```

This adds `operations/utilities/clickhouse-proxy` to the "Tools and utilities" sidebar (next to the other `clickhouse-*` utilities), which clears the check once merged.

Related: https://github.com/ClickHouse/ClickHouse/pull/79699