### PR TITLE
BYOC: Azure GA wording and v2 CloudFormation template link

### DIFF
--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/01_overview.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/01_overview.md
@@ -25,7 +25,7 @@ BYOC is designed specifically for large-scale deployments, and requires customer
 **Supported Cloud Service Providers:**
 * AWS (GA)
 * GCP (GA)
-* Azure (Private Preview). Please join the waitlist [here](https://clickhouse.com/cloud/bring-your-own-cloud) if you're interested.
+* Azure (GA)
 
 **Supported Cloud Regions:**
 All **public regions** listed in our [supported regions](https://clickhouse.com/docs/cloud/reference/supported-regions) documentation are available for BYOC deployments. Private regions aren't currently supported.
@@ -50,6 +50,7 @@ All **public regions** listed in our [supported regions](https://clickhouse.com/
 - **Secure S3**
 - **[AWS PrivateLink](https://aws.amazon.com/privatelink/)**
 - **[GCP Private Service Connect](https://docs.cloud.google.com/vpc/docs/private-service-connect)**
+- **[Azure Private Link](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview)**
 - **Integrations**: See the full list on [this page](/integrations).
 
 ### Planned features (currently unsupported) {#planned-features-currently-unsupported}

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/02_architecture.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/02_architecture.md
@@ -72,12 +72,12 @@ The BYOC deployment model requires two essential components to ensure reliable o
 ClickHouse Cloud needs cross-account IAM permissions to provision and manage resources within your cloud account. This enables ClickHouse to:
 
 - **Provision infrastructure**: Create and configure VPCs, subnets, security groups, and other networking components
-- **Manage Kubernetes clusters**: Deploy and maintain EKS/GKE clusters, node groups, and cluster components
+- **Manage Kubernetes clusters**: Deploy and maintain EKS/GKE/AKS clusters, node groups, and cluster components
 - **Create storage resources**: Provision S3 buckets or equivalent object storage for data and backups
 - **Manage IAM roles**: Create and configure IAM roles for Kubernetes service accounts and supporting services
 - **Operate supporting services**: Deploy and manage monitoring stacks, ingress controllers, and other infrastructure components
 
-These permissions are granted through a cross-account IAM role (AWS) or service account (GCP) that you create during the initial onboarding process. The role follows the principle of least privilege, with permissions scoped to only what's necessary for BYOC operations.
+These permissions are granted through a cross-account IAM role (AWS), service account (GCP), or multi-tenant service principal (Azure) that you create during the initial onboarding process. The role follows the principle of least privilege, with permissions scoped to only what's necessary for BYOC operations.
 
 For detailed information about the specific permissions required, see the [BYOC Privilege Reference](/cloud/reference/byoc/reference/privilege).
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/01_standard.md
@@ -45,7 +45,7 @@ Prepare a fresh AWS account, GCP project, or Azure subscription under your organ
 
 ### Account/project/subscription setup {#account-setup}
 
-The initial BYOC setup can be performed using a [CloudFormation template (AWS)](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml), a [Terraform module (GCP)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/gcp), or a [Terraform module (Azure)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/azure). It creates a highly privileged identity (IAM role/service account/service principal), enabling BYOC controllers from ClickHouse Cloud to manage your infrastructure.
+The initial BYOC setup can be performed using a [CloudFormation template (AWS)](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc_v2.yaml), a [Terraform module (GCP)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/gcp), or a [Terraform module (Azure)](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/azure). It creates a highly privileged identity (IAM role/service account/service principal), enabling BYOC controllers from ClickHouse Cloud to manage your infrastructure.
 
 <Image img={byoc_onboarding_2} size="lg" alt="BYOC initialize account" background='black'/>
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/02_customization/01_aws.md
@@ -46,7 +46,7 @@ Ensure your VPC has working DNS resolution and doesn't block, interfere with, or
 
 ### Configure your AWS account {#configure-aws-account}
 
-The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml) or a Terraform module (see below).
+The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc_v2.yaml) or a Terraform module (see below).
 
 When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` parameter to `false` to ensure ClickHouse Cloud doesn't receive permissions to modify your customer-managed VPC.
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/03_network_setup/index.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/03_onboarding/03_network_setup/index.md
@@ -5,10 +5,12 @@ sidebar_label: 'Private networking setup'
 hide_title: true
 description: 'Table of contents page for the ClickHouse Cloud BYOC Private Networking Setup section'
 doc_type: 'landing-page'
-keywords: ['BYOC', 'cloud', 'bring your own cloud', 'vpc peering', 'privatelink', 'private service connect']
+keywords: ['BYOC', 'cloud', 'bring your own cloud', 'vpc peering', 'privatelink', 'private service connect', 'azure private link']
 ---
 
 
-ClickHouse BYOC supports various private networking options to enhance security and enable direct connectivity for your services. This guide walks you through the recommended approaches for securely connecting ClickHouse Cloud deployments in your own AWS or GCP account to other networks or services, such as your internal applications or analytics tools. We cover options such as VPC Peering, AWS PrivateLink, and GCP Private Service Connect, and outline the main steps and considerations for each.
+ClickHouse BYOC supports various private networking options to enhance security and enable direct connectivity for your services. This guide walks you through the recommended approaches for securely connecting ClickHouse Cloud deployments in your own AWS account, GCP project, or Azure subscription to other networks or services, such as your internal applications or analytics tools. We cover options such as VPC Peering, AWS PrivateLink, and GCP Private Service Connect, and outline the main steps and considerations for each.
+
+For Azure deployments, Azure Private Link is supported — contact the ClickHouse team for setup assistance.
 
 If you require a private network connection to your ClickHouse BYOC deployment, follow the steps in the guides or consult ClickHouse Support for assistance with more advanced scenarios.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/04_connectivity.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/04_connectivity.md
@@ -2,8 +2,8 @@
 title: 'Connect to ClickHouse'
 slug: /cloud/reference/byoc/connect
 sidebar_label: 'Connect to ClickHouse'
-keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connect to clickhouse', 'load balancer', 'privatelink']
-description: 'Connect to your BYOC ClickHouse services via public, private, or PrivateLink endpoints'
+keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connect to clickhouse', 'load balancer', 'privatelink', 'private service connect', 'azure private link']
+description: 'Connect to your BYOC ClickHouse services via public or private load balancers, or private endpoints (PrivateLink, Private Service Connect, Private Link)'
 doc_type: 'reference'
 ---
 
@@ -52,6 +52,8 @@ For example:
 sb9jmrq2ne.asf3kcggao.ap-southeast-1.aws.clickhouse-byoc.com
 ```
 
+The `aws` segment reflects your cloud provider — it is `gcp` or `azure` for deployments on those clouds.
+
 ### IP Filtering {#public-ip-filtering}
 
 IP filtering (IP Access List) is **strongly recommended** when using a public load balancer to restrict access to authorized IP addresses or CIDR ranges.
@@ -60,12 +62,12 @@ For detailed information about IP filtering, see the [IP Access List documentati
 
 ## Private Load Balancer {#private-load-balancer}
 
-A private load balancer provides internal access to your ClickHouse services, accessible only from within your connected networks (e.g., peered VPCs). This is the default configuration when using a customer-managed VPC.
+A private load balancer provides internal access to your ClickHouse services, accessible only from within your connected networks (e.g., peered VPCs/VNets). This is the default configuration when using a customer-managed VPC.
 
 ### Overview {#private-load-balancer-overview}
 
 - **Access**: Accessible only from within your private network infrastructure
-- **Use case**: Ideal for applications running in the same cloud environment or connected via VPC peering
+- **Use case**: Ideal for applications running in the same cloud environment or connected via VPC/VNet peering
 - **Security**: Traffic stays within your private network, no public internet exposure
 
 ### Connecting via Private Load Balancer {#connecting-via-private-load-balancer}
@@ -74,8 +76,8 @@ To connect using the private endpoint:
 
 1. **Enable private load balancer** (if not already enabled). Contact ClickHouse Support if you need to [enable a private load balancer](/cloud/reference/byoc/configurations#load-balancers) for your deployment.
 2. **Ensure network connectivity**:
-   - For VPC peering: Complete the VPC peering setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network))
-   - For other private networks: Ensure routing is configured to reach the BYOC VPC
+   - For VPC/VNet peering: Complete the peering setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network))
+   - For other private networks: Ensure routing is configured to reach the BYOC VPC/VNet
 3. **Obtain your private endpoint**: 
    The private endpoint is available in the ClickHouse Cloud console in the "Connect" section of your service. The private endpoint follows the same format as the public endpoint, but with a `-private` suffix added to the service ID portion. For example:
    - **Public endpoint**: `sb9jmrq2ne.asf3kcggao.ap-southeast-1.aws.clickhouse-byoc.com`
@@ -107,14 +109,16 @@ AWS PrivateLink, GCP Private Service Connect, and Azure Private Link provide the
   - Simplified network architecture
   - Enhanced security and compliance posture
 
-### Connecting via PrivateLink/Private Service Connect {#connecting-via-privatelink}
+### Connecting via a private endpoint {#connecting-via-privatelink}
 
-Complete the PrivateLink, Private Service Connect, or Private Link setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network)). Once configured, you can connect to your ClickHouse service using a PrivateLink-specific endpoint format. The PrivateLink endpoint includes a `vpce` subdomain to indicate it routes through the VPC endpoint. DNS resolution in your VPC automatically routes traffic through the PrivateLink endpoint.
+Complete the PrivateLink, Private Service Connect, or Private Link setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network)). Once configured, you can connect to your ClickHouse service using a dedicated private-endpoint hostname. DNS resolution in your VPC/VNet automatically routes traffic through the private endpoint.
 
