### PR TITLE
Docs: clarify "Preserve NULL values from source" is pipe-wide and set at creation only

### DIFF
--- a/docs/cloud/managed-postgres/clickhouse-integration.md
+++ b/docs/cloud/managed-postgres/clickhouse-integration.md
@@ -67,7 +67,7 @@ Choose a destination database and select which tables to replicate:
 
 - **Destination database**: Select an existing ClickHouse database or create a new one
 - **Prefix default destination table names with schema name**: Adds the Postgres schema as a prefix to avoid naming conflicts
-- **Preserve NULL values from source**: Maintains NULL values instead of converting to defaults
+- **Preserve NULL values from source**: Maintains NULL values instead of converting to type defaults. This setting applies to all tables in the pipe and cannot be changed after the pipe is created.
 - **Remove deleted rows during merges**: For [ReplacingMergeTree](/engines/table-engines/mergetree-family/replacingmergetree) tables, physically removes deleted rows during background merges
 
 Expand schemas and select individual tables to replicate. You can also customize destination table names and column settings.


### PR DESCRIPTION
## Summary

Clarify that the **Preserve NULL values from source** ClickPipes setting applies to all tables in the pipe and cannot be changed after the pipe is created. Customers frequently assume it can be changed later by altering destination columns to `Nullable`, which has no effect on what the pipe writes (confirmed with ClickPipes engineering). One-line change to the setting's description.
