### PR TITLE
Add note about preserving/persisting logs

### DIFF
--- a/knowledgebase/generate-har-file.mdx
+++ b/knowledgebase/generate-har-file.mdx
@@ -9,6 +9,20 @@ description: 'A HAR (HTTP Archive) file captures the network activity in your br
 {frontMatter.description}
 {/* truncate */}
 
+:::warning
+HAR files may contain session cookies or other sensitive data.
+Only share them with authorized support personnel.
+:::
+
+:::note[Capturing login attempts and other multi-step flows]
+Some issues span more than one page load, such as a login that redirects to your identity provider and back. By default your browser clears the network log on each navigation, so the resulting HAR file can come back nearly empty. When reproducing an issue like this, enable your browser's option to retain logs across page loads before you begin:
+
+- Chrome / Edge / Safari: enable "Preserve log"
+- Firefox: enable "Persist Logs"
+
+It is safe to uncheck this again once the HAR file has been generated, if desired.
+:::
+
 ## From Google Chrome \{#from-google-chrome\}
 
 1. Open Developer Tools by pressing <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> (Windows/Linux) / <kbd>Cmd</kbd> + <kbd>Option</kbd> + <kbd>I</kbd> (Mac).
@@ -45,8 +59,3 @@ description: 'A HAR (HTTP Archive) file captures the network activity in your br
 1. Rename the file to something short and descriptive (e.g., login-issue.har).
 2. Compress the file (optional but recommended).
 3. Attach it to your support case or email it to your assigned support contact.
-
-:::note
-HAR files may contain session cookies or other sensitive data.
-Only share them with authorized support personnel.
-:::


### PR DESCRIPTION
Some issues span multiple page loads.  By default, all logging data is lost when a new page is loaded.  A note now explains how to change this behavior. Also moving the note about sensitive information to the top for consistency, and upgrading it to a warning.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
