### PR TITLE
docs(byoc): refresh BYOC FAQ — correct stale answers, expand coverage

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
@@ -47,6 +47,10 @@ Prepare a fresh AWS account, GCP project, or Azure subscription under your organ
 
 The initial BYOC setup can be performed using a [CloudFormation template (AWS)](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc_v2.yaml), a [Terraform module (GCP)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/gcp), or a [Terraform module (Azure)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/azure). It creates a highly privileged identity (IAM role/service account/service principal), enabling BYOC controllers from ClickHouse Cloud to manage your infrastructure.
 
+:::warning Apply the onboarding artifacts exactly as provided
+Do not change anything in the CloudFormation template or Terraform module — including renaming resources or adding parameters such as a `PermissionsBoundary` — without ClickHouse's explicit approval. ClickHouse automation depends on the exact resources these artifacts create; supported customizations are exposed as parameters. In particular, on AWS the IAM role must be named exactly `ClickHouseManagementRole`, with no prefix or suffix: the role name is hard-coded in ClickHouse's automation and is identical for every customer. A modified stack usually applies successfully, but infrastructure provisioning then fails because ClickHouse cannot assume the expected role.
+:::
+
 <Image img={byoc_onboarding_2} size="lg" alt="BYOC initialize account" background='black'/>
 
 :::note

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
@@ -57,6 +57,10 @@ Do not change anything in the CloudFormation template or Terraform module — in
 Storage buckets, VPC/VNet, Kubernetes cluster, and compute resources required for running ClickHouse aren't included in this initial setup. They will be provisioned in the next step.
 :::
 
+:::note External ID
+On AWS, the setup uses an external ID (the `ExternalId` CloudFormation parameter / `external_id` Terraform input) as an `sts:ExternalId` condition on the role trust policy. Use the value shown in the ClickHouse Cloud onboarding flow. Displaying the external ID in the console is rolling out gradually — if your onboarding screen doesn't show one, leave the CloudFormation parameter at its default, or ask your ClickHouse contact for the value to use with Terraform. Don't choose your own value: it must match what ClickHouse's automation expects, or the cross-account role can't be assumed and provisioning fails.
+:::
+
 #### Terraform Module for AWS {#terraform-module-aws}
 
 If you prefer to use Terraform instead of CloudFormation for AWS deployments, use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -48,6 +48,10 @@ Ensure your VPC has working DNS resolution and doesn't block, interfere with, or
 
 The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc_v2.yaml) or a Terraform module (see below).
 
