### PR TITLE
Docs: note that the SAML SSO default role is configurable

### DIFF
--- a/docs/cloud/reference/09_security/01_console-roles.md
+++ b/docs/cloud/reference/09_security/01_console-roles.md
@@ -17,7 +17,7 @@ ClickHouse has four organization level roles available for user management. Only
 | Admin          | Perform all administrative activities for an organization and control all settings. This role is assigned to the first user in the organization by default and automatically has Service Admin permissions on all services. |
 | Billing        | View usage and invoices, and manage payment methods.                                         |
 | Org API reader | API permissions to manage organization level settings and users, no service access. |
-| Member         | Sign-in only with the ability to manage personal profile settings. Assigned to SAML SSO users by default. |
+| Member         | Sign-in only with the ability to manage personal profile settings. Assigned to SAML SSO users by default, unless the organization has configured a different default role. |
 
 ## Service roles {#service-roles}
 Refer to [Manage cloud users](/cloud/security/manage-cloud-users) for instructions on assigning service roles.


### PR DESCRIPTION
## Summary

The `Member` row in the organization roles table says Member is "assigned to SAML SSO users by default" without noting that the default is configurable. Since SAML self-serve setup, organizations designate their own default role for new SSO users ([SAML SSO setup](https://clickhouse.com/docs/products/cloud/guides/security/cloud-access-management/saml-sso-setup)), so a reader can't tell from this page that Member applies only when no default has been set. One-line clarification.

## Checklist

- No URL or anchor change, so no `vercel.json` redirect needed.
- Not an integration page.