-The PrivateLink endpoint format is similar to the public endpoint, but includes a `vpce` subdomain between the service subdomain and BYOC infrastructure subdomain. For example:
+The private-endpoint hostname is similar to the public endpoint, but adds a cloud-specific label between the service subdomain and the BYOC infrastructure subdomain — `vpce` on AWS, `p` on GCP, and `privatelink` on Azure. For example:
 
-- **Public endpoint**: `h5ju65kv87.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
-- **PrivateLink endpoint**: `h5ju65kv87.vpce.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
+- **Public endpoint (AWS)**: `h5ju65kv87.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
+- **PrivateLink endpoint (AWS)**: `h5ju65kv87.vpce.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
+- **Private Service Connect endpoint (GCP)**: `h5ju65kv87.p.mhp0y4dmph.us-central1.gcp.clickhouse-byoc.com`
+- **Private Link endpoint (Azure)**: `h5ju65kv87.privatelink.mhp0y4dmph.westus3.azure.clickhouse-byoc.com`
 
 Once the endpoint is set up and allowlisted, select **PrivateLink** (**Private Service Connect** on GCP, **Private Link** on Azure) from the **Connection via** dropdown in the **Connect** dialog to copy the private-endpoint connection details directly.
 
@@ -138,7 +142,7 @@ If you're experiencing connection issues:
 
 1. **Verify endpoint accessibility**: Ensure you're using the correct endpoint (public vs. private)
 2. **Check IP filters**: For public load balancers, verify your IP address is in the allow list
