### PR TITLE
DBI-798: Document MySQL Server ID Advanced setting

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mysql/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/index.md
@@ -116,6 +116,7 @@ You can configure the advanced settings if needed. A brief description of each s
 - **Pull batch size**: The number of rows to fetch in a single batch. This is a best effort setting and may not be respected in all cases.
 - **Snapshot number of rows per partition**: This is the number of rows that will be fetched in each partition during the initial snapshot. This is useful when you have a large number of rows in your tables and you want to control the number of rows fetched in each partition.
 - **Snapshot number of tables in parallel**: This is the number of tables that will be fetched in parallel during the initial snapshot. This is useful when you have a large number of tables and you want to control the number of tables fetched in parallel.
+- **Server ID**: Optional parameter to set the server ID for the MySQL binlog replication. If not set, ClickPipes will generate a random server ID that might change over the ClickPipe lifecycle. Use it to deterministically identify your ClickPipe at the source MySQL server side.
 
 ### Configure the tables {#configure-the-tables}
 


### PR DESCRIPTION
## Summary

Document the addition of the `Server ID` field for MySQL DB pipes. 

Part of: https://linear.app/clickhouse/issue/DBI-798

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
