### PR TITLE
Clarify Private Link connection limitations

### DIFF
--- a/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
+++ b/docs/cloud/guides/security/02_connectivity/private_networking/02_aws-privatelink.md
@@ -22,6 +22,10 @@ import aws_private_link_ped_nsname from '@site/static/images/cloud/security/aws-
 
 You can use [AWS PrivateLink](https://aws.amazon.com/privatelink/) to establish secure connectivity between VPCs, AWS services, your on-premises systems, and ClickHouse Cloud without exposing traffic to the public Internet. This document outlines the steps to connect to ClickHouse Cloud using AWS PrivateLink.
 
+:::important
+AWS PrivateLink supports only connections initiated from your AWS VPC to ClickHouse Cloud. It can't be used for connections initiated from ClickHouse Cloud to services in your VPC, such as a [private database](#connecting-to-a-remote-database).
+:::
+
 To restrict access to your ClickHouse Cloud services exclusively through AWS PrivateLink addresses, follow the instructions provided by ClickHouse Cloud [IP Access Lists](/cloud/security/setting-ip-filters).
 
 :::note
@@ -375,10 +379,8 @@ jq .result.privateEndpointIds
 
 ### Connecting to a remote database {#connecting-to-a-remote-database}
 
-Let's say you're trying to use [MySQL](/sql-reference/table-functions/mysql) or [PostgreSQL](/sql-reference/table-functions/postgresql) table functions in ClickHouse Cloud and connect to your database hosted in an Amazon Web Services (AWS) VPC. AWS PrivateLink can't be used to enable this connection securely. PrivateLink is a one-way, unidirectional connection. It allows your internal network or Amazon VPC to connect securely to ClickHouse Cloud, but it doesn't allow ClickHouse Cloud to connect to your internal network.
-
 According to the [AWS PrivateLink documentation](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/aws-privatelink.html):
 
 > Use AWS PrivateLink when you have a client/server set up where you want to allow one or more consumer VPCs unidirectional access to a specific service or set of instances in the service provider VPC. Only the clients in the consumer VPC can initiate a connection to the service in the service provider VPC.
 
-To do this, configure your AWS Security Groups to allow connections from ClickHouse Cloud to your internal/private database service. Check the [default egress IP addresses for ClickHouse Cloud regions](/manage/data-sources/cloud-endpoints-api), along with the [available static IP addresses](https://api.clickhouse.cloud/static-ips.json).
+To connect [MySQL](/sql-reference/table-functions/mysql) or [PostgreSQL](/sql-reference/table-functions/postgresql) table functions in ClickHouse Cloud to a database hosted in your AWS VPC, configure your AWS security groups to allow connections from ClickHouse Cloud. Check the [default egress IP addresses for ClickHouse Cloud regions](/manage/data-sources/cloud-endpoints-api), along with the [available static IP addresses](https://api.clickhouse.cloud/static-ips.json).

--- a/docs/cloud/guides/security/02_connectivity/private_networking/03_gcp-private-service-connect.md
+++ b/docs/cloud/guides/security/02_connectivity/private_networking/03_gcp-private-service-connect.md
@@ -30,6 +30,8 @@ Service producers publish their applications to consumers by creating Private Se
 <Image img={gcp_psc_overview} size="lg" alt="Overview of Private Service Connect" border />
 
 :::important
+GCP Private Service Connect supports only connections initiated from your GCP VPC to ClickHouse Cloud. It can't be used for connections initiated from ClickHouse Cloud to services in your VPC, such as a [private database](#connecting-to-a-remote-database).
+
 By default, a ClickHouse service isn't available over a Private Service connection even if the PSC connection is approved and established; you need to explicitly add the PSC ID to the allow list on an instance level by completing the [step](#add-endpoint-id-to-services-allow-list) below.
 :::
 
@@ -425,13 +427,11 @@ curl --silent --user "${KEY_ID:?}:${KEY_SECRET:?}" -X GET -H "Content-Type: appl
 
 ### Connecting to a remote database {#connecting-to-a-remote-database}
 
-Let's say you're trying to use the [MySQL](/sql-reference/table-functions/mysql) or [PostgreSQL](/sql-reference/table-functions/postgresql) table functions in ClickHouse Cloud and connect to your database hosted in GCP. GCP PSC can't be used to enable this connection securely. PSC is a one-way, unidirectional connection. It allows your internal network or GCP VPC to connect securely to ClickHouse Cloud, but it doesn't allow ClickHouse Cloud to connect to your internal network.
-
 According to the [GCP Private Service Connect documentation](https://cloud.google.com/vpc/docs/private-service-connect):
 
 > Service-oriented design: Producer services are published through load balancers that expose a single IP address to the consumer VPC network. Consumer traffic that accesses producer services is unidirectional and can only access the service IP address, rather than having access to an entire peered VPC network.
 
-To do this, configure your GCP VPC firewall rules to allow connections from ClickHouse Cloud to your internal/private database service. Check the [default egress IP addresses for ClickHouse Cloud regions](/manage/data-sources/cloud-endpoints-api), along with the [available static IP addresses](https://api.clickhouse.cloud/static-ips.json).
+To connect [MySQL](/sql-reference/table-functions/mysql) or [PostgreSQL](/sql-reference/table-functions/postgresql) table functions in ClickHouse Cloud to a database hosted in your GCP VPC, configure your GCP VPC firewall rules to allow connections from ClickHouse Cloud. Check the [default egress IP addresses for ClickHouse Cloud regions](/manage/data-sources/cloud-endpoints-api), along with the [available static IP addresses](https://api.clickhouse.cloud/static-ips.json).
 
 ## More information {#more-information}
 

--- a/docs/cloud/guides/security/02_connectivity/private_networking/04_azure-privatelink.md
+++ b/docs/cloud/guides/security/02_connectivity/private_networking/04_azure-privatelink.md
@@ -33,6 +33,10 @@ This guide shows how to use Azure Private Link to provide private connectivity v
 
 <Image img={azure_pe} size="lg" alt="Overview of PrivateLink" background='white' />
 
+:::important
+Azure Private Link supports only connections initiated from your Azure VNet to ClickHouse Cloud. It can't be used for connections initiated from ClickHouse Cloud to services in your VNet, such as a private database.
+:::
+
 Azure supports cross-region connectivity via Private Link. This enables you to establish connections between VNets located in different regions where you have ClickHouse services deployed.
 
 :::note


### PR DESCRIPTION
## Summary

- Add prominent connection-direction callouts near the introductions of the AWS PrivateLink, GCP Private Service Connect, and Azure Private Link guides.
- Clarify that clients in the customer VPC or VNet must initiate connections and that ClickHouse Cloud can't use these private connections to initiate connections to customer services.
- Keep the provider documentation and private-database workaround in the existing remote-database sections without duplicating the limitation text.

## Why

DOC-916 identified that the Azure limitation was missing and that the equivalent AWS and GCP explanations were too easy to miss near the bottom of their pages.

## Reader impact

Readers can now see the connection-initiation limitation before starting setup, helping them avoid choosing PrivateLink or Private Service Connect for ClickHouse-initiated connections to private databases and other services.

## Validation

- `git diff --check` passes.
- Targeted markdownlint passes for all three changed files.
- Vale reports no errors for the AWS and GCP pages. The Azure page retains three pre-existing heading-capitalization errors unrelated to this change.
- Claims were verified with official AWS, Google Cloud, and Microsoft Azure documentation; confidence is high.
- `yarn check-style` remains blocked by 1,287 unrelated markdownlint errors in generated and reference pages.
- The repository spelling check remains blocked by the existing invalid `manage-clickpipes` entry in the aspell dictionary.
