### PR TITLE
Except clickhouse-proxy from the floating-pages check (unblocks ClickHouse#79699)

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -10,6 +10,7 @@
 integrations/language-clients/java/client-v1
 integrations/language-clients/java/jdbc-v1
 operations/utilities/clickhouse-keeper-http-api.md
+operations/utilities/clickhouse-proxy
 cloud/features/backups/faq.md
 interfaces/web-terminal
 interfaces/web-sql


### PR DESCRIPTION
## What

Adds `operations/utilities/clickhouse-proxy` to `plugins/floating-pages-exceptions.txt`.

## Why

[ClickHouse/ClickHouse#79699](https://github.com/ClickHouse/ClickHouse/pull/79699) adds a new `clickhouse-proxy` docs page. Until it syncs into clickhouse-docs, it's a floating page (not referenced by any sidebar), which fails the `Build docusaurus` check on the upstream PR:

```
1 floating pages found:
  - /opt/clickhouse-docs/docs/operations/utilities/clickhouse-proxy.md
Error: Found "floating" pages without sidebars.
```

Excepting the page unblocks the upstream PR's docs build now, without breaking our build (a `sidebars.js` `type: doc` entry can't reference the page until it exists locally — see #6527).

## Sequencing

1. **This PR** — add the exception (unblocks upstream). ← merge now
2. After the page syncs into clickhouse-docs, **#6527** adds it to the "Tools and utilities" sidebar **and removes this exception**.

Related: #6527, [ClickHouse#79699](https://github.com/ClickHouse/ClickHouse/pull/79699)

🤖 Generated with [Claude Code](https://claude.com/claude-code)