-3. **Verify network connectivity**: For private connections, ensure VPC peering or PrivateLink is properly configured
+3. **Verify network connectivity**: For private connections, ensure VPC/VNet peering or the private endpoint is properly configured
 4. **Check security groups**: For private load balancers, verify security group rules allow traffic from your source network
 4. **Check security groups**: For PrivateLink, Private Service Connect, or Private Link, verify the endpoint ID has been added to the allowlist of the ClickHouse service
 5. **Review authentication**: Ensure you're using correct credentials (username and password)

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/04_connectivity.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/04_connectivity.md
@@ -11,7 +11,7 @@ import Image from '@theme/IdealImage';
 import byoc_connect_1 from '@site/static/images/cloud/reference/byoc-connect-1.png';
 import byoc_connect_via from '@site/static/images/cloud/reference/byoc-connect-via.png';
 
-This page describes the different ways to connect to your ClickHouse services in BYOC. You can choose from public load balancers, private load balancers, or PrivateLink/Private Service Connect endpoints based on your security and networking requirements.
+This page describes the different ways to connect to your ClickHouse services in BYOC. You can choose from public load balancers, private load balancers, or private endpoints (AWS PrivateLink, GCP Private Service Connect, or Azure Private Link) based on your security and networking requirements.
 
 ## Selecting a connection path in the console {#connection-via}
 
