### PR TITLE
Except `operations/introspection-port` from the floating-pages check

### DIFF
--- a/plugins/floating-pages-exceptions.txt
+++ b/plugins/floating-pages-exceptions.txt
@@ -23,3 +23,4 @@ use-cases/observability/clickstack/managed-onboarding/monitoring-aws-cloudwatch-
 use-cases/observability/clickstack/managed-onboarding/instrument-application.md
 use-cases/observability/clickstack/managed-onboarding/tuning-clickstack-schema.md
 use-cases/observability/clickstack/managed-onboarding/managed-getting-started.md
+operations/introspection-port

--- a/sidebars.js
+++ b/sidebars.js
@@ -1618,6 +1618,7 @@ const sidebars = {
         'faq/operations/multi-region-replication',
         'faq/operations/production',
         'operations/cluster-discovery',
+        'operations/introspection-port',
         'operations/monitoring',
         'operations/opentelemetry',
         'operations/quotas',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1618,7 +1618,6 @@ const sidebars = {
         'faq/operations/multi-region-replication',
         'faq/operations/production',
         'operations/cluster-discovery',
-        'operations/introspection-port',
         'operations/monitoring',
         'operations/opentelemetry',
         'operations/quotas',


### PR DESCRIPTION
## Summary

Add `operations/introspection-port` to `plugins/floating-pages-exceptions.txt`. The page (`docs/en/operations/introspection-port.md`) is added in https://github.com/ClickHouse/ClickHouse/pull/110838, and the two repos are circularly blocked: a sidebar entry cannot merge here before the page exists on ClickHouse master (`DocsCheck` fails on the missing document id), while the `Docs check` on the ClickHouse PR fails until this repo stops flagging the page as floating.

The exception breaks the cycle. A follow-up PR will remove the exception and add `operations/introspection-port` to the operations guides list in `sidebars.js` once the page is on ClickHouse master.

Related: https://github.com/ClickHouse/ClickHouse/pull/110838

🤖 Generated with [Claude Code](https://claude.com/claude-code)