### PR TITLE
feat: dbt server host name

### DIFF
--- a/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
+++ b/docs/integrations/data-ingestion/etl-tools/dbt/features-and-configurations.md
@@ -40,6 +40,7 @@ your_profile_name:
       secure: [False] # Use TLS (native protocol) or HTTPS (http protocol)
       client_cert: [null] # Path to a TLS client certificate in .pem format
       client_cert_key: [null] # Path to the private key for the TLS client certificate
+      server_host_name: [null] # Override the TLS SNI and hostname verification target. Useful when connecting via a DNS alias (e.g. an internal CNAME or AWS PrivateLink endpoint) where the TLS certificate is issued for a different hostname than the one used in `host`.
       retries: [1] # Number of times to retry a "retriable" database exception (such as a 503 'Service Unavailable' error)
       compression: [<empty string>] # Use gzip compression if truthy (http), or compression type for a native connection
       connect_timeout: [10] # Timeout in seconds to establish a connection to ClickHouse


### PR DESCRIPTION
## Summary

Documents the new `server_host_name` profile option added in ClickHouse/dbt-clickhouse#687.

Adds a single line to the profile YAML reference in the dbt features and configurations page, grouped with the other TLS options (`verify`, `secure`, `client_cert`, `client_cert_key`).

## Checklist
- [x] Delete items not relevant to your PR
- [ ] ~~URL changes should add a redirect to the old URL via vercel.json~~ — no URL changes
- [ ] ~~If adding a new integration page, also add an entry to the integrations list~~ — existing page only