### PR TITLE
Notify PR authors about repository migration

### DIFF
--- a/.github/workflows/repository-migration-notice.yml
+++ b/.github/workflows/repository-migration-notice.yml
@@ -34,8 +34,9 @@ jobs:
               return;
             }
 
+            const prAuthor = context.payload.pull_request.user.login;
             const body = `${marker}
-            Thanks for contributing to the ClickHouse documentation!
+            @${prAuthor}, thanks for contributing to the ClickHouse documentation!
 
             We’ve moved documentation development to the main [ClickHouse/ClickHouse](https://github.com/ClickHouse/ClickHouse) repository. For future documentation changes, please open your pull request there, with changes under the [docs/](https://github.com/ClickHouse/ClickHouse/tree/master/docs) directory.
 


### PR DESCRIPTION
## Summary
Mention the pull request author in the automated repository migration notice so GitHub sends an explicit mention notification and the notice is harder to overlook.

This follows the existing automated author-mention pattern in the trademark license agreement workflow.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6603

## Checklist
- [x] Delete items not relevant to your PR