### PR TITLE
Reword ClickPipes resync doc

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/mongodb/resync.md
+++ b/docs/integrations/data-ingestion/clickpipes/mongodb/resync.md
@@ -24,12 +24,10 @@ Resync involves the following operations in order:
 
 All the settings of the original ClickPipe are retained in the resync ClickPipe. The statistics of the original ClickPipe are cleared in the UI.
 
-### Use cases for resyncing a ClickPipe {#use-cases-mongodb-resync}
-
-Here are a few scenarios:
-
-1. You may need to perform major schema changes on the source tables which would break the existing ClickPipe and you would need to restart. You can just click Resync after performing the changes.
-2. Specifically for Clickhouse, maybe you needed to change the ORDER BY keys on the target tables. You can Resync to re-populate data into the new table with the right sorting key.
+:::note
+You can resync multiple times, however please account for the load on the source database when you resync,
+since initial load with parallel threads is involved each time.
+:::
 
 ### Resync ClickPipe Guide {#guide-mongodb-resync}
 

--- a/docs/integrations/data-ingestion/clickpipes/mysql/resync.md
+++ b/docs/integrations/data-ingestion/clickpipes/mysql/resync.md
@@ -29,10 +29,11 @@ All the settings of the original ClickPipe are retained in the resync ClickPipe.
 Here are a few scenarios:
 
 1. You may need to perform major schema changes on the source tables which would break the existing ClickPipe and you would need to restart. You can just click Resync after performing the changes.
-2. Specifically for Clickhouse, maybe you needed to change the ORDER BY keys on the target tables. You can Resync to re-populate data into the new table with the right sorting key.
+2. Specifically for Clickhouse, maybe you needed to update the values in ORDER BY columns on the target tables. You can Resync to re-populate data into the new table with the right sorting key.
 
 :::note
-You can resync multiple times, however please account for the load on the source database when you resync.
+You can resync multiple times, however please account for the load on the source database when you resync,
+since initial load with parallel threads is involved each time.
 :::
 
 ### Resync ClickPipe Guide {#guide-mysql-resync}

--- a/docs/integrations/data-ingestion/clickpipes/postgres/resync.md
+++ b/docs/integrations/data-ingestion/clickpipes/postgres/resync.md
@@ -28,7 +28,7 @@ All the settings of the original ClickPipe are retained in the resync ClickPipe.
 Here are a few scenarios:
 
 1. You may need to perform major schema changes on the source tables which would break the existing ClickPipe and you would need to restart. You can just click Resync after performing the changes.
-2. Specifically for Clickhouse, maybe you needed to change the ORDER BY keys on the target tables. You can Resync to re-populate data into the new table with the right sorting key.
+2. Specifically for Clickhouse, maybe you needed to update the values in ORDER BY columns on the target tables. You can Resync to re-populate data into the new table with the right sorting key.
 3. The replication slot of the ClickPipe is invalidated: Resync creates a new ClickPipe and a new slot on the source database.
 
 :::note


### PR DESCRIPTION
## Summary
The old wording could imply that you can actually change your ORDER BY key with resync, where in practice it can at most overwrite a custom one the pipe is not aware of. Also remove the schema change mentions that don't apply to Mongo and replicate the parallel snapshotting note that now applies to all.

## Checklist
- [x] Delete items not relevant to your PR

