### PR TITLE
Cross-linking: add a link to the release status page

### DIFF
--- a/docs/cloud/features/06_admin_features/upgrades.md
+++ b/docs/cloud/features/06_admin_features/upgrades.md
@@ -14,7 +14,9 @@ import fast_release from '@site/static/images/cloud/manage/fast_release.png';
 import scheduled_upgrades from '@site/static/images/cloud/manage/scheduled_upgrades.png';
 import scheduled_upgrade_window from '@site/static/images/cloud/manage/scheduled_upgrade_window.png';
 
-With ClickHouse Cloud you never have to worry about patching and upgrades. We roll out upgrades that include fixes, new features and performance improvements on a periodic basis. For the full list of what is new in ClickHouse refer to our [Cloud changelog](/whats-new/changelog/cloud).
+With ClickHouse Cloud you never have to worry about patching and upgrades. We roll out upgrades that include fixes, new features and performance improvements on a periodic basis.
+- For the full list of what is new in ClickHouse refer to our [Cloud changelog](/whats-new/changelog/cloud)
+- For version release timing, see the [release status](/cloud/release-status) page
 
 :::note
 We're introducing a new upgrade mechanism, a concept we call "make before break" (or MBB). With this new approach, we add updated replicas before removing the old ones during the upgrade operation. This results in more seamless upgrades that are less disruptive to running workloads.


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
small suggestion: from the release channels page https://clickhouse.com/docs/manage/updates, add a link to the release schedule https://clickhouse.com/docs/cloud/release-status - people tend to ask "when can I have version X" and this would just remove a tiny bit of friction :slightly_smiling_face:
## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
