### PR TITLE
docs(observability): document number-tile color picker on ClickStack dashboards

### DIFF
--- a/docs/use-cases/observability/clickstack/dashboards/index.md
+++ b/docs/use-cases/observability/clickstack/dashboards/index.md
@@ -220,6 +220,43 @@ To remove, edit, or duplicate a visualization, hover over it and use the corresp
 
 Each tile has a **Display Settings** drawer for options that control how its value is rendered. Open it from the tile editor by clicking **Display Settings**. The available options depend on the visualization type.
 
+#### Number tile color {#number-tile-color}
+
+Number tiles support a static **Color** choice from the curated chart palette. With a number tile selected, open **Display Settings** and use the **Color** control (labeled **Number tile color** for accessibility) to pick a swatch, or clear the selection to use the default text color.
+
+Colors are stored as palette tokens, not raw hex values, so the same tile reflows correctly across light, dark, and IDE themes.
+
+**Categorical tokens** (multi-series hues):
+
+| Token | Label |
+|---|---|
+| `chart-blue` | Blue |
+| `chart-orange` | Orange |
+| `chart-red` | Red |
+| `chart-cyan` | Cyan |
+| `chart-green` | Green |
+| `chart-pink` | Pink |
+| `chart-purple` | Purple |
+| `chart-light-blue` | Light Blue |
+| `chart-brown` | Brown |
+| `chart-gray` | Gray |
+
+**Semantic tokens** (status-oriented):
+
+| Token | Label |
+|---|---|
+| `chart-success` | Success |
+| `chart-warning` | Warning |
+| `chart-error` | Error |
+
+Use semantic tokens when the number represents a status (for example error count in `chart-error`, or a healthy rate in `chart-success`). Use categorical tokens when you want visual distinction between related KPI tiles without implying status.
+
+Older configs may still store legacy numeric tokens (`chart-1` through `chart-10`). ClickStack maps those to the hue-named tokens above when loading a dashboard.
+
+The same palette powers optional **color rules** in the same drawer: ordered conditions evaluated against the displayed value (last match wins). When no rule matches, the static color applies, then the default text color.
+
+#### Number tile background chart {#number-tile-background-chart}
+
 Number tiles can show a **background chart**: a trend sparkline drawn behind the value, so its movement over the selected time range is visible at a glance. This is useful for SLO and error-budget tiles, where how a value is trending matters as much as its current reading.
 
 With a number tile selected, open **Display Settings** and set **Background chart** to **Line** or **Area** (or **None** to turn it off). The sparkline is derived from a time-bucketed version of the tile's query, so no extra configuration is needed. It inherits the tile color by default; set a **Background color** to override it with a specific palette color.
@@ -235,6 +272,44 @@ With a table tile selected, open **Display Settings** and turn on **Alternate Ro
 <Image img={table_tile_display_settings} alt="Display Settings drawer for a table tile, with Alternate Row Background turned on" size="lg"/>
 
 Table tiles also keep a separator between the header row and the data as you scroll, so the column headers stay distinct.
+
+#### Dashboards API: number tile color {#api-number-tile-color}
+
+When creating or updating dashboards through the external API (`POST` / `PUT` `/api/v2/dashboards`), set `color` on a builder number-tile config to a palette token. Raw hex values are rejected.
+
+```json
+{
+  "name": "Error rate KPIs",
+  "tiles": [
+    {
+      "id": "65f5e4a3b9e77c001a222222",
+      "name": "Errors",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 4,
+      "config": {
+        "displayType": "number",
+        "sourceId": "<SOURCE_ID>",
+        "select": [
+          {
+            "aggFn": "count",
+            "where": "SeverityText:error",
+            "whereLanguage": "lucene",
+            "alias": "Errors"
+          }
+        ],
+        "color": "chart-error",
+        "backgroundChart": {
+          "type": "area"
+        }
+      }
+    }
+  ]
+}
+```
+
+`color` accepts any token from the categorical and semantic lists above (for example `chart-blue` or `chart-success`). Optional `backgroundChart.color` overrides the sparkline color with the same token enum. See the [ClickStack API reference](/use-cases/observability/clickstack/api-reference) for authentication and base URLs.
 
 ## Dashboard - Listing and search {#dashboard-listing-search}
 


### PR DESCRIPTION
## Summary

Fixes ClickHouse/ClickHouse#113307

Documents the number-tile **Color** option in **Display Settings** on the ClickStack dashboards page (`docs/use-cases/observability/clickstack/dashboards/index.md`).

Related docs work in the same ClickStack area: [#6565](<https://github.com/ClickHouse/clickhouse-docs/issues/6565>) (ClickStack MCP tools and authoring).

### What this adds

* How to open the **Color** control on a number tile
* Categorical tokens (`chart-blue` … `chart-gray`) and semantic tokens (`chart-success`, `chart-warning`, `chart-error`)
* Why tokens (not hex) reflow across light, dark, and IDE themes
* Legacy `chart-1`…`chart-10` mapping note
* Brief note on ordered color rules (same palette)
* External API example setting `color` on a builder number-tile config for `POST`/`PUT` `/api/v2/dashboards` (API parity landed in hyperdxio/hyperdx#2359)

### Screenshots

Not included. The issue asks for light/dark screenshots; this PR ships verified prose and token tables only so we do not invent UI. Happy to add screenshots in a follow-up from a real ClickStack session.

### Verification

Cross-checked against HyperDX/ClickStack source:

* `packages/app/src/components/ChartDisplaySettingsDrawer.tsx` — `showTileColor` for `DisplayType.Number`; **Color** control via `ColorSwatchInput` (`aria-label` “Number tile color”)
* `packages/app/src/components/ColorSwatchInput.tsx` — token labels and palette-only storage
* `packages/common-utils/src/types.ts` — `CATEGORICAL_PALETTE_TOKENS`, `SEMANTIC_PALETTE_TOKENS`, `LEGACY_CHART_PALETTE_TOKEN_MAP`
* `packages/api/src/routers/external-api/v2/dashboards.ts` — `ChartPaletteToken` enum and `color` on `NumberBuilderChartConfig` / raw SQL number config

## Test plan

- [ ] Preview the dashboards page and confirm the new **Number tile color** subsection renders under **Tile display settings**
- [ ] Confirm links to the API reference resolve
- [ ] Spot-check token tables against the product color swatch UI