@@ -21,7 +21,7 @@ For BYOC services, the **Connect** dialog includes a **Connection via** dropdown
 
 - **Public load balancer** — the internet-facing endpoint.
 - **Private load balancer** — the internal endpoint, reached over VPC peering or connected networks. Listed only when a [private load balancer](#private-load-balancer) is enabled for your infrastructure.
-- **PrivateLink** (AWS) / **Private Service Connect** (GCP) — the cloud provider's private-endpoint hostname. Listed only when [PrivateLink or Private Service Connect](#privatelink-or-private-service-connect) is enabled.
+- **PrivateLink** (AWS) / **Private Service Connect** (GCP) / **Private Link** (Azure) — the cloud provider's private-endpoint hostname. Listed only when a [private endpoint](#privatelink-or-private-service-connect) is enabled.
 
 Selecting a path updates the hostname in every connection example in the dialog — the HTTPS (`curl`) command, the native client, JDBC, MySQL, and the language-client snippets (Python, Node.js, Java, Go, and C#) — so you can copy a ready-to-use command for the exact path you need without editing the hostname by hand.
 
@@ -93,9 +93,9 @@ For AWS deployments, the private load balancer's security group controls which n
 
 For more details, see [Private Load Balancer Security Group configuration](https://clickhouse.com/docs/cloud/reference/byoc/configurations#private-load-balancer-security-group).
 
-## PrivateLink or Private Service Connect {#privatelink-or-private-service-connect}
+## PrivateLink, Private Service Connect, or Private Link {#privatelink-or-private-service-connect}
 
-AWS PrivateLink and GCP Private Service Connect provide the most secure connectivity option, allowing you to access ClickHouse services privately without VPC peering or internet gateways.
+AWS PrivateLink, GCP Private Service Connect, and Azure Private Link provide the most secure connectivity option, allowing you to access ClickHouse services privately without VPC/VNet peering or internet gateways.
 
 ### Overview {#privatelink-overview}
 
@@ -109,18 +109,18 @@ AWS PrivateLink and GCP Private Service Connect provide the most secure connecti
 
 ### Connecting via PrivateLink/Private Service Connect {#connecting-via-privatelink}
 
-Complete the PrivateLink or Private Service Connect setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network)). Once configured, you can connect to your ClickHouse service using a PrivateLink-specific endpoint format. The PrivateLink endpoint includes a `vpce` subdomain to indicate it routes through the VPC endpoint. DNS resolution in your VPC automatically routes traffic through the PrivateLink endpoint.
+Complete the PrivateLink, Private Service Connect, or Private Link setup (see [Private Networking Setup](/cloud/reference/byoc/onboarding/network)). Once configured, you can connect to your ClickHouse service using a PrivateLink-specific endpoint format. The PrivateLink endpoint includes a `vpce` subdomain to indicate it routes through the VPC endpoint. DNS resolution in your VPC automatically routes traffic through the PrivateLink endpoint.
 
 The PrivateLink endpoint format is similar to the public endpoint, but includes a `vpce` subdomain between the service subdomain and BYOC infrastructure subdomain. For example:
 
 - **Public endpoint**: `h5ju65kv87.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
 - **PrivateLink endpoint**: `h5ju65kv87.vpce.mhp0y4dmph.us-west-2.aws.clickhouse-byoc.com`
 
-Once the endpoint is set up and allowlisted, select **PrivateLink** (or **Private Service Connect** on GCP) from the **Connection via** dropdown in the **Connect** dialog to copy the private-endpoint connection details directly.
+Once the endpoint is set up and allowlisted, select **PrivateLink** (**Private Service Connect** on GCP, **Private Link** on Azure) from the **Connection via** dropdown in the **Connect** dialog to copy the private-endpoint connection details directly.
 
 ### Endpoint ID Allowlist {#endpoint-id-allowlist}
 
-In order to use PrivateLink or Private Service Connect, the Endpoint ID of your client connection must be explicitly allowed for each ClickHouse service. Please contact ClickHouse Support and provide your Endpoint IDs so they can be added to the service allowlist.
+In order to use PrivateLink, Private Service Connect, or Private Link, the Endpoint ID of your client connection must be explicitly allowed for each ClickHouse service. Please contact ClickHouse Support and provide your Endpoint IDs so they can be added to the service allowlist.
 
 For detailed setup instructions, see the [Private Networking Setup guide](/cloud/reference/byoc/onboarding/network).
 
@@ -130,7 +130,7 @@ For detailed setup instructions, see the [Private Networking Setup guide](/cloud
 |------------------|----------------|---------------------|----------|
 | **Public Load Balancer** | Medium (with IP filtering) | Internet access | Applications/users from various locations |
 | **Private Load Balancer** | High | VPC peering or private network | Applications in same cloud environment |
-| **PrivateLink/Private Service Connect** | Highest | Cloud provider managed service | Enterprise deployments requiring maximum isolation |
+| **PrivateLink/Private Service Connect/Private Link** | Highest | Cloud provider managed service | Enterprise deployments requiring maximum isolation |
 
 ## Troubleshooting Connection Issues {#troubleshooting}
 
@@ -140,6 +140,6 @@ If you're experiencing connection issues:
 2. **Check IP filters**: For public load balancers, verify your IP address is in the allow list
 3. **Verify network connectivity**: For private connections, ensure VPC peering or PrivateLink is properly configured
 4. **Check security groups**: For private load balancers, verify security group rules allow traffic from your source network
-4. **Check security groups**: For PrivateLink or Private Service Connect, verify the endpoint ID has been added to the allowlist of the ClickHouse service
+4. **Check security groups**: For PrivateLink, Private Service Connect, or Private Link, verify the endpoint ID has been added to the allowlist of the ClickHouse service
 5. **Review authentication**: Ensure you're using correct credentials (username and password)
 6. **Contact Support**: If issues persist, contact ClickHouse Support

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/05_configuration.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/05_configuration.md
@@ -46,9 +46,9 @@ To set up the security group for your private load balancer:
 All changes to private load balancer security groups must be performed by ClickHouse Support. This ensures configuration consistency and avoids conflicts within the ClickHouse Cloud-managed environment.
 :::
 
-## PrivateLink or Private Service Connect {#privatelink-or-private-service-connect}
+## PrivateLink, Private Service Connect, or Private Link {#privatelink-or-private-service-connect}
 
-For maximum network isolation and security, BYOC deployments can use **AWS PrivateLink** or **GCP Private Service Connect**. These options allow your applications to connect privately to ClickHouse Cloud services without requiring VPC peering or exposing endpoints to the public internet.
+For maximum network isolation and security, BYOC deployments can use **AWS PrivateLink**, **GCP Private Service Connect**, or **Azure Private Link**. These options allow your applications to connect privately to ClickHouse Cloud services without requiring VPC/VNet peering or exposing endpoints to the public internet.
 
 For step-by-step setup instructions, see the [Private Networking Setup guide](/cloud/reference/byoc/onboarding/network).
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/06_observability.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/06_observability.md
@@ -51,17 +51,19 @@ To connect to the built-in Prometheus stack:
 
 1. **Contact ClickHouse Support** to enable the private load balancer for your BYOC environment.
 2. **Request the Prometheus endpoint URL** from ClickHouse Support.
-3. **Verify private network connectivity** to the Prometheus endpoint—typically via VPC peering or other private network setup.
+3. **Verify private network connectivity** to the Prometheus endpoint—typically via VPC/VNet peering or other private network setup.
 
 Endpoint formats vary by connectivity type:
 
 | Connectivity | Endpoint format |
 |---|---|
-| VPC / VPC peering | `https://prometheus-internal.<subdomain>.<region>.<cloud>.clickhouse-byoc.com` |
-| PrivateLink | `https://prometheus.vpce.<subdomain>.<region>.<cloud>.clickhouse-byoc.com` |
+| VPC/VNet peering | `https://prometheus-internal.<subdomain>.<region>.<cloud>.clickhouse-byoc.com` |
+| Private endpoint | `https://prometheus.<label>.<subdomain>.<region>.<cloud>.clickhouse-byoc.com` |
+
+`<cloud>` is `aws`, `gcp`, or `azure`. For private endpoints, `<label>` is cloud-specific: `vpce` on AWS, `p` on GCP, and `privatelink` on Azure.
 
 :::note
-The Prometheus stack URL is only accessible via private network connections and doesn't require authentication. Access is restricted to networks that can reach your BYOC VPC through VPC peering or other private connectivity options.
+The Prometheus stack URL is only accessible via private network connections and doesn't require authentication. Access is restricted to networks that can reach your BYOC VPC/VNet through peering or other private connectivity options.
 :::
 
 ### Integrating with Your Monitoring Tools {#prometheus-stack-integration}

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/07_operations.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/07_operations.md
@@ -28,7 +28,7 @@ Examples of cloud services that are upgraded include:
 
 ## Kubernetes Cluster Upgrade Process {#k8s-upgrade-process}
 
-The Kubernetes cluster (EKS for AWS, GKE for GCP) that hosts your ClickHouse services requires periodic upgrades to maintain security, compatibility, and access to new features. ClickHouse Cloud manages all Kubernetes cluster upgrades for your BYOC deployment, ensuring your cluster stays current with the supported versions.
+The Kubernetes cluster (EKS for AWS, GKE for GCP, AKS for Azure) that hosts your ClickHouse services requires periodic upgrades to maintain security, compatibility, and access to new features. ClickHouse Cloud manages all Kubernetes cluster upgrades for your BYOC deployment, ensuring your cluster stays current with the supported versions.
 
 ### Cluster Upgrade Types {#cluster-upgrade-types}
 
@@ -50,4 +50,4 @@ Kubernetes cluster upgrades are scheduled in coordination with you through Click
 
 ### Version Support {#version-support}
 
-ClickHouse Cloud maintains Kubernetes clusters within the supported version ranges defined by your cloud service provider (AWS EKS or Google GKE). We ensure your cluster remains compatible with provider requirements while staying current with security patches and feature updates.
+ClickHouse Cloud maintains Kubernetes clusters within the supported version ranges defined by your cloud service provider (AWS EKS, Google GKE, or Azure AKS). We ensure your cluster remains compatible with provider requirements while staying current with security patches and feature updates.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/01_faq.md
@@ -12,9 +12,9 @@ doc_type: 'reference'
 ### Compute {#compute}
 
 <details>
-<summary>Can I create multiple services in this single EKS cluster?</summary>
+<summary>Can I create multiple services in this single Kubernetes (EKS/GKE/AKS) cluster?</summary>
 
-Yes. The infrastructure only needs to be provisioned once for every AWS account and region combination.
+Yes. The infrastructure only needs to be provisioned once for every cloud account/project/subscription and region combination.
 
 </details>
 
@@ -28,7 +28,7 @@ All **public regions** listed in our [supported regions](https://clickhouse.com/
 <details>
 <summary>Will there be some resource overhead? What are the resources needed to run services other than ClickHouse instances?</summary>
 
-Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, `aws-cluster-autoscaler`, Istio, and the monitoring stack.
+Besides the ClickHouse instances themselves (ClickHouse servers and ClickHouse Keeper), we also run supporting services such as `clickhouse-operator`, the cluster autoscaler, Istio, and the monitoring stack.
 
 The resource consumption of these shared components is relatively stable and doesn't grow linearly with the number or size of your ClickHouse services. As a rough guideline, in AWS we typically use a dedicated node group of about four `4xlarge` EC2 instances to run these workloads.
 
@@ -51,9 +51,9 @@ Yes. Implementing a customer controlled mechanism where customers can approve en
 </details>
 
 <details>
-<summary>What is the size of the VPC IP range created?</summary>
+<summary>What is the size of the VPC/VNet IP range created?</summary>
 
-By default, we use `10.0.0.0/16` for BYOC VPC. We recommend reserving at least /22 for potential future scaling,
+By default, we use `10.0.0.0/16` for the BYOC VPC (AWS/GCP) or VNet (Azure). We recommend reserving at least /22 for potential future scaling,
 but if you prefer to limit the size, it is possible to use /23 if it is likely that you will be limited
 to 30 server pods.
 

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/02_priviledge.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/02_priviledge.md
@@ -66,3 +66,25 @@ In addition to the `clickhouse-management` service account created via Terraform
   - Target identity for the monitoring stack running in your cluster. Used to read/write long-term metric storage in a GCS bucket dedicated to this deployment.
 - **ClickHouse runtime management identity**
   - Used by ClickHouse's runtime data-plane management controller which handles day-2 operations such as Private Service Connect endpoint management, bucket lifecycle adjustments, and service-account rotations.
+
+## Azure roles and identities {#azure-roles-and-identities}
+
+### Onboarding service principal {#onboarding-service-principal}
+
+Onboarding with the [Terraform module for Azure](https://github.com/ClickHouse/terraform-byoc-onboarding/tree/main/modules/azure) provisions a multi-tenant application as an Enterprise Application (service principal) in your tenant, following Azure guidance for cross-tenant authentication. The service principal is assigned a least-privilege custom role scoped to the target subscription, with permissions covering:
+
+- **Networking**: Manage the VNet, subnets, public IPs, NAT gateways, network security groups, and DNS zones that host your BYOC infrastructure.
+- **Cluster**: Manage AKS clusters and node pools.
+- **Storage**: Manage the storage accounts and blob containers used for ClickHouse data, backups, and monitoring data.
+- **Identity**: Manage user-assigned managed identities and their federated identity credentials inside the subscription.
+- **Authorization**: Manage custom role definitions and role assignments. All permissions are scoped to the target subscription — the role cannot touch resources in other subscriptions or tenants.
+
+### Additional managed identities created by the controller {#additional-managed-identities-created-by-the-controller}
+
+When you provision BYOC services, ClickHouse's control plane creates user-assigned managed identities in your subscription. Each is federated to a specific Kubernetes service account (workload identity) with a narrow, single-purpose permission set:
+
+- **Per-service identity**
+  - Used by each ClickHouse service to access its own storage account for table data and backups, via a custom blob-storage role scoped to that storage account.
+  - When a service is restored from a backup, it additionally receives read-only access to the source service's backup container.
+- **Shared infrastructure identity**
+  - Used by ClickHouse's runtime data-plane management controller for day-2 operations such as Private Link service management.

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/03_network_security.md
@@ -16,10 +16,10 @@ The ClickHouse Cloud control plane maintains several types of connections to ope
 
 | Purpose                                      | Connection type                                 | Notes                                                                                                                                                                                           |
 | -------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Daily operations — Kubernetes API server** | Public with IP filtering (default), or private via Tailscale or AWS VPC Lattice | Management services talk to the EKS API server over the public network, restricted by IP allow lists. After initial deployment, you can optionally switch this to private access via Tailscale or, on AWS, VPC Lattice. |
-| **Daily operations — AWS APIs**              | ClickHouse VPC → AWS                            | Management services call AWS APIs (e.g., EKS, EC2) from ClickHouse Cloud’s own VPC to AWS. This doesn't involve your VPC or Tailscale.                                                          |
+| **Daily operations — Kubernetes API server** | Public with IP filtering (default), or private via Tailscale or AWS VPC Lattice | Management services talk to the Kubernetes (EKS/GKE/AKS) API server over the public network, restricted by IP allow lists. After initial deployment, you can optionally switch this to private access via Tailscale or, on AWS, VPC Lattice. |
+| **Daily operations — cloud provider APIs**   | ClickHouse VPC → cloud provider                 | Management services call your cloud provider's APIs (e.g., EKS and EC2 on AWS, GKE on GCP, AKS on Azure) from ClickHouse Cloud’s own environment. This doesn't involve your VPC/VNet or Tailscale.                                                          |
 | **Troubleshooting — ClickHouse service**     | Tailscale                                       | ClickHouse engineers access the ClickHouse service (e.g., system tables) for diagnostics via Tailscale.                                                                                         |
-| **Troubleshooting — Kubernetes API server**  | Tailscale                                       | ClickHouse engineers access the EKS API server for cluster diagnostics via Tailscale.                                                                                                           |
+| **Troubleshooting — Kubernetes API server**  | Tailscale                                       | ClickHouse engineers access the Kubernetes API server for cluster diagnostics via Tailscale.                                                                                                           |
 
 The following section describes how the **Tailscale** private network is used for troubleshooting and optional management access.
 
@@ -47,22 +47,22 @@ For each service or endpoint that needs to be accessed via Tailscale, ClickHouse
 
 1. **Tailnet Address Registration**: Each endpoint registers a unique tailnet address (e.g., `k8s.xxxx.us-east-1.aws.byoc.clickhouse-prd.com` for the Kubernetes API server)
 
-2. **Tailscale Agent Container**: A Tailscale agent container runs in your EKS cluster, responsible for:
+2. **Tailscale Agent Container**: A Tailscale agent container runs in your Kubernetes cluster, responsible for:
    - Connecting to the Tailscale coordination server
    - Registering services to make them discoverable
    - Coordinating network setup with Nginx pods
 
 3. **Nginx Pod**: An Nginx pod that:
    - Terminates TLS traffic from Tailscale
-   - Routes traffic to the appropriate IPs within your EKS cluster
+   - Routes traffic to the appropriate IPs within your Kubernetes cluster
 
 ### Network Connection Process {#tailscale-connection-process}
 
 The Tailscale connection establishment follows these steps:
 
 1. **Initial Connection**:
-   - Tailscale agents on both ends (ClickHouse engineer's environment and your BYOC EKS cluster) connect to the Tailscale coordination server
-   - The EKS cluster agent registers the Kubernetes service to make it discoverable
+   - Tailscale agents on both ends (ClickHouse engineer's environment and your BYOC Kubernetes cluster) connect to the Tailscale coordination server
+   - The cluster agent registers the Kubernetes service to make it discoverable
    - ClickHouse engineers must escalate internally to gain visibility to the service
 
 2. **Connection Mode**:
@@ -78,7 +78,7 @@ The Tailscale connection establishment follows these steps:
 
 **Outbound-only connections**:
 
-- Tailscale agents in your EKS cluster initiate outbound connections to the Tailscale coordination/relay servers
+- Tailscale agents in your Kubernetes cluster initiate outbound connections to the Tailscale coordination/relay servers
 - **No inbound connections are required** — no security group rules need to allow inbound traffic to Tailscale agents
 - This reduces the attack surface and simplifies network security configuration
 
@@ -92,11 +92,11 @@ For the full data access policy — what engineers can see, certificate-based au
 
 ### Management Services Access {#management-services-access}
 
-By default, ClickHouse management services access your BYOC Kubernetes cluster via the EKS API server's public IP address, which is restricted to ClickHouse's NAT gateway IP addresses only.
+By default, ClickHouse management services access your BYOC Kubernetes cluster via the API server's public IP address, which is restricted to ClickHouse's NAT gateway IP addresses only.
 
 **Optional Private Endpoint Configuration**:
 
-- You can configure the EKS API server to use only a private endpoint
+- You can configure the Kubernetes API server to use only a private endpoint
 - In this case, management services access the API server via Tailscale (similar to human troubleshooting access) or, on AWS, via VPC Lattice (see [Kubernetes API Private Connection](/cloud/reference/byoc/configurations#k8s-api-private-connection))
 - Public access is kept as a backup mechanism for emergency investigation and support needs
 
@@ -104,7 +104,7 @@ By default, ClickHouse management services access your BYOC Kubernetes cluster v
 
 **Tailscale Connection Flow**:
 
-1. Tailscale agent in EKS cluster → Tailscale coordination server (outbound)
+1. Tailscale agent in your Kubernetes cluster → Tailscale coordination server (outbound)
 2. Tailscale agent on engineer's machine → Tailscale coordination server (outbound)
 3. Direct or relayed connection established between agents
 4. Encrypted traffic flows through the established tunnel

--- a/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
+++ b/docs/cloud/guides/infrastructure/01_deployment_options/byoc/08_reference/04_clickhouse_data_access.md
@@ -16,7 +16,7 @@ ClickHouse Cloud's control plane runs your BYOC deployment without reading custo
 | Component | What leaves your VPC |
 |-----------|----------------------|
 | State exporter | Service state (health, status) to an `SQS` queue owned by ClickHouse Cloud. |
-| Billing scraper | CPU and memory metrics to an S3 bucket owned by ClickHouse Cloud. |
+| Billing scraper | CPU and memory metrics to an object storage bucket owned by ClickHouse Cloud. |
 | AlertManager | Cluster health alerts to ClickHouse Cloud. |
 
 Query traffic, table contents, and schemas never flow through these channels. Logs and metrics stay inside your BYOC VPC.


### PR DESCRIPTION
## Summary
BYOC docs updates for Azure GA:

**1. Azure GA wording** — BYOC on Azure is generally available; the docs still presented it as private preview.
- Overview: `Azure (Private Preview)` + waitlist link → `Azure (GA)`; added **Azure Private Link** to the supported features list (implemented in the data plane, exposed in the console's **Connection via** dropdown as "Private Link").
- Architecture: added AKS and the multi-tenant service principal to the cross-account access concepts alongside the AWS/GCP equivalents.
- Private networking setup landing page: mentions Azure; setup is via the ClickHouse team until a dedicated Azure network-setup guide exists (AWS/GCP guides unchanged).

**2. Connect page made cloud-agnostic** — added **Private Link** (Azure) wherever PrivateLink/Private Service Connect are enumerated, plus per-cloud private-endpoint hostname examples. The endpoint label differs per cloud (`vpce` on AWS, `p` on GCP, `privatelink` on Azure — per `GetPrivateFQDN` in data-plane-management), so the previous "includes a `vpce` subdomain" claim was AWS-only; the page now shows all three formats. VPC-only phrasing generalized to VPC/VNet. Section anchors unchanged.

**3. Azure concepts across the remaining BYOC pages**
- **Infrastructure configuration**: PrivateLink/PSC section now includes Azure Private Link.
- **Observability**: Prometheus endpoint table shows the per-cloud private-endpoint label instead of a hardcoded `vpce` (which was already inaccurate for GCP).
- **Operations**: Kubernetes upgrade sections include AKS.
- **Privilege reference**: new "Azure roles and identities" section at parity with the AWS/GCP sections — onboarding service principal permissions sourced from the `terraform-byoc-onboarding` Azure module's custom role, controller-created managed identities from the data plane IAM code.
- **Network security**: generalized EKS-specific wording to Kubernetes (EKS/GKE/AKS); the "AWS APIs" row now covers all provider APIs. Tailscale model is identical across clouds.
- **Data access**: billing scraper sink genericized from "S3 bucket" to "object storage bucket" (it's an Azure Blob container on Azure, ABAC-scoped). State exporter's SQS row is correct on all clouds (non-AWS state exporters federate into an AWS role).
- **FAQ**: genericized the EKS-only and AWS-account-only phrasings.

**4. CloudFormation v2 link** — the AWS onboarding pages now point at the v2 template (`cf-templates/byoc_v2.yaml`, verified live) instead of the legacy `byoc.yaml`. The v2 template supports the same parameters referenced in the docs (`IncludeVPCWritePermissions`, `IncludeIAMWritePermissions`).

Not covered (possible follow-ups): dedicated Azure pages under onboarding customization and network setup (AWS/GCP each have one); Azure equivalents of the AWS-specific billing/cost/service-limit reference pages; cloud changelog entry for the GA announcement.

English docs only — i18n copies are handled by the translation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)