### PR TITLE
Add ClickPipes CDC latency metrics to monitoring docs

### DIFF
--- a/docs/integrations/data-ingestion/clickpipes/monitoring.md
+++ b/docs/integrations/data-ingestion/clickpipes/monitoring.md
@@ -90,8 +90,10 @@ Not every metric is emitted by every pipe type. In particular, CDC ClickPipes ex
 
 | Metric                                    | Type | Available for | Description |
 |-------------------------------------------|------|---------------|-------------|
-| `ClickPipes_Latency`                      | Gauge (_avg_) | Streaming, object storage | Time in milliseconds between when a record was produced at the source and when it was written to ClickHouse. |
+| `ClickPipes_Latency`                      | Gauge (_avg_) | All | Time in milliseconds between when a record was produced at the source and when it was written to ClickHouse. |
 | `ClickPipes_SourceReplicationLatency_MiB` | Gauge (_avg_) | CDC (Postgres only) | Replication slot lag at the source in MiB. Only emitted by Postgres ClickPipes. |
+| `ClickPipes_CDC_SourceLatency`            | Gauge (_avg_) | CDC | Lag in milliseconds from a source event timestamp to ClickPipes processing. |
+| `ClickPipes_CDC_DestinationLatency`       | Gauge (_avg_) | CDC | Lag in milliseconds from receiving an event in a ClickPipe to writing it into a ClickHouse table. |
 
 ### Resource utilization {#metrics-resources}
 


### PR DESCRIPTION
## Summary

**DO NOT MERGE**

Documents two new CDC latency metrics recently exposed on the DataPlane Prometheus endpoint, and updates `ClickPipes_Latency`'s availability.

- `ClickPipes_CDC_SourceLatency` — Lag in milliseconds from a source event timestamp to ClickPipes processing.
- `ClickPipes_CDC_DestinationLatency` — Lag in milliseconds from receiving an event in a ClickPipe to writing it into a ClickHouse table.
- `ClickPipes_Latency` "Available for" changed from _Streaming, object storage_ to _All_, since it is now emitted for CDC pipes too.

Metric descriptions match the source definitions in `data-plane-application`.

## Checklist
- [x] No URL changes
- [x] Not a new integration page