### PR TITLE
docs(managed-postgres): document the storage notification

### DIFF
--- a/docs/cloud/features/08_monitoring/cloud-notifications.md
+++ b/docs/cloud/features/08_monitoring/cloud-notifications.md
@@ -62,14 +62,6 @@ ClickHouse sends service notifications when a certain alert condition is trigger
 
 ClickHouse sends ClickPipes notifications when your ClickPipe is experiencing failures or issues. 
 
-## Postgres notifications {#postgres-notifications}
-
-ClickHouse sends Postgres notifications for managed Postgres services. These notifications only appear for organizations with Postgres services.
-
-| Notify when | Specific alert condition | Default notification channels | Resolution steps |
-|---|---|---|---|
-| Postgres storage passed 85% threshold | When storage usage on a Postgres service reaches 85% of capacity. Notification will only trigger once per calendar day. | UI, email | Storage scales automatically when usage reaches 90% (brief cutover downtime). No action is needed unless auto-scaling is already at its limit. |
-
 ## Billing notifications {#billing-notifications}
 
 ClickHouse sends billing notifications for payment issues, and when prepaid commitments reach certain consumption thresholds. 

--- a/docs/cloud/features/08_monitoring/cloud-notifications.md
+++ b/docs/cloud/features/08_monitoring/cloud-notifications.md
@@ -62,6 +62,14 @@ ClickHouse sends service notifications when a certain alert condition is trigger
 
 ClickHouse sends ClickPipes notifications when your ClickPipe is experiencing failures or issues. 
 
+## Postgres notifications {#postgres-notifications}
+
+ClickHouse sends Postgres notifications for managed Postgres services. These notifications only appear for organizations with Postgres services.
+
+| Notify when | Specific alert condition | Default notification channels | Resolution steps |
+|---|---|---|---|
+| Postgres storage passed 85% threshold | When storage usage on a Postgres service reaches 85% of capacity. Notification will only trigger once per calendar day. | UI, email | Storage scales automatically when usage reaches 90% (brief cutover downtime). No action is needed unless auto-scaling is already at its limit. |
+
 ## Billing notifications {#billing-notifications}
 
 ClickHouse sends billing notifications for payment issues, and when prepaid commitments reach certain consumption thresholds. 

--- a/docs/cloud/managed-postgres/monitoring/notifications.md
+++ b/docs/cloud/managed-postgres/monitoring/notifications.md
@@ -1,0 +1,32 @@
+---
+slug: /cloud/managed-postgres/monitoring/notifications
+sidebar_label: 'Notifications'
+title: 'Managed Postgres notifications'
+description: 'Cloud console notifications for Managed Postgres services'
+keywords: ['managed postgres', 'notifications', 'alerts', 'storage', 'disk usage']
+doc_type: 'guide'
+---
+
+import BetaBadge from '@theme/badges/BetaBadge';
+
+<BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.monitoring-notifications-beta" />
+
+ClickHouse Cloud sends notifications when a Managed Postgres service
+needs attention. Notifications are delivered through the
+[cloud console notification system](/cloud/notifications): the console
+inbox, email, and Slack, and can be customized per notification from
+the **Postgres** section of the notification settings page. The
+section appears for organizations with Managed Postgres services.
+
+## Supported notifications {#supported-notifications}
+
+| Notify when | Specific alert condition | Default notification channels | Resolution steps |
+|---|---|---|---|
+| Postgres storage passed 85% threshold | When storage usage on a Managed Postgres service reaches 85% of capacity. Notification will only trigger once per calendar day. | UI, email | Storage scales automatically when usage reaches 90% (brief cutover downtime). No action is needed unless auto-scaling is already at its limit. |
+
+## Related pages {#related}
+
+- [Cloud notifications](/cloud/notifications) — channels, severities, and
+  how to customize delivery
+- [Monitoring dashboard](/cloud/managed-postgres/monitoring/dashboard) —
+  live disk, CPU, and memory charts for each instance

--- a/docs/cloud/managed-postgres/monitoring/overview.md
+++ b/docs/cloud/managed-postgres/monitoring/overview.md
@@ -20,6 +20,7 @@ methods:
 | [Query Insights](/cloud/managed-postgres/monitoring/query-insights)              | Per-statement telemetry: every query pattern ranked by impact, with diagnostic counters    | None                    |
 | [Prometheus endpoint](/cloud/managed-postgres/monitoring/prometheus)             | Scrape metrics into Prometheus, Grafana, Datadog, or any OpenMetrics-compatible collector  | API key + scraper config |
 | [Metrics reference](/cloud/managed-postgres/monitoring/metrics)                  | Full list of metrics exposed by the Prometheus endpoint, with types, labels, and meanings  | N/A                     |
+| [Notifications](/cloud/managed-postgres/monitoring/notifications)                | Console, email, and Slack alerts when a service needs attention, such as storage nearing capacity | None                    |
 
 ## Quick start {#quick-start}
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -417,6 +417,7 @@ const sidebars = {
             'cloud/managed-postgres/monitoring/query-insights',
             'cloud/managed-postgres/monitoring/prometheus',
             'cloud/managed-postgres/monitoring/metrics',
+            'cloud/managed-postgres/monitoring/notifications',
           ],
         },
         'cloud/managed-postgres/openapi',


### PR DESCRIPTION
## Summary

Adds a **Notifications** page under Managed Postgres > Monitoring, documenting the storage notification:

- **Postgres storage passed 85% threshold**: fires when a service's storage reaches 85% of capacity, once per calendar day, delivered via UI and email by default; resolution note mirrors the in-product copy (auto-scaling handles it at 90% unless already at its limit)
- Wired into the monitoring sidebar and the monitoring overview table
- Links back to the general Cloud notifications page for channels/customization

An earlier commit added this to the Cloud notifications page instead; reverted in favor of keeping it within the Managed Postgres section.

## Notes for reviewers

- The notification name matches the settings-row title shipping in control-plane (ClickHouse/control-plane#37224)
- Postgres notifications are currently rolled out per organization via feature flag; keeping this as a draft until the rollout timing is decided is fine
- The instance-down notification is deliberately not documented yet