### PR TITLE
docs: Remove note that ClickStack doesn't support exponential histograms

### DIFF
--- a/docs/use-cases/observability/clickstack/ingesting-data/schemas.md
+++ b/docs/use-cases/observability/clickstack/ingesting-data/schemas.md
@@ -46,10 +46,6 @@ The following tables are created for each data type in the `default` database. Y
 
 ### Exponential histograms {#exponential-histograms}
 
-:::note
-HyperDX doesn't support fetching/displaying exponential histogram metrics yet. You may configure them in the metrics source but future support is forthcoming.
-:::
-
 <OtelMetricsExponentialHistogramSchema />
 
 ### Summary table {#summary-table}


### PR DESCRIPTION
## Summary

This PR removes the note that HyperDX / ClickStack doesn't support exponential histogram metrics, since support was added ~last week.

## Checklist
- [ ] Delete items not relevant to your PR
- [ ] URL changes should add a redirect to the old URL via https://github.com/ClickHouse/clickhouse-docs/blob/main/vercel.json
- [ ] If adding a new integration page, also add an entry to the integrations list here: https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/integrations/index.mdx
