### PR TITLE
Document Iceberg catalog vs path-based writes

### DIFF
--- a/docs/use-cases/data_lake/guides/writing-data.md
+++ b/docs/use-cases/data_lake/guides/writing-data.md
@@ -16,11 +16,65 @@ In the previous guides, you queried open table formats in place and loaded data 
 - **Offloading to long-term storage** - Data arrives in ClickHouse as a real-time analytics layer, powering dashboards and operational reporting. Once the data ages beyond its real-time window, it can be written out to Iceberg in object storage for durable, cost-effective retention in an interoperable format.
 - **Reverse ETL** - Transformations, aggregations, and enrichment performed inside ClickHouse produce derived datasets that downstream tools and other teams need to consume. Writing these results to Iceberg tables makes them available across the broader data ecosystem.
 
-In both cases, `INSERT INTO SELECT` lets you move data from ClickHouse tables into Iceberg tables stored in object storage.
+In both cases, `INSERT INTO SELECT` lets you move data from ClickHouse tables into Iceberg tables stored in object storage. Writing is currently supported for Iceberg tables; partial support for Delta Lake is in progress.
 
-:::note
-Writing to open table formats is currently supported for **Iceberg tables only**. Partial support for Delta Lake tables is under development. Tables must not be managed by a catalog.
-:::
+Iceberg inserts require [allow_insert_into_iceberg](/operations/settings/settings#allow_insert_into_iceberg) (25.7+, Beta from 26.2).
+
+## Write with or without a catalog {#write-paths}
+
+How you write depends on whether the Iceberg table is managed by a data catalog.
+
+### Without a catalog {#without-catalog}
+
+Create a standalone table with the [`IcebergS3`](/engines/table-engines/integrations/iceberg) (or `IcebergLocal` / `IcebergAzure`) table engine, then `INSERT` into it (25.7+).
+
+```sql
+SET allow_insert_into_iceberg = 1;
+
+CREATE TABLE uk.uk_iceberg
+(
+    price UInt32,
+    town String
+)
+ENGINE = IcebergS3(
+    'https://your-bucket.s3.amazonaws.com/warehouse/uk_iceberg/',
+    '<aws_access_key>',
+    '<aws_secret_key>'
+);
+
+INSERT INTO uk.uk_iceberg
+SELECT
+    price,
+    town
+FROM uk.uk_price_paid
+WHERE town = 'LONDON';
+```
+
+
+### With a catalog {#with-catalog}
+
+When tables are registered in Glue, REST, or another catalog, connect with [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) and `INSERT` into the catalog tables (26.4+). `catalog_type` and related settings belong on the database — not on `IcebergS3`.
+
+```sql
+SET allow_database_glue_catalog = 1;
+SET allow_insert_into_iceberg = 1;
+
+CREATE DATABASE glue
+ENGINE = DataLakeCatalog
+SETTINGS
+    catalog_type = 'glue',
+    region = 'us-east-1',
+    aws_access_key_id = '<key>',
+    aws_secret_access_key = '<secret>';
+
+INSERT INTO glue.`my_namespace.my_table` (col1, col2)
+SELECT
+    col1,
+    col2
+FROM clickhouse_table;
+```
+
+Use the backticked `<namespace>.<table>` name for catalog tables. See the [support matrix](/use-cases/data-lake/support-matrix#catalog-support) for which catalogs support insert and create.
 
 ## Prepare a source dataset {#prepare-source}
 
@@ -100,11 +154,11 @@ Peak memory usage: 485.15 MiB.
 
 ## Write data to an Iceberg table {#write-iceberg}
 
+The following steps use the without-catalog path: a standalone [`IcebergS3`](/engines/table-engines/integrations/iceberg) table.
+
 ### Create the Iceberg table {#create-iceberg-table}
 
-To write data into Iceberg, create a table using the [`IcebergS3` table engine](/engines/table-engines/integrations/iceberg).
-
-Note that the schema must be simplified compared to the MergeTree source. ClickHouse supports a richer type system than Iceberg and the underlying Parquet files - types such as `Enum`, `LowCardinality`, and `UInt8` are not supported in Iceberg and must be mapped to compatible types.
+Create the destination table with `IcebergS3`. The schema must be simplified compared to the MergeTree source — ClickHouse types such as `Enum`, `LowCardinality`, and `UInt8` are not supported in Iceberg and must be mapped to compatible types.
 
 ```sql
 CREATE TABLE uk.uk_iceberg
@@ -132,7 +186,7 @@ ENGINE = IcebergS3('https://datasets-documentation.s3.amazonaws.com/lake_formats
 Use `INSERT INTO SELECT` to write data from the MergeTree table into the Iceberg table. In this example, we write only London transactions:
 
 ```sql
-SET allow_experimental_insert_into_iceberg = 1;
+SET allow_insert_into_iceberg = 1;
 
 INSERT INTO uk.uk_iceberg SELECT *
 FROM uk.uk_price_paid

--- a/docs/use-cases/data_lake/reference/aws_glue_catalog.md
+++ b/docs/use-cases/data_lake/reference/aws_glue_catalog.md
@@ -4,8 +4,7 @@ sidebar_label: 'AWS Glue catalog'
 title: 'AWS Glue catalog'
 pagination_prev: null
 pagination_next: null
-description: 'In this guide, we will walk you through the steps to query
- your data in S3 buckets using ClickHouse and the AWS Glue Data Catalog.'
+description: 'Connect ClickHouse to the AWS Glue Data Catalog to read and write Iceberg tables in S3.'
 keywords: ['Glue', 'Data Lake']
 show_related_blogs: true
 doc_type: 'guide'
@@ -15,9 +14,7 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 <BetaBadge/>
 
-ClickHouse supports integration with multiple catalogs (Unity, Glue, Polaris, 
-etc.). In this guide, we will walk you through the steps to query your data in 
-S3 buckets using ClickHouse and the Glue Data Catalog.
+Connect ClickHouse to the AWS Glue Data Catalog with the [`DataLakeCatalog`](/engines/database-engines/datalakecatalog) database engine to read and write Iceberg tables stored in S3.
 
 :::note
 Glue supports many different table formats, but this integration only supports Iceberg tables.
@@ -25,14 +22,14 @@ Glue supports many different table formats, but this integration only supports I
 
 ## Configuring Glue in AWS {#configuring}
 
-To connect to the glue catalog, you will need:
+To connect to the Glue catalog, you need:
 - AWS region of your catalog
-- Access Key ID/Access Secret Key (v25.12+) or AWS Role ARN (v26.2+)
+- Access Key ID/Access Secret Key (v25.12+) or AWS IAM Role ARN (v26.2+)
 
-For AWS Role auth, AWS Role Session Name is an additional optional field. 
+For AWS IAM Role auth, AWS Role Session Name is an additional optional field.
 
 :::note
-You will need to enable it using `SET allow_database_glue_catalog = 1;`
+Enable the integration with `SET allow_database_glue_catalog = 1;`
 :::
 
 ## Creating a connection between Glue data catalog and ClickHouse {#connecting}
@@ -52,7 +49,7 @@ SETTINGS
     aws_secret_access_key = '<secret-key>'
 ```
 
-### AWS Role {#aws-role}
+### AWS IAM Role {#aws-role}
 ```sql title="Query"
 CREATE DATABASE glue
 ENGINE = DataLakeCatalog
@@ -213,6 +210,28 @@ SHOW CREATE TABLE `iceberg-benchmark.hitsiceberg`;
   │ )                                                       │
   │ENGINE = Iceberg('s3://<s3-path>')                       │
   └─────────────────────────────────────────────────────────┘
+```
+
+## Write to existing Iceberg tables in Glue {#write}
+
+Iceberg tables registered in Glue appear as tables in your `DataLakeCatalog` database. From 26.4, write to them with standard `INSERT` — enable [allow_insert_into_iceberg](/operations/settings/settings#allow_insert_into_iceberg) (25.7+, Beta from 26.2) first:
+
+```sql
+SET allow_insert_into_iceberg = 1;
+
+INSERT INTO glue.`iceberg-benchmark.hitsiceberg` (watchid, title, eventdate)
+VALUES (123456789, 'example', today());
+```
+
+Or copy rows from a ClickHouse table with `INSERT INTO ... SELECT`:
+
+```sql
+INSERT INTO glue.`iceberg-benchmark.hitsiceberg` (watchid, title, eventdate)
+SELECT
+    watchid,
+    title,
+    eventdate
+FROM some_local_table;
 ```
 
 ## Loading data from your Data Lake into ClickHouse {#loading-data-into-clickhouse}


### PR DESCRIPTION
## Summary
- Clarify writing Iceberg with and without a catalog in the writing-data guide (25.7+ inserts; catalog-backed writes from 26.4)
- Add a Glue guide section for `INSERT` into catalog-exposed Iceberg tables
- Remove the outdated "tables must not be managed by a catalog" guidance

Related community feedback: users were putting `catalog_type` on `IcebergS3` after following misleading patterns. Companion ClickHouse repo docs changes are tracked separately.

## Test plan
- [ ] Preview writing-data page: with/without catalog sections render and links resolve
- [ ] Preview Glue catalog page: write section and versions look correct
- [ ] Confirm support-matrix link from writing-data works


Made with [Cursor](https://cursor.com)