### PR TITLE
Use GitHub Actions bot for migration notice

### DIFF
--- a/.github/workflows/repository-migration-notice.yml
+++ b/.github/workflows/repository-migration-notice.yml
@@ -5,24 +5,17 @@ on:
     types: [opened]
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   post-migration-notice:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}
-
       - name: Comment with the new contribution location
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const marker = '<!-- clickhouse-docs-migration-notice -->';
             const issue = {


### PR DESCRIPTION
## Summary

- remove the shared GitHub App token from the migration notice workflow
- grant the built-in `GITHUB_TOKEN` the required `pull-requests: write` permission
- post migration notices as `github-actions[bot]`

## Why

The shared app token caused migration notices to appear as `workflow-authentication-public[bot]`. The original built-in token attempt failed because the workflow granted `issues: write`, while GitHub's pull request conversation comment endpoint requires `pull-requests: write`.

## Validation

- parsed the workflow as YAML
- ran `git diff --check`
- verified the required permission against GitHub's REST API documentation