### PR TITLE
docs: fix typo in best practices for using primary indexes

### DIFF
--- a/docs/guides/best-practices/sparse-primary-indexes.md
+++ b/docs/guides/best-practices/sparse-primary-indexes.md
@@ -349,7 +349,7 @@ The first (based on physical order on disk) 8192 rows (their column values) logi
 
   Therefore all granules (except the last one) of our example table have the same size.
 
-- For tables with adaptive index granularity (index granularity is adaptive by [default](/operations/settings/merge-tree-settings#index_granularity_bytes) the size of some granules can be less than 8192 rows depending on the row data sizes.
+- For tables with adaptive index granularity (index granularity is adaptive by [default](/operations/settings/merge-tree-settings#index_granularity_bytes)) the size of some granules can be less than 8192 rows depending on the row data sizes.
 
 - We marked some column values from our primary key columns (`UserID`, `URL`) in orange.
   These orange-marked column values are the primary key column values of each first row of each granule.


### PR DESCRIPTION
## Summary

Fixed a typo in the best practices for using primary indexes

## Checklist
- [x] Delete items not relevant to your PR
- [x] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [x] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