+:::warning The IAM role name is a hard requirement
+The role must be named exactly `ClickHouseManagementRole` — no prefixes, suffixes, or renaming to satisfy an organizational naming convention. The name is hard-coded in ClickHouse's automation and identical for every customer, so a renamed role applies successfully but provisioning then fails because ClickHouse cannot assume the expected role. More generally, do not change anything in the provided template or module without ClickHouse's explicit approval; supported customizations are exposed as parameters.
+:::
+
 When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` parameter to `false` to ensure ClickHouse Cloud doesn't receive permissions to modify your customer-managed VPC.
 
 :::note

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -72,6 +72,10 @@ module "clickhouse_onboarding" {
 
 Replace `<version>` with the latest tag from the module's [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases) — always use the latest release.
 
+:::note External ID
+For `external_id` (or the `ExternalId` CloudFormation parameter), use the value shown in the ClickHouse Cloud onboarding flow. Displaying the external ID in the console is rolling out gradually — if your onboarding screen doesn't show one, leave the CloudFormation parameter at its default, or ask your ClickHouse contact for the value to use with Terraform. Don't choose your own value: it must match what ClickHouse's automation expects, or the cross-account role can't be assumed and provisioning fails.
+:::
+
 :::note
 The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
 :::

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/03_network_setup/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/03_network_setup/01_aws.md
@@ -104,6 +104,10 @@ Optional, after verifying that peering is working, you can request the removal o
 
 AWS PrivateLink provides a secure and private connection to your ClickHouse BYOC services without the need for VPC peering or internet gateways. All traffic flows within the AWS network, ensuring that it never traverses the public internet.
 
+:::note Cross-region connections
+The **Enable private link** toggle in the ClickHouse console provisions the endpoint service and covers **same-region** consumers only. AWS disables cross-region access on endpoint services by default, and the ClickHouse console doesn't manage it — if your clients are in a different region, you enable it yourself: the endpoint service lives in your BYOC account, so add the consumer regions to its **Supported regions** list in your own AWS console (see step 3 below). ClickHouse won't change or reset these values. AWS cross-region data transfer rates apply.
+:::
+
 <VerticalStepper headerLevel="h3">
 
 ### Enable private link in ClickHouse console {#step-1-enable-private-link}

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -3,43 +3,129 @@ title: 'BYOC FAQ'
 slug: /cloud/reference/byoc/reference/faq
 sidebar_label: 'FAQ'
 keywords: ['BYOC', 'cloud', 'bring your own cloud', 'FAQ']
-description: 'Deploy ClickHouse on your own cloud infrastructure'
+description: 'Frequently asked questions about ClickHouse Bring Your Own Cloud (BYOC)'
 doc_type: 'reference'
 ---
 
 ## FAQ {#faq}
 
-### Compute {#compute}
+### Onboarding and provisioning {#onboarding-and-provisioning}
 
 <details>
-<summary>Can I create multiple services in this single Kubernetes (EKS/GKE/AKS) cluster?</summary>
+<summary>How do we get started with BYOC?</summary>
 
-Yes. The infrastructure only needs to be provisioned once for every cloud account/project/subscription and region combination.
+Reach out to ClickHouse via the [contact form](https://clickhouse.com/cloud/bring-your-own-cloud), and the team will enable BYOC for your organization. You then prepare a dedicated cloud account (AWS account, GCP project) and follow the [standard onboarding guide](/cloud/reference/byoc/onboarding/standard). We strongly recommend a dedicated account or project used only for BYOC.
+
+</details>
+
+<details>
+<summary>How long does infrastructure provisioning take, and what are common reasons it gets stuck?</summary>
+
+Expect roughly 45–90 minutes end to end. When provisioning stalls, the most common causes are on the account side:
+
+- The CloudFormation template or Terraform module was modified before applying it (for example, adding a `PermissionsBoundary`). Apply the artifacts as provided — supported customizations are exposed as parameters.
+- Organization-level policies (AWS SCPs, GCP organization policies such as `iam.allowedPolicyMemberDomains`) blocking role assumption or IAM bindings.
+- Account quota limits (for example Elastic IPs or VPCs on AWS).
+
+Provisioning retries automatically and self-heals once the underlying issue is fixed. If your infrastructure remains stuck for more than a couple of hours, contact support.
+
+</details>
+
+<details>
+<summary>Can BYOC use an existing VPC? What about shared VPCs?</summary>
+
+Yes — you can deploy into an existing VPC that lives in the **same** account or project as the BYOC infrastructure. See the customization guides for [AWS](/cloud/reference/byoc/onboarding/customization-aws) and [GCP](/cloud/reference/byoc/onboarding/customization-gcp).
+
+Subnets shared from another account (AWS RAM) or a GCP Shared VPC host project are not supported today. The recommended pattern is a dedicated account or project for BYOC, connected to your existing network via VPC peering or PrivateLink / Private Service Connect. Note that with a customer-managed VPC, only the private load balancer is enabled by default (see [configuration](/cloud/reference/byoc/configurations)).
+
+</details>
+
+<details>
+<summary>Can BYOC be installed into an existing Kubernetes cluster?</summary>
+
+No. The Kubernetes cluster (EKS or GKE) is created and fully managed by ClickHouse. This is required so that ClickHouse can operate the platform reliably and keep it upgraded.
+
+</details>
+
+<details>
+<summary>Can we run our own workloads in the BYOC cluster or cloud account?</summary>
+
+In the cloud account: yes, as long as your resources do not touch ClickHouse-provisioned ones (all ClickHouse-created resources carry the tag `clickhouse-byoc=true`), though a dedicated account remains the recommendation.
+
+In the Kubernetes cluster: it is possible with constraints — use your own node groups with taints and tolerations, stay out of ClickHouse-managed namespaces, and do not install cluster-wide admission controllers or policy engines, which can block reconciliation of ClickHouse components. Describe your plan to support first so we can confirm there are no collisions.
+
+</details>
+
+### Compute and scaling {#compute}
+
+<details>
+<summary>Can I create multiple services in a single BYOC infrastructure?</summary>
+
+Yes. The infrastructure (including the Kubernetes cluster) only needs to be provisioned once for every cloud account and region combination, and all services you create in that region share it.
 
 </details>
 
 <details>
 <summary>Which regions do you support for BYOC?</summary>
 
-All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments.
+All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. BYOC provisions across three availability zones, so regions with fewer than three zones and AWS Local Zones are not supported. If a region you need is not listed, contact your ClickHouse representative to discuss availability.
 
 </details>
 
 <details>
 <summary>Will there be some resource overhead? What are the resources needed to run services other than ClickHouse instances?</summary>
 
-Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, the cluster autoscaler, Istio, and the monitoring stack.
+Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, `aws-cluster-autoscaler`, Istio, and the monitoring stack.
 
-The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, in AWS we typically use a dedicated node group of about four `4xlarge` EC2 instances to run these workloads.
+The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, in AWS we typically use a dedicated node group of about four `4xlarge` EC2 instances to run these workloads. In addition, each service runs a dedicated three-node ClickHouse Keeper ensemble, which is shared by all services in the same warehouse. See the [cost model](/cloud/reference/byoc/cost-model-aws) for details.
+
+</details>
+
+<details>
+<summary>Does BYOC support autoscaling?</summary>
+
+Service-level (vertical) autoscaling is on the roadmap. Available today: manual vertical and horizontal scaling through the console, automatic idling and wake-up for intermittent workloads, and automatic node-group scaling at the infrastructure level — you never manage nodes yourself. ClickHouse Keeper is monitored and scaled by ClickHouse.
+
+</details>
+
+<details>
+<summary>Which instance types does BYOC run on? Can we change the instance family?</summary>
+
+BYOC runs on a curated set of node groups rather than arbitrary instance types — on AWS, ARM-based (Graviton) memory-optimized families by default. Different instance families, CPU-to-memory ratios, or architectures can be provisioned on request through support; spot instances are not supported. See [configuration](/cloud/reference/byoc/configurations).
+
+</details>
+
+<details>
+<summary>Can we separate ingest and query workloads?</summary>
+
+Yes. Warehouses (compute-compute separation) are supported in BYOC: multiple services share the same data, so you can dedicate services to ingestion and others to querying.
 
 </details>
 
 ### Network and security {#network-and-security}
 
 <details>
-<summary>Can we revoke permissions set up during installation after setup is complete?</summary>
+<summary>Can we limit or revoke the permissions granted during installation?</summary>
 
-This is currently not possible.
+You can reduce the grants from the start: the onboarding template is parameterized, so you can withhold network write permissions when bringing your own VPC (`IncludeVPCWritePermissions=false`), withhold KMS permissions (off by default), and — in private preview on AWS — manage the IAM roles yourself (`IncludeIAMWritePermissions=false`, see [customer-managed IAM roles](/cloud/reference/byoc/onboarding/customization-aws)). The cross-account roles support an `ExternalId` condition to prevent confused-deputy access.
+
+After provisioning, do not remove permissions from the management role unilaterally: ClickHouse continuously reconciles the infrastructure, and missing permissions break provisioning, upgrades, and support. To change the granted permissions or offboard entirely, coordinate with support (see the decommissioning question below).
+
+</details>
+
+<details>
+<summary>What exactly can ClickHouse do in our cloud account? Can our security team review the permissions?</summary>
+
+All roles and their purposes are documented in the [privilege reference](/cloud/reference/byoc/reference/privilege). Write permissions are scoped: resource creation and mutation are restricted by the `clickhouse-byoc=true` resource tag and `clickhouse-cloud-*` name prefixes, so the management role cannot modify resources it did not create. The management role has **no object-level access to your data buckets** — object access is limited to in-cluster identities scoped to the ClickHouse workloads. Read permissions are broader because they are required for continuous reconciliation.
+
+ClickHouse can provide the rendered policy JSON for review and walk your security team through each permission on request.
+
+</details>
+
+<details>
+<summary>What access do ClickHouse employees have to our environment and data?</summary>
+
+By default, none to your data. For troubleshooting, engineers must go through an internal just-in-time escalation process; access is time-bound, certificate-based, limited to `system.*` tables (no customer data tables), logged, and audited by our security team. Any query run by a ClickHouse engineer is visible to you in your own `system.query_log`. See [ClickHouse data access](/cloud/reference/byoc/reference/clickhouse_data_access) for the full model.
 
 </details>
 
@@ -51,35 +137,170 @@ Yes. Implementing a customer controlled mechanism where customers can approve en
 </details>
 
 <details>
-<summary>What is the size of the VPC/VNet IP range created?</summary>
+<summary>What data leaves our account?</summary>
 
-By default, we use `10.0.0.0/16` for the BYOC VPC (AWS/GCP) or VNet (Azure). We recommend reserving at least /22 for potential future scaling,
+Only operational metadata: service and backup state events, usage metrics for billing, and alert notifications. Your data, backups, logs, and monitoring data stay in your account. See [network security](/cloud/reference/byoc/reference/network_security) for the complete list of outbound flows.
+
+</details>
+
+<details>
+<summary>How does the ClickHouse control plane reach the Kubernetes API in our account? Is Tailscale required?</summary>
+
+By default, the Kubernetes API endpoint is public but restricted to ClickHouse's NAT IP addresses. For private-only connectivity, two options exist: Tailscale (outbound-only, used by default for troubleshooting access) and, on AWS, a fully private path via VPC Lattice (private preview). See [network security](/cloud/reference/byoc/reference/network_security) and [configuration](/cloud/reference/byoc/configurations). Do not remove the ClickHouse IP allowlist entries from the API endpoint — the control plane needs them to manage the cluster.
+
+</details>
+
+<details>
+<summary>What is the size of the VPC IP range created?</summary>
+
+By default, we use `10.0.0.0/16` for BYOC VPC. We recommend reserving at least /22 for potential future scaling,
 but if you prefer to limit the size, it is possible to use /23 if it is likely that you will be limited
 to 30 server pods.
 
 </details>
 
 <details>
-<summary>Can I decide maintenance frequency?</summary>
-
-Contact support to schedule maintenance windows. Please expect a minimum of a weekly update schedule.
-
-</details>
-
-<details>
 <summary>How does network communication work between BYOC VPC and S3?</summary>
 
-Traffic between your Customer BYOC VPC and S3 uses HTTPS (port 443) via the AWS S3 API for table data, backups, and logs. When using S3 VPC endpoints, this traffic remains within the AWS network and doesn't traverse the public internet.
+Traffic between your Customer BYOC VPC and S3 uses HTTPS (port 443) via the AWS S3 API for table data, backups, and logs. This traffic goes through an S3 gateway VPC endpoint, so it remains within the AWS network, doesn't traverse the public internet, and incurs no NAT gateway charges. On GCP, access to Google APIs similarly uses Private Google Access.
 
 </details>
 
 <details>
-<summary>What ports are used for internal ClickHouse cluster communication?</summary>
+<summary>The data is in our own bucket — can we read or modify it directly?</summary>
 
-Internal ClickHouse cluster communication within the Customer BYOC VPC uses:
-- Native ClickHouse protocol on port 9000
-- HTTP/HTTPS on ports 8123/8443
-- Interserver communication on port 9009 for replication and distributed queries
+No. Table data blobs are stored in a shared layout without per-table paths, so objects cannot be attributed to tables, and any direct modification risks corrupting your services. Never modify bucket contents directly; if you suspect an issue, open a support ticket.
+
+</details>
+
+<details>
+<summary>What ports are used for client and cluster communication?</summary>
+
+Client connections terminate at the load balancer on TLS ports: **8443** (HTTPS interface) and **9440** (native protocol over TLS); port 443 also routes to the HTTPS interface.
+
+Inside the VPC, cluster-internal communication uses the native protocol on port 9000, HTTP on port 8123, and interserver communication on port 9009 for replication and distributed queries. These internal ports and the ClickHouse Keeper ports are never exposed on any load balancer.
+
+</details>
+
+<details>
+<summary>Are our service endpoints exposed to the public internet? Can we go private-only?</summary>
+
+By default (with a ClickHouse-managed VPC), each service gets a public load balancer protected by an IP access list, plus a private load balancer reachable from your VPC and peered networks. IP filtering is enforced at the ingress proxy layer, so the load balancer ports may appear open in scans while connections from unlisted sources are rejected. The public endpoint can be disabled entirely once nothing depends on it. See [connectivity](/cloud/reference/byoc/connect).
+
+</details>
+
+<details>
+<summary>Can we use our own DNS domain or bring our own TLS certificates?</summary>
+
+Not today. Service endpoints are provisioned under `clickhouse-byoc.com` with ClickHouse-managed certificates.
+
+</details>
+
+<details>
+<summary>How do we set up AWS PrivateLink or GCP Private Service Connect?</summary>
+
+Follow the network setup guides for [AWS](/cloud/reference/byoc/onboarding/network-aws) and [GCP](/cloud/reference/byoc/onboarding/network-gcp). Two things commonly missed: endpoint allowlisting is **per service**, so endpoints must be registered again for each new service, and DNS resolution for the private endpoint names must be configured on your side if you run your own DNS.
+
+</details>
+
+<details>
+<summary>Our security tooling flagged privileged containers or host mounts in the BYOC cluster — is this expected?</summary>
+
+Some platform components legitimately require elevated privileges or host filesystem access, such as the EBS CSI driver, node configuration jobs, and the Prometheus node exporter (which reads `/proc` and `/sys`). If your scanner raises findings, share them with support — we will confirm whether each one is by design or actionable.
+
+</details>
+
+<details>
+<summary>Do you support customer-managed encryption keys (CMEK)?</summary>
+
+Not currently for BYOC. Data at rest is encrypted with cloud-provider-managed keys. See the [overview](/cloud/reference/byoc/overview) for the current list of planned features.
+
+</details>
+
+### Upgrades and maintenance {#upgrades-and-maintenance}
+
+<details>
+<summary>How do ClickHouse version upgrades work? Can I decide maintenance frequency?</summary>
+
+Upgrades work the same way as in ClickHouse Cloud: services enroll in release channels (fast, regular, slow) and honor scheduled maintenance windows — contact support to configure them. Please expect a minimum of a weekly update schedule. Upgrades are rolling, replica-by-replica (make-before-break), so there is no whole-service downtime. See [operations](/cloud/reference/byoc/operations).
+
+</details>
+
+<details>
+<summary>Who is responsible for Kubernetes upgrades, and what impact should we expect?</summary>
+
+ClickHouse owns and performs Kubernetes upgrades proactively, ahead of provider end-of-support dates, and coordinates the window with you through support. Control-plane upgrades are transparent; node-group upgrades roll nodes one by one with make-before-break semantics, so you may see brief connection resets as pods restart, but no data loss. See [operations](/cloud/reference/byoc/operations).
+
+</details>
+
+### Backups and disaster recovery {#backups-and-disaster-recovery}
+
+<details>
+<summary>Where are backups stored?</summary>
+
+In object storage in your own cloud account — backups never leave your environment. Backup schedule and retention are configurable; contact support to adjust them.
+
+</details>
+
+<details>
+<summary>What is included in a backup? Are system tables backed up?</summary>
+
+All user-created databases, tables, and objects, plus access entities (users, roles, settings profiles, row policies, quotas) and user-defined functions. System log tables such as `system.query_log` are not included.
+
+</details>
+
+<details>
+<summary>Why am I billed for backups that are older than my retention window?</summary>
+
+Backups form chains: a full backup followed by incrementals that depend on it. The base full backup is required to restore any incremental in its chain, so it is retained (and stored) until every dependent incremental has aged out of retention.
+
+</details>
+
+<details>
+<summary>How can we monitor backup status ourselves?</summary>
+
+Two ways: the ClickHouse Cloud API backup endpoints, and the Prometheus counters exposed by the in-cluster monitoring stack (`backups_initiated_total`, `backups_completed_total`, `backups_failed_total`) — we recommend alerting on failures in your own monitoring. See [observability](/cloud/reference/byoc/observability).
+
+</details>
+
+<details>
+<summary>How do we meet disaster recovery requirements (RPO/RTO)?</summary>
+
+BYOC deploys across three availability zones, and writes are acknowledged only after object storage confirms them. For regional disaster recovery, backup frequency and destination can be configured to match your RPO and RTO targets, including backing up to a bucket in another region — contact support to set this up.
+
+</details>
+
+### Observability {#observability}
+
+<details>
+<summary>How do we integrate BYOC with our own monitoring and alerting?</summary>
+
+The monitoring stack (Prometheus, Grafana, AlertManager) runs inside your account, and you can consume it directly: query it over the PromQL API, federate it into your own Prometheus, or scrape the ClickHouse `/metrics_all` endpoint per service. There is no turnkey integration for third-party platforms such as Datadog today — integrate via their Prometheus-compatible ingestion. See [observability](/cloud/reference/byoc/observability) for endpoints and setup.
+
+</details>
+
+### Cost {#cost}
+
+<details>
+<summary>What do we pay for with BYOC?</summary>
+
+Two separate bills: ClickHouse Cloud charges based on the memory allocated to your services, and your cloud provider bills you directly for the underlying infrastructure at cost, with no markup. See the [cost model](/cloud/reference/byoc/cost-model-aws), [billable AWS services](/cloud/reference/byoc/billable-aws-services), and [AWS service limits](/cloud/reference/byoc/aws-service-limits).
+
+</details>
+
+### Availability and lifecycle {#availability-and-lifecycle}
+
+<details>
+<summary>Which cloud providers is BYOC available on?</summary>
+
+AWS and GCP are generally available. Azure is in private preview — contact your ClickHouse representative to join. See the [overview](/cloud/reference/byoc/overview) for current status.
+
+</details>
+
+<details>
+<summary>How do we decommission a BYOC environment?</summary>
+
+Contact ClickHouse **before** deleting anything. The correct order is: ClickHouse deprovisions the services and infrastructure first, then you remove the onboarding stack and any remaining resources. Deleting resources or revoking the management role's permissions first severs the control-plane connection mid-flight and forces manual cleanup. All ClickHouse-created resources are tagged `clickhouse-byoc=true`, so you can enumerate them afterwards to verify nothing is left.
 
 </details>
 
@@ -88,6 +309,6 @@ Internal ClickHouse cluster communication within the Customer BYOC VPC uses:
 <details>
 <summary>Does ClickHouse offer an uptime SLA for BYOC?</summary>
 
-No, since the data plane is hosted in the customer's cloud environment, service availability depends on resources not in ClickHouse's control. Therefore, ClickHouse doesn't offer a formal uptime SLA for BYOC deployments. If you have additional questions, please contact support@clickhouse.com.
+No, since the data plane is hosted in the customer's cloud environment, service availability depends on resources not in ClickHouse's control. Therefore, ClickHouse doesn't offer a formal uptime SLA for BYOC deployments. Note that running services operate independently of the ClickHouse control plane: a control-plane outage does not take down services running in your account. If you have additional questions, please contact support@clickhouse.com.
 
 </details>

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -217,6 +217,13 @@ Follow the network setup guides for [AWS](/cloud/reference/byoc/onboarding/netwo
 </details>
 
 <details>
+<summary>Can we connect over PrivateLink from a different AWS region?</summary>
+
+Yes, but the console's **Enable private link** toggle covers same-region consumers only — AWS disables cross-region access on endpoint services by default, and the ClickHouse console doesn't manage it. Since the endpoint service lives in your BYOC account, you enable it yourself: add the consumer regions to the endpoint service's **Supported regions** list in your AWS console, then create the endpoint with the cross-region option on the consumer side. ClickHouse won't change or reset these values. See the [PrivateLink setup guide](/cloud/reference/byoc/onboarding/network-aws#setup-privatelink) for the steps; AWS cross-region data transfer rates apply.
+
+</details>
+
+<details>
 <summary>Is there a list of endpoints we need to allow in our firewall or egress rules?</summary>
 
 There is no single published endpoint list. The cluster requires working outbound internet access (directly or via NAT) in addition to private access to cloud provider APIs — see the [network connectivity requirements](/cloud/reference/byoc/onboarding/customization-aws#ensure-network-connectivity). If your network policy requires an explicit inventory, contact support to review your setup.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -25,9 +25,17 @@ Expect roughly 45–90 minutes end to end. When provisioning stalls, the most co
 
 - The CloudFormation template or Terraform module was modified before applying it — for example, adding a `PermissionsBoundary`, or renaming the IAM role to satisfy a naming convention (on AWS it must be named exactly `ClickHouseManagementRole`). Apply the artifacts as provided — supported customizations are exposed as parameters, and any other change needs ClickHouse's approval first.
 - Organization-level policies (AWS SCPs, GCP organization policies such as `iam.allowedPolicyMemberDomains`, or Azure policies restricting role assignments) blocking role assumption or IAM bindings.
+- An external ID mismatch on the onboarding role (see the external ID question below).
 - Account quota limits (for example Elastic IPs or VPCs on AWS).
 
 Provisioning retries automatically and self-heals once the underlying issue is fixed. If your infrastructure remains stuck for more than a couple of hours, contact support.
+
+</details>
+
+<details>
+<summary>What value should we use for the external ID in the onboarding template?</summary>
+
+Use the external ID shown in the ClickHouse Cloud onboarding flow (the `ExternalId` parameter in CloudFormation, the `external_id` input in Terraform). Displaying the external ID in the console is rolling out gradually — if your onboarding screen doesn't show one, leave the CloudFormation parameter at its default, or ask your ClickHouse contact for the value to use with Terraform. Don't choose your own value: it must match what ClickHouse's automation expects, or the cross-account role can't be assumed and provisioning fails.
 
 </details>
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -23,7 +23,7 @@ Reach out to ClickHouse via the [contact form](https://clickhouse.com/cloud/brin
 
 Expect roughly 45–90 minutes end to end. When provisioning stalls, the most common causes are on the account side:
 
-- The CloudFormation template or Terraform module was modified before applying it (for example, adding a `PermissionsBoundary`). Apply the artifacts as provided — supported customizations are exposed as parameters.
+- The CloudFormation template or Terraform module was modified before applying it — for example, adding a `PermissionsBoundary`, or renaming the IAM role to satisfy a naming convention (on AWS it must be named exactly `ClickHouseManagementRole`). Apply the artifacts as provided — supported customizations are exposed as parameters, and any other change needs ClickHouse's approval first.
 - Organization-level policies (AWS SCPs, GCP organization policies such as `iam.allowedPolicyMemberDomains`, or Azure policies restricting role assignments) blocking role assumption or IAM bindings.
 - Account quota limits (for example Elastic IPs or VPCs on AWS).
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -14,7 +14,7 @@ doc_type: 'reference'
 <details>
 <summary>How do we get started with BYOC?</summary>
 
-Reach out to ClickHouse via the [contact form](https://clickhouse.com/cloud/bring-your-own-cloud), and the team will enable BYOC for your organization. You then prepare a dedicated cloud account (AWS account, GCP project) and follow the [standard onboarding guide](/cloud/reference/byoc/onboarding/standard). We strongly recommend a dedicated account or project used only for BYOC.
+Reach out to ClickHouse via the [contact form](https://clickhouse.com/cloud/bring-your-own-cloud), and the team will enable BYOC for your organization. You then prepare a dedicated cloud account (AWS account, GCP project, or Azure subscription) and follow the [standard onboarding guide](/cloud/reference/byoc/onboarding/standard). We strongly recommend a dedicated account, project, or subscription used only for BYOC.
 
 </details>
 
@@ -24,7 +24,7 @@ Reach out to ClickHouse via the [contact form](https://clickhouse.com/cloud/brin
 Expect roughly 45–90 minutes end to end. When provisioning stalls, the most common causes are on the account side:
 
 - The CloudFormation template or Terraform module was modified before applying it (for example, adding a `PermissionsBoundary`). Apply the artifacts as provided — supported customizations are exposed as parameters.
-- Organization-level policies (AWS SCPs, GCP organization policies such as `iam.allowedPolicyMemberDomains`) blocking role assumption or IAM bindings.
+- Organization-level policies (AWS SCPs, GCP organization policies such as `iam.allowedPolicyMemberDomains`, or Azure policies restricting role assignments) blocking role assumption or IAM bindings.
 - Account quota limits (for example Elastic IPs or VPCs on AWS).
 
 Provisioning retries automatically and self-heals once the underlying issue is fixed. If your infrastructure remains stuck for more than a couple of hours, contact support.
@@ -34,16 +34,16 @@ Provisioning retries automatically and self-heals once the underlying issue is f
 <details>
 <summary>Can BYOC use an existing VPC? What about shared VPCs?</summary>
 
-Yes — you can deploy into an existing VPC that lives in the **same** account or project as the BYOC infrastructure. See the customization guides for [AWS](/cloud/reference/byoc/onboarding/customization-aws) and [GCP](/cloud/reference/byoc/onboarding/customization-gcp).
+On AWS and GCP, you can deploy into an existing VPC that lives in the **same** account or project as the BYOC infrastructure. See the customization guides for [AWS](/cloud/reference/byoc/onboarding/customization-aws) and [GCP](/cloud/reference/byoc/onboarding/customization-gcp). Bringing your own VNet on Azure is not available today.
 
-Subnets shared from another account (AWS RAM) or a GCP Shared VPC host project are not supported today. The recommended pattern is a dedicated account or project for BYOC, connected to your existing network via VPC peering or PrivateLink / Private Service Connect. Note that with a customer-managed VPC, only the private load balancer is enabled by default (see [configuration](/cloud/reference/byoc/configurations)).
+Subnets shared from another account (AWS RAM) or a GCP Shared VPC host project are not supported. The recommended pattern is a dedicated account or project for BYOC, connected to your existing network via VPC peering, PrivateLink, Private Service Connect, or Azure Private Link. Note that with a customer-managed VPC, only the private load balancer is enabled by default (see [configuration](/cloud/reference/byoc/configurations)).
 
 </details>
 
 <details>
 <summary>Can BYOC be installed into an existing Kubernetes cluster?</summary>
 
-No. The Kubernetes cluster (EKS or GKE) is created and fully managed by ClickHouse. This is required so that ClickHouse can operate the platform reliably and keep it upgraded.
+No. The Kubernetes cluster (EKS, GKE, or AKS) is created and fully managed by ClickHouse. This is required so that ClickHouse can operate the platform reliably and keep it upgraded.
 
 </details>
 
@@ -61,21 +61,21 @@ In the Kubernetes cluster: it is possible with constraints — use your own node
 <details>
 <summary>Can I create multiple services in a single BYOC infrastructure?</summary>
 
-Yes. The infrastructure (including the Kubernetes cluster) only needs to be provisioned once for every cloud account and region combination, and all services you create in that region share it.
+Yes. The infrastructure (including the Kubernetes cluster) only needs to be provisioned once for every cloud account/project/subscription and region combination, and all services you create in that region share it.
 
 </details>
 
 <details>
 <summary>Which regions do you support for BYOC?</summary>
 
-All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. BYOC provisions across three availability zones, so regions with fewer than three zones and AWS Local Zones are not supported. If a region you need is not listed, contact your ClickHouse representative to discuss availability.
+All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. BYOC provisions across three availability zones, so regions with fewer than three zones and AWS Local Zones are not supported, and BYOC is not available in AWS China regions. If a region you need is not listed, contact your ClickHouse representative to discuss availability.
 
 </details>
 
 <details>
 <summary>Will there be some resource overhead? What are the resources needed to run services other than ClickHouse instances?</summary>
 
-Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, `aws-cluster-autoscaler`, Istio, and the monitoring stack.
+Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, the cluster autoscaler, Istio, and the monitoring stack.
 
 The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, in AWS we typically use a dedicated node group of about four `4xlarge` EC2 instances to run these workloads. In addition, each service runs a dedicated three-node ClickHouse Keeper ensemble, which is shared by all services in the same warehouse. See the [cost model](/cloud/reference/byoc/cost-model-aws) for details.
 
@@ -91,7 +91,14 @@ Service-level (vertical) autoscaling is on the roadmap. Available today: manual 
 <details>
 <summary>Which instance types does BYOC run on? Can we change the instance family?</summary>
 
-BYOC runs on a curated set of node groups rather than arbitrary instance types — on AWS, ARM-based (Graviton) memory-optimized families by default. Different instance families, CPU-to-memory ratios, or architectures can be provisioned on request through support; spot instances are not supported. See [configuration](/cloud/reference/byoc/configurations).
+BYOC runs on a curated set of node groups rather than arbitrary instance types — ARM-based, memory-optimized instances by default (Graviton on AWS). Different instance families, CPU-to-memory ratios, or architectures can be provisioned on request through support; spot instances are not supported. See [configuration](/cloud/reference/byoc/configurations).
+
+</details>
+
+<details>
+<summary>Can we run very small replicas to keep costs down?</summary>
+
+Each replica runs as one pod on its own node — node size is matched to the replica size, nodes are provisioned on demand, and multiple replicas are never packed onto one node. Very small replicas are therefore inefficient: a larger share of the hardware goes to overhead, and network and disk bandwidth scale with instance size. Sizes below what the console offers are custom requests through support.
 
 </details>
 
@@ -107,16 +114,16 @@ Yes. Warehouses (compute-compute separation) are supported in BYOC: multiple ser
 <details>
 <summary>Can we limit or revoke the permissions granted during installation?</summary>
 
-You can reduce the grants from the start: the onboarding template is parameterized, so you can withhold network write permissions when bringing your own VPC (`IncludeVPCWritePermissions=false`), withhold KMS permissions (off by default), and — in private preview on AWS — manage the IAM roles yourself (`IncludeIAMWritePermissions=false`, see [customer-managed IAM roles](/cloud/reference/byoc/onboarding/customization-aws)). The cross-account roles support an `ExternalId` condition to prevent confused-deputy access.
+You can reduce the grants from the start: the onboarding template is parameterized, so you can withhold network write permissions when bringing your own VPC (`IncludeVPCWritePermissions=false`) and — in private preview on AWS, enabled through support — manage the IAM roles yourself (`IncludeIAMWritePermissions=false`, see [customer-managed IAM roles](/cloud/reference/byoc/onboarding/customization-aws)). The cross-account roles support an `ExternalId` condition to prevent confused-deputy access.
 
-After provisioning, do not remove permissions from the management role unilaterally: ClickHouse continuously reconciles the infrastructure, and missing permissions break provisioning, upgrades, and support. To change the granted permissions or offboard entirely, coordinate with support (see the decommissioning question below).
+After provisioning, do not remove permissions from the management identity unilaterally: ClickHouse continuously reconciles the infrastructure, and missing permissions break provisioning, upgrades, and support. To change the granted permissions or offboard entirely, coordinate with support (see the decommissioning question below).
 
 </details>
 
 <details>
 <summary>What exactly can ClickHouse do in our cloud account? Can our security team review the permissions?</summary>
 
-All roles and their purposes are documented in the [privilege reference](/cloud/reference/byoc/reference/privilege). Write permissions are scoped: resource creation and mutation are restricted by the `clickhouse-byoc=true` resource tag and `clickhouse-cloud-*` name prefixes, so the management role cannot modify resources it did not create. The management role has **no object-level access to your data buckets** — object access is limited to in-cluster identities scoped to the ClickHouse workloads. Read permissions are broader because they are required for continuous reconciliation.
+All roles and identities and their purposes are documented in the [privilege reference](/cloud/reference/byoc/reference/privilege) for AWS, GCP, and Azure. Write permissions of the management identity (an IAM role on AWS, a service account on GCP, a service principal on Azure) are scoped by resource tags and name prefixes such as `clickhouse-cloud-*`, so it cannot modify resources it did not create, and it has **no object-level access to your data buckets** — object access is limited to in-cluster identities scoped to the ClickHouse workloads. Read permissions are broader because they are required for continuous reconciliation.
 
 ClickHouse can provide the rendered policy JSON for review and walk your security team through each permission on request.
 
@@ -151,18 +158,18 @@ By default, the Kubernetes API endpoint is public but restricted to ClickHouse's
 </details>
 
 <details>
-<summary>What is the size of the VPC IP range created?</summary>
+<summary>What is the size of the VPC/VNet IP range created?</summary>
 
-By default, we use `10.0.0.0/16` for BYOC VPC. We recommend reserving at least /22 for potential future scaling,
+By default, we use `10.0.0.0/16` for the BYOC VPC (AWS/GCP) or VNet (Azure). We recommend reserving at least /22 for potential future scaling,
 but if you prefer to limit the size, it is possible to use /23 if it is likely that you will be limited
 to 30 server pods.
 
 </details>
 
 <details>
-<summary>How does network communication work between BYOC VPC and S3?</summary>
+<summary>How does network communication work between the BYOC network and object storage?</summary>
 
-Traffic between your Customer BYOC VPC and S3 uses HTTPS (port 443) via the AWS S3 API for table data, backups, and logs. This traffic goes through an S3 gateway VPC endpoint, so it remains within the AWS network, doesn't traverse the public internet, and incurs no NAT gateway charges. On GCP, access to Google APIs similarly uses Private Google Access.
+On AWS, traffic between your Customer BYOC VPC and S3 uses HTTPS (port 443) via the AWS S3 API for table data, backups, and logs. This traffic goes through an S3 gateway VPC endpoint, so it remains within the AWS network, doesn't traverse the public internet, and incurs no NAT gateway charges. On GCP, access to Google APIs similarly uses Private Google Access. On Azure, data is stored in Azure Blob Storage accounts within your subscription.
 
 </details>
 
@@ -178,14 +185,14 @@ No. Table data blobs are stored in a shared layout without per-table paths, so o
 
 Client connections terminate at the load balancer on TLS ports: **8443** (HTTPS interface) and **9440** (native protocol over TLS); port 443 also routes to the HTTPS interface.
 
-Inside the VPC, cluster-internal communication uses the native protocol on port 9000, HTTP on port 8123, and interserver communication on port 9009 for replication and distributed queries. These internal ports and the ClickHouse Keeper ports are never exposed on any load balancer.
+Inside the network, cluster-internal communication uses the native protocol on port 9000, HTTP on port 8123, and interserver communication on port 9009 for replication and distributed queries. These internal ports and the ClickHouse Keeper ports are never exposed on any load balancer.
 
 </details>
 
 <details>
 <summary>Are our service endpoints exposed to the public internet? Can we go private-only?</summary>
 
-By default (with a ClickHouse-managed VPC), each service gets a public load balancer protected by an IP access list, plus a private load balancer reachable from your VPC and peered networks. IP filtering is enforced at the ingress proxy layer, so the load balancer ports may appear open in scans while connections from unlisted sources are rejected. The public endpoint can be disabled entirely once nothing depends on it. See [connectivity](/cloud/reference/byoc/connect).
+With a ClickHouse-managed VPC, each service gets a public load balancer protected by an IP access list by default; a private load balancer, reachable from your network and peered networks, can additionally be enabled through support. With a customer-managed VPC, the defaults are inverted and only the private load balancer is enabled. IP filtering is enforced at the ingress proxy layer, so the load balancer ports may appear open in scans while connections from unlisted sources are rejected. The public endpoint can be disabled entirely once nothing depends on it. The console's [Connection via selector](/cloud/reference/byoc/connect#connection-via) shows the endpoints for each connection path enabled for your service. See [connectivity](/cloud/reference/byoc/connect).
 
 </details>
 
@@ -197,9 +204,16 @@ Not today. Service endpoints are provisioned under `clickhouse-byoc.com` with Cl
 </details>
 
 <details>
-<summary>How do we set up AWS PrivateLink or GCP Private Service Connect?</summary>
+<summary>How do we set up AWS PrivateLink, GCP Private Service Connect, or Azure Private Link?</summary>
 
-Follow the network setup guides for [AWS](/cloud/reference/byoc/onboarding/network-aws) and [GCP](/cloud/reference/byoc/onboarding/network-gcp). Two things commonly missed: endpoint allowlisting is **per service**, so endpoints must be registered again for each new service, and DNS resolution for the private endpoint names must be configured on your side if you run your own DNS.
+Follow the network setup guides for [AWS](/cloud/reference/byoc/onboarding/network-aws) and [GCP](/cloud/reference/byoc/onboarding/network-gcp); for Azure deployments, Azure Private Link is supported — contact the ClickHouse team for setup assistance. Two things commonly missed: endpoint allowlisting is **per service**, so endpoints must be registered again for each new service, and DNS resolution for the private endpoint names must be configured on your side if you run your own DNS. Once set up, use the console's [Connection via selector](/cloud/reference/byoc/connect#connection-via) to copy the correct private endpoint hostname.
+
+</details>
+
+<details>
+<summary>Is there a list of endpoints we need to allow in our firewall or egress rules?</summary>
+
+There is no single published endpoint list. The cluster requires working outbound internet access (directly or via NAT) in addition to private access to cloud provider APIs — see the [network connectivity requirements](/cloud/reference/byoc/onboarding/customization-aws#ensure-network-connectivity). If your network policy requires an explicit inventory, contact support to review your setup.
 
 </details>
 
@@ -259,14 +273,14 @@ Backups form chains: a full backup followed by incrementals that depend on it. T
 <details>
 <summary>How can we monitor backup status ourselves?</summary>
 
-Two ways: the ClickHouse Cloud API backup endpoints, and the Prometheus counters exposed by the in-cluster monitoring stack (`backups_initiated_total`, `backups_completed_total`, `backups_failed_total`) — we recommend alerting on failures in your own monitoring. See [observability](/cloud/reference/byoc/observability).
+Two ways: the ClickHouse Cloud API backup endpoints, and the backup metrics (initiation, completion, and failure counters) exposed by the in-cluster monitoring stack — we recommend alerting on failures in your own monitoring. See [observability](/cloud/reference/byoc/observability).
 
 </details>
 
 <details>
 <summary>How do we meet disaster recovery requirements (RPO/RTO)?</summary>
 
-BYOC deploys across three availability zones, and writes are acknowledged only after object storage confirms them. For regional disaster recovery, backup frequency and destination can be configured to match your RPO and RTO targets, including backing up to a bucket in another region — contact support to set this up.
+BYOC deploys across three availability zones, and writes are acknowledged only after object storage confirms them. Cross-region replication is not available today, so regional disaster recovery is backup-based and the achievable RPO is bounded by your backup frequency. Backup frequency and destination can be configured to match your targets, including backing up to a bucket in another region — contact support to set this up.
 
 </details>
 
@@ -275,7 +289,7 @@ BYOC deploys across three availability zones, and writes are acknowledged only a
 <details>
 <summary>How do we integrate BYOC with our own monitoring and alerting?</summary>
 
-The monitoring stack (Prometheus, Grafana, AlertManager) runs inside your account, and you can consume it directly: query it over the PromQL API, federate it into your own Prometheus, or scrape the ClickHouse `/metrics_all` endpoint per service. There is no turnkey integration for third-party platforms such as Datadog today — integrate via their Prometheus-compatible ingestion. See [observability](/cloud/reference/byoc/observability) for endpoints and setup.
+The monitoring stack (Prometheus, Grafana, AlertManager) runs inside your account, and you can consume it directly over private connectivity: query it over the PromQL API, federate it into your own Prometheus, or scrape the ClickHouse `/metrics_all` endpoint per service. There is no turnkey integration for third-party platforms such as Datadog today — integrate via their Prometheus-compatible ingestion. See [observability](/cloud/reference/byoc/observability) for endpoints and setup.
 
 </details>
 
@@ -284,7 +298,7 @@ The monitoring stack (Prometheus, Grafana, AlertManager) runs inside your accoun
 <details>
 <summary>What do we pay for with BYOC?</summary>
 
-Two separate bills: ClickHouse Cloud charges based on the memory allocated to your services, and your cloud provider bills you directly for the underlying infrastructure at cost, with no markup. See the [cost model](/cloud/reference/byoc/cost-model-aws), [billable AWS services](/cloud/reference/byoc/billable-aws-services), and [AWS service limits](/cloud/reference/byoc/aws-service-limits).
+Two separate bills: ClickHouse Cloud charges based on the memory allocated to your services, and your cloud provider bills you directly for the underlying infrastructure at cost, with no markup. The detailed cost reference pages currently cover AWS: see the [cost model](/cloud/reference/byoc/cost-model-aws), [billable AWS services](/cloud/reference/byoc/billable-aws-services), and [AWS service limits](/cloud/reference/byoc/aws-service-limits).
 
 </details>
 
@@ -293,14 +307,14 @@ Two separate bills: ClickHouse Cloud charges based on the memory allocated to yo
 <details>
 <summary>Which cloud providers is BYOC available on?</summary>
 
-AWS and GCP are generally available. Azure is in private preview — contact your ClickHouse representative to join. See the [overview](/cloud/reference/byoc/overview) for current status.
+AWS, GCP, and Azure are all generally available. See the [overview](/cloud/reference/byoc/overview) for the supported features and regions on each cloud.
 
 </details>
 
 <details>
 <summary>How do we decommission a BYOC environment?</summary>
 
-Contact ClickHouse **before** deleting anything. The correct order is: ClickHouse deprovisions the services and infrastructure first, then you remove the onboarding stack and any remaining resources. Deleting resources or revoking the management role's permissions first severs the control-plane connection mid-flight and forces manual cleanup. All ClickHouse-created resources are tagged `clickhouse-byoc=true`, so you can enumerate them afterwards to verify nothing is left.
+Terminate your services and the BYOC infrastructure from the ClickHouse console — do not start by deleting resources or revoking permissions in your cloud provider console, which severs the control-plane connection mid-flight and forces manual cleanup. Once the console-driven termination completes, remove the onboarding stack (CloudFormation stack or Terraform module) and any remaining resources. All ClickHouse-created resources are tagged `clickhouse-byoc=true`, so you can enumerate them afterwards to verify nothing is left.
 
 </details>
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -34,7 +34,7 @@ Provisioning retries automatically and self-heals once the underlying issue is f
 <details>
 <summary>Can BYOC use an existing VPC? What about shared VPCs?</summary>
 
-On AWS and GCP, you can deploy into an existing VPC that lives in the **same** account or project as the BYOC infrastructure. See the customization guides for [AWS](/cloud/reference/byoc/onboarding/customization-aws) and [GCP](/cloud/reference/byoc/onboarding/customization-gcp). Bringing your own VNet on Azure is not available today.
+On AWS and GCP, you can deploy into an existing VPC that lives in the **same** account or project as the BYOC infrastructure. See the customization guides for [AWS](/cloud/reference/byoc/onboarding/customization-aws) and [GCP](/cloud/reference/byoc/onboarding/customization-gcp). Bringing your own VNet on Azure is coming soon.
 
 Subnets shared from another account (AWS RAM) or a GCP Shared VPC host project are not supported. The recommended pattern is a dedicated account or project for BYOC, connected to your existing network via VPC peering, PrivateLink, Private Service Connect, or Azure Private Link. Note that with a customer-managed VPC, only the private load balancer is enabled by default (see [configuration](/cloud/reference/byoc/configurations)).
 
@@ -68,7 +68,7 @@ Yes. The infrastructure (including the Kubernetes cluster) only needs to be prov
 <details>
 <summary>Which regions do you support for BYOC?</summary>
 
-All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. BYOC provisions across three availability zones, so regions with fewer than three zones and AWS Local Zones are not supported, and BYOC is not available in AWS China regions. If a region you need is not listed, contact your ClickHouse representative to discuss availability.
+All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. BYOC provisions across three availability zones, so regions with fewer than three zones and AWS Local Zones are not supported. If a region you need is not listed, contact your ClickHouse representative to discuss availability.
 
 </details>
 
@@ -77,14 +77,14 @@ All **public regions** listed in our [supported regions](https://clickhouse.com/
 
 Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, the cluster autoscaler, Istio, and the monitoring stack.
 
-The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, in AWS we typically use a dedicated node group of about four `4xlarge` EC2 instances to run these workloads. In addition, each service runs a dedicated three-node ClickHouse Keeper ensemble, which is shared by all services in the same warehouse. See the [cost model](/cloud/reference/byoc/cost-model-aws) for details.
+The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, we typically use a dedicated node group of about six `2xlarge` instances to run these workloads. In addition, each service runs a dedicated three-node ClickHouse Keeper ensemble, which is shared by all services in the same warehouse. See the [cost model](/cloud/reference/byoc/cost-model-aws) for details.
 
 </details>
 
 <details>
 <summary>Does BYOC support autoscaling?</summary>
 
-Service-level (vertical) autoscaling is on the roadmap. Available today: manual vertical and horizontal scaling through the console, automatic idling and wake-up for intermittent workloads, and automatic node-group scaling at the infrastructure level — you never manage nodes yourself. ClickHouse Keeper is monitored and scaled by ClickHouse.
+Service-level (vertical) autoscaling is on the roadmap. Available today: manual vertical and horizontal scaling through the console, scheduled scaling for predictable load patterns, automatic idling and wake-up for intermittent workloads, and automatic node-group scaling at the infrastructure level — you never manage nodes yourself. ClickHouse Keeper is monitored and scaled by ClickHouse.
 
 </details>
 
@@ -114,7 +114,7 @@ Yes. Warehouses (compute-compute separation) are supported in BYOC: multiple ser
 <details>
 <summary>Can we limit or revoke the permissions granted during installation?</summary>
 
-You can reduce the grants from the start: the onboarding template is parameterized, so you can withhold network write permissions when bringing your own VPC (`IncludeVPCWritePermissions=false`) and — in private preview on AWS, enabled through support — manage the IAM roles yourself (`IncludeIAMWritePermissions=false`, see [customer-managed IAM roles](/cloud/reference/byoc/onboarding/customization-aws)). The cross-account roles support an `ExternalId` condition to prevent confused-deputy access.
+You can reduce the grants from the start: the onboarding template is parameterized, so you can withhold network write permissions when bringing your own VPC (`IncludeVPCWritePermissions=false`) and — in private preview on AWS, enabled through support — manage the IAM roles yourself (`IncludeIAMWritePermissions=false`, see [customer-managed IAM roles](/cloud/reference/byoc/onboarding/customization-aws)). The cross-account roles support an `ExternalId` condition to prevent confused-deputy access. In addition, some permissions are required only for specific features and can be removed if you will never use those features — contact support if you need to scope down permissions beyond what the template parameters provide.
 
 After provisioning, do not remove permissions from the management identity unilaterally: ClickHouse continuously reconciles the infrastructure, and missing permissions break provisioning, upgrades, and support. To change the granted permissions or offboard entirely, coordinate with support (see the decommissioning question below).
 
@@ -124,8 +124,6 @@ After provisioning, do not remove permissions from the management identity unila
 <summary>What exactly can ClickHouse do in our cloud account? Can our security team review the permissions?</summary>
 
 All roles and identities and their purposes are documented in the [privilege reference](/cloud/reference/byoc/reference/privilege) for AWS, GCP, and Azure. Write permissions of the management identity (an IAM role on AWS, a service account on GCP, a service principal on Azure) are scoped by resource tags and name prefixes such as `clickhouse-cloud-*`, so it cannot modify resources it did not create, and it has **no object-level access to your data buckets** — object access is limited to in-cluster identities scoped to the ClickHouse workloads. Read permissions are broader because they are required for continuous reconciliation.
-
-ClickHouse can provide the rendered policy JSON for review and walk your security team through each permission on request.
 
 </details>
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -159,7 +159,7 @@ Only operational metadata: service and backup state events, usage metrics for bi
 <details>
 <summary>How does the ClickHouse control plane reach the Kubernetes API in our account? Is Tailscale required?</summary>
 
-By default, the Kubernetes API endpoint is public but restricted to ClickHouse's NAT IP addresses. For private-only connectivity, two options exist: Tailscale (outbound-only, used by default for troubleshooting access) and, on AWS, a fully private path via VPC Lattice (private preview). See [network security](/cloud/reference/byoc/reference/network_security) and [configuration](/cloud/reference/byoc/configurations). Do not remove the ClickHouse IP allowlist entries from the API endpoint — the control plane needs them to manage the cluster.
+By default, the Kubernetes API endpoint is public but restricted to ClickHouse's NAT IP addresses. For private-only connectivity, two options exist: Tailscale (outbound-only, used by default for troubleshooting access) and, on AWS, a fully private path via VPC Lattice (private preview). Note that this applies only to the Kubernetes API: cloud provider API calls (for example EKS and EC2 on AWS) originate from ClickHouse Cloud's network via cross-account role assumption and can never be routed through Tailscale — see [cloud provider APIs vs the Kubernetes API](/cloud/reference/byoc/reference/network_security#cloud-api-vs-kubernetes-api) and [configuration](/cloud/reference/byoc/configurations). Do not remove the ClickHouse IP allowlist entries from the API endpoint — the control plane needs them to manage the cluster.
 
 </details>
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
@@ -21,6 +21,24 @@ The ClickHouse Cloud control plane maintains several types of connections to ope
 | **Troubleshooting — ClickHouse service**     | Tailscale                                       | ClickHouse engineers access the ClickHouse service (e.g., system tables) for diagnostics via Tailscale.                                                                                         |
 | **Troubleshooting — Kubernetes API server**  | Tailscale                                       | ClickHouse engineers access the Kubernetes API server for cluster diagnostics via Tailscale.                                                                                                           |
 
+## Cloud provider APIs vs the Kubernetes API {#cloud-api-vs-kubernetes-api}
+
+Two distinct control paths are easy to conflate. They differ in where the traffic originates, how it authenticates, and whether Tailscale applies:
+
+| | Cloud provider APIs | Kubernetes API server |
+| --- | --- | --- |
+| **What it manages** | Cloud resources: the Kubernetes cluster itself, node groups, load balancers, storage buckets, DNS | Workloads inside the cluster: ClickHouse pods, operators, and their configuration |
+| **Traffic destination** | The cloud provider's public API endpoints (for example `eks.amazonaws.com`, `ec2.amazonaws.com`) — this traffic never enters your VPC/VNet | Your cluster's API endpoint in your account |
+| **Authentication** | AWS: cross-account `sts:AssumeRole` into `ClickHouseManagementRole` and the per-infrastructure management role, protected by an external ID. GCP: service account impersonation (no keys). Azure: federated identity for the ClickHouse service principal (no credentials exchanged) | Short-lived Kubernetes credentials issued through the cloud provider's API (for example `eks:GetToken` using the assumed role) |
+| **Tailscale applicability** | **None.** These calls go from ClickHouse Cloud's network directly to the cloud provider and cannot be routed through Tailscale or through your network | Public endpoint restricted to ClickHouse egress IPs by default; can be switched to private access via Tailscale or, on AWS, VPC Lattice |
+| **Your audit trail** | AWS CloudTrail (or the GCP/Azure equivalents) in your account records every call with the assumed identity | Kubernetes audit logs on the cluster |
+
+In short: only Kubernetes API and troubleshooting traffic can use Tailscale. Cloud provider API calls always originate from ClickHouse Cloud's network and terminate at the provider's endpoints — routing them through Tailscale isn't possible, because they never enter your network in the first place.
+
+### Network-origin permission boundaries {#network-origin-permission-boundaries}
+
+If your organization restricts IAM role assumption or cloud API calls by network origin (for example, AWS SCPs or role trust conditions using `aws:SourceIp` or `aws:SourceVpc`), those conditions will block ClickHouse's automation: the calls legitimately originate from ClickHouse Cloud's network, not yours. Exempt the ClickHouse-created roles from such conditions, or contact ClickHouse for the current egress IP ranges if you must allowlist by origin.
+
 The following section describes how the **Tailscale** private network is used for troubleshooting and optional management access.
 
 ## Tailscale Private Network {#tailscale-private-network}


### PR DESCRIPTION
## Summary

Refreshes the BYOC FAQ (`/cloud/reference/byoc/reference/faq`), which had drifted from the current state of the product and covered only 10 questions. This PR corrects inaccurate answers and expands the page to 29 entries based on the questions customers actually ask during POCs and operations. Answers stay short and link to the canonical BYOC pages (onboarding, connectivity, configuration, operations, observability, privilege/network-security/data-access references) instead of duplicating them.

### Corrections to existing answers
- **Permission revocation**: replaced "this is currently not possible" with the actual options — onboarding template parameters (`IncludeVPCWritePermissions`, `IncludeIAMWritePermissions` (private preview), `IncludeKMSPermissions`), `ExternalId` support — plus a warning that unilaterally removing permissions breaks reconciliation.
- **Ports**: the old answer presented plaintext 9000/8123 as the communication ports. Corrected to client-facing TLS ports (8443/9440) at the load balancer, with 9000/8123/9009 and Keeper ports internal-only and never exposed.
- **Regions**: added the three-AZ requirement (single-AZ regions and AWS Local Zones unsupported) and guidance for unlisted regions.
- **Resource overhead**: added the per-service ClickHouse Keeper ensemble and a cost-model link.
- **Maintenance**: now describes release channels and rolling make-before-break upgrades.
- **Uptime SLA**: notes that running services are independent of the control plane.
- De-AWS-ified wording where the answer applies to all clouds (e.g. "this single EKS cluster" → "a single BYOC infrastructure").

### New sections/questions
- **Onboarding and provisioning**: getting started, provisioning duration + common stuck causes, existing/shared VPCs, existing Kubernetes clusters, running customer workloads alongside.
- **Compute and scaling**: autoscaling status, instance types, warehouses.
- **Network and security**: what ClickHouse can do in the account, employee data access, data egress, control-plane connectivity (Tailscale / VPC Lattice), direct bucket access, public vs private endpoints, custom DNS, PrivateLink/PSC per-service allowlisting, security-scanner findings, CMEK.
- **Upgrades and maintenance**: Kubernetes upgrade ownership and impact.
- **Backups and disaster recovery**: storage location, backup contents, chain/billing mechanics, self-monitoring, RPO/RTO.
- **Observability**, **Cost**, **Availability and lifecycle** (cloud availability, safe decommissioning).

Existing section anchors (`#compute`, `#network-and-security`, `#uptime-sla`) are preserved.

`markdownlint-cli2` passes on the file.

## Checklist
- [x] No URL changes (slug unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update 2026-07-22

Rebased onto main (which now marks Azure GA and reworked the connect page) and refreshed the content:

- **Azure GA alignment**: availability answer now lists AWS/GCP/Azure as GA; Azure subscription/AKS/VNet/Azure Private Link and the privilege reference's Azure section are reflected across onboarding, cluster, VPC-range, object-storage, and PrivateLink answers. BYO-VNet is called out as not available on Azure.
- **Review feedback**: decommissioning answer rewritten around console-driven termination (terminate services and infrastructure in the ClickHouse console first, then remove the onboarding stack).
- **Correction**: private load balancer is *not* enabled by default with a ClickHouse-managed VPC (matches the configuration page's defaults table); answers now also point to the new [Connection via selector](/cloud/reference/byoc/connect#connection-via).
- **Dropped**: the KMS onboarding parameter mention (not documented on main) and hard-coded backup metric names (kept as generic backup counters).
- **New questions**: small-replica economics (one pod per node, no bin-packing) and firewall/egress endpoint requirements — both recurring asks.
