### PR TITLE
Add performance note for dbt reuse_connections: false

### DIFF
--- a/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
+++ b/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
@@ -51,7 +51,7 @@ your_profile_name:
       local_db_prefix: [<empty string>] # Database prefix of local tables on shards for distributed materializations. If empty, it uses the same database as the distributed table.
       allow_automatic_deduplication: [False] # Enable ClickHouse automatic deduplication for Replicated tables
       tcp_keepalive: [False] # Native client only, specify TCP keepalive configuration. Specify custom keepalive settings as [idle_time_sec, interval_sec, probes].
-      reuse_connections: [True] # Re-use the same connection across models. Set to `False` to close the connection at the end of each model — useful on multi-replica ClickHouse Cloud services where the load balancer routes by TCP connection.
+      reuse_connections: [True] # Re-use the same connection across models. Set to `False` to close the connection at the end of each model — useful on multi-replica ClickHouse Cloud services where the load balancer routes by TCP connection. Note: disabling connection reuse adds a new TCP/TLS handshake per model, which increases total `dbt run` wall time (typically ~200-500 ms per model). Combine with `threads > 1` for the best balance between distribution and throughput.
       custom_settings: [{}] # A dictionary/mapping of custom ClickHouse settings for the connection - default is empty.
       database_engine: '' # Database engine to use when creating new ClickHouse schemas (databases).  If not set (the default), new databases will use the default ClickHouse database engine (usually Atomic).
       threads: [1] # Number of threads to use when running queries. Before setting it to a number higher than 1, make sure to read the [read-after-write consistency](#read-after-write-consistency) section.


### PR DESCRIPTION
## Summary

Follow-up to #6378. Adds a performance note to the `reuse_connections` documentation clarifying that:

1. Disabling connection reuse adds ~200-500ms of TCP/TLS handshake overhead per model
2. Users should combine with `threads > 1` for the best balance between replica distribution and throughput

This sets the right expectation for users enabling the feature on ClickHouse Cloud.

## Checklist
- [x] Documentation-only change