### PR TITLE
Fix authentication for repository migration notice

### DIFF
--- a/.github/workflows/repository-migration-notice.yml
+++ b/.github/workflows/repository-migration-notice.yml
@@ -12,9 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Comment with the new contribution location
-        uses: actions/github-script@v7
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
         with:
+          app-id: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}
+
+      - name: Comment with the new contribution location
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const marker = '<!-- clickhouse-docs-migration-notice -->';
             const issue = {


### PR DESCRIPTION
## Summary

- authenticate the migration notice workflow with the repository's existing GitHub App token
- upgrade `actions/github-script` to v8 for the Node.js 24 runtime

## Why

The test run on #6591 triggered correctly but failed with `Resource not accessible by integration` when the default `GITHUB_TOKEN` attempted to create the PR comment. The existing CLA workflow uses this GitHub App credential pattern successfully.

## Validation

- parsed the workflow as YAML
- compiled the embedded script in an async context
- checked the diff for whitespace errors