### PR TITLE
Update 01_export-backups-to-own-cloud-account.md

### DIFF
--- a/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
+++ b/docs/cloud/guides/backups/03_bring_your_own_backup/01_export-backups-to-own-cloud-account.md
@@ -7,7 +7,8 @@ doc_type: 'guide'
 ---
 
 ClickHouse Cloud supports taking backups to your own cloud service provider (CSP) account (AWS S3, Google Cloud Storage, or Azure Blob Storage).
-For details of how ClickHouse Cloud backups work, including "full" vs. "incremental" backups, see the [backups](/cloud/manage/backups/overview) docs.
+For details of how ClickHouse Cloud backups work, including "full" vs. "incremental" backups, see the [backups](/cloud/manage/backups/overview) docs. Note that 
+backups to your own cloud account behave differently from in-place Cloud backups in one important way: they cannot use native copy (see the note below).
 
 In this guide, we show examples of how to take full and incremental backups to AWS, GCP, Azure object storage as well as how to restore from the backups.
 
@@ -15,6 +16,15 @@ In this guide, we show examples of how to take full and incremental backups to A
 Any usage where backups are being exported to a different region in the same cloud provider will incur [data transfer](/cloud/manage/network-data-transfer) charges.  
 
 Cross-Cloud backups are only supported via the backup/restore commands outlined on this page, and not via the UI.
+:::
+
+:::warning 
+**Performance impact vs. in-place backups**  
+Backups to your own bucket cannot use native (server-side) copy. Native copy requires the source and destination to share the same credentials, which is not
+the case here: the source is a ClickHouse-managed bucket and the destination is your own bucket, authenticated with separate credentials.
+
+Because native copy is unavailable, data is downloaded from the source and re-uploaded to your bucket ("copy-through-buffers"). As a result, exporting
+backups to your own bucket is slower and consumes more  resources than standard in-place Cloud backups.
 :::
 
 ## Requirements {#requirements}


### PR DESCRIPTION
updated page to distinguish performance for external backups vs backups in CH bucket

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
