### PR TITLE
Update FAQ around native JSON support in Postgres CDC ClickPipes

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/postgres/faq.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/faq.md
@@ -164,9 +164,14 @@ ClickPipes for Postgres aims to map Postgres data types as natively as possible 
 
 Currently, we don't support defining custom data type mappings as part of the pipe. However, note that the default data type mapping used by ClickPipes is highly native. Most column types in Postgres are replicated as closely as possible to their native equivalents on ClickHouse. Integer array types in Postgres, for instance, are replicated as integer array types on ClickHouse.
 
-### How are JSON and JSONB columns replicated from Postgres? {#how-are-json-and-jsonb-columns-replicated-from-postgres}
+### How are `json` and `jsonb` columns replicated from Postgres? {#how-are-json-and-jsonb-columns-replicated-from-postgres}
 
-JSON and JSONB columns are replicated as String type in ClickHouse. Since ClickHouse supports a native [JSON type](/sql-reference/data-types/newjson), you can create a materialized view over the ClickPipes tables to perform the translation if needed. Alternatively, you can use [JSON functions](/sql-reference/functions/json-functions) directly on the String columns. We're actively working on a feature that replicates JSON and JSONB columns directly to the JSON type in ClickHouse. This feature is expected to be available in a few months.
+`json` and `jsonb` columns are replicated as String type in ClickHouse due to incompatibilities with the [native JSON type](https://clickhouse.com/docs/sql-reference/data-types/newjson). For example:
+
+* PostgreSQL allows any valid JSON value at the top level (strings, numbers, arrays), while ClickHouse's JSON type only supports objects.
+* Keys containing dots (e.g., "app.kubernetes.io/name") are also interpreted as nested paths by ClickHouse's JSON type, which could alter the data structure.
+
+To handle JSON strings downstream of a Postgres CDC ClickPipe, you can use [JSON functions](https://clickhouse.com/docs/sql-reference/functions/json-functions) directly on the columns to extract and work with the data. For better query performance, you can also use a materialized view to extract specific fields into typed columns, or to cast the column to the native JSON type (keeping in mind that the cast might fail if it hits a cross-platform type incompatibility).
 
 ### What happens to inserts when a mirror is paused? {#what-happens-to-inserts-when-a-mirror-is-paused}
 


### PR DESCRIPTION
## Summary

It's common for users of the Postgres CDC pipe to ask why we don't provide a native `json`/`jsonb`->JSON type mapping. Our FAQ isn't clear about this, and also includes a misleading claim that we are working on it.
