### PR TITLE
feat(clickpipes): document clickpipes_egress_ips in static-ips API

### DIFF
--- a/docs/cloud/guides/data_sources/01_cloud-endpoints-api.md
+++ b/docs/cloud/guides/data_sources/01_cloud-endpoints-api.md
@@ -15,6 +15,8 @@ import gcp_authorized_network from '@site/static/images/_snippets/gcp-authorized
 
 If you need to fetch the list of static IPs, you can use the following ClickHouse Cloud API endpoint: [`https://api.clickhouse.cloud/static-ips.json`](https://api.clickhouse.cloud/static-ips.json). This API provides the endpoints for ClickHouse Cloud services, such as ingress/egress IPs and S3 endpoints per region and cloud.
 
+For regions where [ClickPipes](/integrations/clickpipes) is available, each entry also includes a `clickpipes_egress_ips` field listing the static NAT IPs that ClickPipes uses to egress to your data sources. Add these to your source's allow list when ingesting through ClickPipes. See [the ClickPipes list of static IPs](/integrations/clickpipes#list-of-static-ips) for details.
+
 If you're using an integration like the MySQL or PostgreSQL Engine, it is possible that you need to authorize ClickHouse Cloud to access your instances. You can use this API to retrieve the public IPs and configure them in `firewalls` or `Authorized networks` in GCP or in `Security Groups` for Azure, AWS, or in any other infrastructure egress management system you're using.
 
 For example, to allow access from a ClickHouse Cloud service hosted on AWS in the region `ap-south-1`, you can add the `egress_ips` addresses for that region:
@@ -24,6 +26,14 @@ For example, to allow access from a ClickHouse Cloud service hosted on AWS in th
 {
   "aws": [
     {
+      "clickpipes_egress_ips": [
+        "13.203.140.189",
+        "13.232.213.12",
+        "13.235.145.208",
+        "35.154.167.40",
+        "65.0.39.245",
+        "65.1.225.89"
+      ],
       "egress_ips": [
         "3.110.39.68",
         "15.206.7.77",

--- a/docs/integrations/data-ingestion/clickpipes/index.md
+++ b/docs/integrations/data-ingestion/clickpipes/index.md
@@ -64,6 +64,18 @@ More connectors will get added to ClickPipes, you can find out more by [contacti
 
 The following tables list the static NAT IPs that ClickPipes uses to connect to your external services. Add the IPs for the ClickPipes region that serves your ClickHouse Cloud service to your IP allow list. In the case of object storage pipes you should also add the [ClickHouse cluster IPs](/manage/data-sources/cloud-endpoints-api) to your IP allow list.
 
+:::tip Fetch these IPs programmatically
+The ClickPipes static NAT IPs are also available from the [Cloud endpoints API](/manage/data-sources/cloud-endpoints-api) under the `clickpipes_egress_ips` field of each region, so you can keep an allow list in sync automatically:
+
+```bash
+# AWS — replace <region> with the ClickPipes region serving your service
+curl -s https://api.clickhouse.cloud/static-ips.json | jq -r '.aws[] | select(.region == "<region>") | .clickpipes_egress_ips[]'
+
+# Google Cloud
+curl -s https://api.clickhouse.cloud/static-ips.json | jq -r '.gcp[] | select(.region == "<region>") | .clickpipes_egress_ips[]'
+```
+:::
+
 Services in the Google Cloud regions listed in the Google Cloud table below use those Google Cloud IPs only if the service did not contain pre-existing ClickPipes prior to June 15th, 2026. Services in those regions with pre-existing ClickPipes prior to June 15th, 2026 continue to use the default region IPs listed below.
 
 For other services, ClickPipes traffic will originate from a default region based on your service's location:


### PR DESCRIPTION
## What

Documents the new per-region `clickpipes_egress_ips` field exposed by `https://api.clickhouse.cloud/static-ips.json`, which lists the static NAT IPs ClickPipes uses to egress to customer data sources.

- **`cloud/guides/data_sources/01_cloud-endpoints-api.md`** — notes the new `clickpipes_egress_ips` field in the schema description and adds it to the sample `jq '.'` output (using the real ap-south-1 ClickPipes NAT IPs).
- **`integrations/data-ingestion/clickpipes/index.md`** (`#list-of-static-ips`) — adds a tip with `jq` snippets so customers can fetch the ClickPipes NAT IPs programmatically instead of copying the hand-maintained tables.

Resolves the docs side of [CLP-1115](https://linear.app/clickhouse/issue/CLP-1115) — the customer asked for a `static-ips.json`-style API for ClickPipes NAT IPs, mirroring the ClickHouse Cloud endpoints API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
