### PR TITLE
Recommend DataLakeCatalog in data lake getting started guide

### DIFF
--- a/docs/use-cases/data_lake/getting-started.md
+++ b/docs/use-cases/data_lake/getting-started.md
@@ -22,7 +22,7 @@ A hands-on walkthrough of querying data lake tables, accelerating them with Merg
 
 Screenshots in this guide are from the [ClickHouse Cloud](https://console.clickhouse.cloud) SQL console. All queries work on both Cloud and self-managed deployments.
 
-ClickHouse offers three ways to read open table formats: table functions, table engines, and the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine. **If your tables live in a data catalog** (Glue, Unity Catalog, REST, and others), connect with `DataLakeCatalog` — it is the recommended integration. The table function and table engine sections below are best for ad hoc queries or when you know a specific storage path and don't use a catalog.
+ClickHouse offers three ways to read open table formats: table functions, table engines, and the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine. **If your tables live in a data catalog** (Glue, Unity Catalog, REST, and others), connect with `DataLakeCatalog` so you can get access to all of your Iceberg/Delta tables in one function. The table function and table engine sections below are best for ad hoc queries or when you know a specific storage path and don't use a catalog.
 
 <VerticalStepper headerLevel="h2">
 

--- a/docs/use-cases/data_lake/getting-started.md
+++ b/docs/use-cases/data_lake/getting-started.md
@@ -22,11 +22,13 @@ A hands-on walkthrough of querying data lake tables, accelerating them with Merg
 
 Screenshots in this guide are from the [ClickHouse Cloud](https://console.clickhouse.cloud) SQL console. All queries work on both Cloud and self-managed deployments.
 
+ClickHouse offers three ways to read open table formats: table functions, table engines, and the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine. **If your tables live in a data catalog** (Glue, Unity Catalog, REST, and others), connect with `DataLakeCatalog` — it is the recommended integration. The table function and table engine sections below are best for ad hoc queries or when you know a specific storage path and don't use a catalog.
+
 <VerticalStepper headerLevel="h2">
 
 ## Query Iceberg data directly {#query-directly}
 
-The fastest way to start is with the [`icebergS3()`](/sql-reference/table-functions/iceberg) table function — point it at an Iceberg table in S3 and query immediately, no setup required.
+The fastest way to start — especially for ad hoc queries or when you don't use a catalog — is the [`icebergS3()`](/sql-reference/table-functions/iceberg) table function. Point it at an Iceberg table in S3 and query immediately, no setup required.
 
 Inspect the schema:
 
@@ -54,7 +56,7 @@ ClickHouse reads the Iceberg metadata directly from S3 and infers the schema aut
 
 ## Create a persistent table engine {#table-engine}
 
-For repeated access, create a table using the Iceberg table engine so you don't need to pass the path every time. The data stays in S3 — no data is duplicated:
+When you don't use a catalog but will query the same path repeatedly, create a table using the Iceberg table engine so you don't need to pass the path every time. The data stays in S3 — no data is duplicated:
 
 ```sql
 CREATE TABLE hits_iceberg
@@ -79,7 +81,11 @@ The table engine supports data caching, metadata caching, schema evolution, and 
 
 ## Connect to a catalog {#connect-catalog}
 
-Most organizations manage Iceberg tables through a data catalog to centralize the table metadata and data discovery. ClickHouse supports connecting to your catalog using the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine, exposing all catalog tables as a ClickHouse database. This is the more scalable path so as new Iceberg tables are created, they are always accessible in ClickHouse without additional work. 
+If your organization uses a data catalog, this is the integration path we recommend. Catalogs centralize table metadata and discovery — instead of managing a table definition for every storage path, connect once with the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine. Every table in the catalog appears as a ClickHouse table, including tables added upstream after you create the connection.
+
+:::important Recommended when you use a catalog
+Use `DataLakeCatalog` for production workloads with Glue, Unity Catalog, REST, and other [supported catalogs](/use-cases/data-lake/reference). Table functions and table engines work when you know a specific path, but they don't stay in sync as your catalog grows and require separate credentials or paths per table.
+:::
 
 Here's an example connecting to [AWS Glue](/use-cases/data-lake/glue-catalog):
 
@@ -113,7 +119,7 @@ Backticks are required around `<database>.<table>` because ClickHouse doesn't na
 
 ## Issue a query {#issue-query}
 
-Regardless of which method you used above — table function, table engine, or catalog — the same ClickHouse SQL works across all of them:
+Regardless of which method you used above — table function, table engine, or `DataLakeCatalog` — the same ClickHouse SQL works across all of them. In production with a catalog, query through the `DataLakeCatalog` database; the other examples remain useful for quick tests and path-based access:
 
 ```sql
 -- Table function
@@ -234,8 +240,8 @@ The resulting Iceberg table is readable by any Iceberg-compatible engine.
 
 Now that you've seen the full workflow, dive deeper into each area:
 
+- [Connecting to catalogs](/use-cases/data-lake/getting-started/connecting-catalogs) — Recommended for catalog-backed workloads; full Unity Catalog walkthrough with Delta and Iceberg
 - [Querying directly](/use-cases/data-lake/getting-started/querying-directly) — All four formats, cluster variants, table engines, caching
-- [Connecting to catalogs](/use-cases/data-lake/getting-started/connecting-catalogs) — Full Unity Catalog walkthrough with Delta and Iceberg
 - [Accelerating analytics](/use-cases/data-lake/getting-started/accelerating-analytics) — Schema optimization, indexing, ~40x speedup demo
 - [Writing to data lakes](/use-cases/data-lake/getting-started/writing-data) — Raw writes, aggregated writes, type mapping
 - [Support matrix](/use-cases/data-lake/support-matrix) — Feature comparison across formats and storage backends

--- a/docs/use-cases/data_lake/guides/best-practices.md
+++ b/docs/use-cases/data_lake/guides/best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: 'Data lakes Best Practices'
+title: 'Data lakes best practices'
 sidebar_label: 'Best practices'
 slug: /use-cases/data-lake/best-practices
 sidebar_position: 5

--- a/docs/use-cases/data_lake/guides/best-practices.md
+++ b/docs/use-cases/data_lake/guides/best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: 'Data lake best practices'
+title: 'Data lakes Best Practices'
 sidebar_label: 'Best practices'
 slug: /use-cases/data-lake/best-practices
 sidebar_position: 5


### PR DESCRIPTION
## Summary
- Clarify that `DataLakeCatalog` is the recommended integration when tables are registered in a data catalog (Glue, Unity Catalog, REST, and others)
- Reframe table function and table engine sections as path-based options for ad hoc use or workloads without a catalog
- Add an important callout in the catalog section and reorder Next steps to prioritize connecting to catalogs
- Update the data lake best practices page title casing

## Test plan
- [ ] Preview the getting started page and confirm the catalog recommendation reads clearly
- [ ] Verify the important admonition renders correctly
- [ ] Confirm Next steps links resolve


Made with [Cursor](https://cursor.com)