### PR TITLE
Document `BACKUP` privilege prerequisite for BYO backups

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
@@ -19,6 +19,8 @@ Cross-Cloud backups are only supported via the backup/restore commands outlined 
 
 ## Requirements {#requirements}
 
+Before you run a `BACKUP` command, make sure your ClickHouse user has the `BACKUP` privilege. The `default_role` in ClickHouse Cloud doesn't include this privilege. Contact [ClickHouse Support](https://clickhouse.com/support/program) to request it before exporting backups.
+
 You will need the following details to export/restore backups to your own CSP storage bucket.
 
 ### AWS {#aws}


### PR DESCRIPTION
## Summary

Document that exporting a bring-your-own backup requires the `BACKUP` privilege, that ClickHouse Cloud's `default_role` does not include it, and that users should contact ClickHouse Support to request the privilege before exporting backups.

Related: https://linear.app/clickhouse/issue/DOC-920/mention-backup-privilege-prerequisite-for-byo-backups

## Checklist

- [x] This change does not rename URLs or add an integration page.